### PR TITLE
Fix for circles coloring of a transformer inside a voltage level

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/util/TopologicalStyleProvider.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/util/TopologicalStyleProvider.java
@@ -9,10 +9,8 @@ package com.powsybl.sld.util;
 import com.powsybl.iidm.network.Bus;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.VoltageLevel;
-import com.powsybl.sld.model.Edge;
-import com.powsybl.sld.model.Node;
+import com.powsybl.sld.model.*;
 import com.powsybl.sld.model.Node.NodeType;
-import com.powsybl.sld.model.VoltageLevelInfos;
 import com.powsybl.sld.styles.BaseVoltageStyle;
 import com.powsybl.sld.svg.DiagramStyles;
 
@@ -69,10 +67,14 @@ public class TopologicalStyleProvider extends AbstractBaseVoltageDiagramStylePro
         return styleMap;
     }
 
+    private String getStyleMapKey(Node node) {
+        return node instanceof FeederWithSideNode ? node.getEquipmentId() + "_" + ((FeederWithSideNode) node).getSide().name() : node.getEquipmentId();
+    }
+
     private Optional<String> getNodeTopologicalStyle(String baseVoltageLevelStyle, VoltageLevelInfos voltageLevelInfos, Node node) {
         Map<String, String> styleMap = getVoltageLevelStyleMap(baseVoltageLevelStyle, voltageLevelInfos);
         String nodeTopologicalStyle = styleMap.computeIfAbsent(
-            node.getEquipmentId(), id -> findConnectedStyle(baseVoltageLevelStyle, voltageLevelInfos, node));
+                getStyleMapKey(node), id -> findConnectedStyle(baseVoltageLevelStyle, voltageLevelInfos, node));
         return Optional.ofNullable(nodeTopologicalStyle);
     }
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/util/TopologyVisitorId.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/util/TopologyVisitorId.java
@@ -38,7 +38,7 @@ public class TopologyVisitorId implements TopologyVisitor {
 
     @Override
     public void visitLine(Line e, Branch.Side s) {
-        idFunction.accept(e.getId());
+        idFunction.accept(e.getId() + "_" + s.name());
     }
 
     @Override
@@ -59,11 +59,11 @@ public class TopologyVisitorId implements TopologyVisitor {
     @Override
     public void visitThreeWindingsTransformer(ThreeWindingsTransformer e,
                                               ThreeWindingsTransformer.Side s) {
-        idFunction.accept(e.getId());
+        idFunction.accept(e.getId() + "_" + s.name());
     }
 
     @Override
     public void visitTwoWindingsTransformer(TwoWindingsTransformer e, Branch.Side s) {
-        idFunction.accept(e.getId());
+        idFunction.accept(e.getId() + "_" + s.name());
     }
 }

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosTopological.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosTopological.svg
@@ -278,7 +278,7 @@ polyline {fill: none}
             </g>
             <g class="sld-two-wt sld-top-feeder sld-constant-color" id="idtrf1_95_ONE" transform="translate(135.0,130.5)">
                 <circle class="sld-vl300to500-0" cx="5" cy="10" r="5"/>
-                <circle class="sld-vl180to300-0" cx="5" cy="5" r="5"/>
+                <circle class="sld-disconnected" cx="5" cy="5" r="5"/>
                 <text class="sld-label" id="trf1_ONE_N_LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">trf1</text>
             </g>
             <g class="sld-wire sld-constant-color sld-vl300to500-0" id="_95_vl1_95_bbs1_95_dtrf11">
@@ -324,7 +324,7 @@ polyline {fill: none}
             </g>
             <g class="sld-two-wt sld-top-feeder sld-constant-color" id="idtrf5_95_ONE" transform="translate(375.0,130.5)">
                 <circle class="sld-vl300to500-0" cx="5" cy="10" r="5"/>
-                <circle class="sld-vl50to70-0" cx="5" cy="5" r="5"/>
+                <circle class="sld-disconnected" cx="5" cy="5" r="5"/>
                 <text class="sld-label" id="trf5_ONE_N_LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">trf5</text>
             </g>
             <g class="sld-wire sld-constant-color sld-vl300to500-0" id="_95_vl1_95_bbs1_95_dtrf15">
@@ -366,8 +366,8 @@ polyline {fill: none}
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl1_95_trf6_95_fictif" transform="translate(492.0,193.0)">
-                <circle class="sld-vl180to300-0" cx="5" cy="5" r="5"/>
-                <circle class="sld-vl50to70-0" cx="11" cy="5" r="5"/>
+                <circle class="sld-disconnected" cx="5" cy="5" r="5"/>
+                <circle class="sld-disconnected" cx="11" cy="5" r="5"/>
                 <circle class="sld-vl300to500-0" cx="8" cy="9" r="5"/>
             </g>
             <g class="sld-line sld-top-feeder sld-constant-color sld-vl300to500-0" id="idtrf6_95_TWO" transform="translate(460.0,138.0)">
@@ -479,7 +479,7 @@ polyline {fill: none}
             </g>
             <g class="sld-two-wt sld-top-feeder sld-constant-color" id="idtrf2_95_ONE" transform="translate(1175.0,130.5)">
                 <circle class="sld-vl300to500-0" cx="5" cy="10" r="5"/>
-                <circle class="sld-vl180to300-0" cx="5" cy="5" r="5"/>
+                <circle class="sld-disconnected" cx="5" cy="5" r="5"/>
                 <text class="sld-label" id="trf2_ONE_N_LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">trf2</text>
             </g>
             <g class="sld-wire sld-constant-color sld-vl300to500-0" id="_95_vl1_95_bbs2_95_dtrf12">
@@ -521,8 +521,8 @@ polyline {fill: none}
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl1_95_trf8_95_fictif" transform="translate(972.0,193.0)">
-                <circle class="sld-vl180to300-0" cx="5" cy="5" r="5"/>
-                <circle class="sld-vl50to70-0" cx="11" cy="5" r="5"/>
+                <circle class="sld-disconnected" cx="5" cy="5" r="5"/>
+                <circle class="sld-disconnected" cx="11" cy="5" r="5"/>
                 <circle class="sld-vl300to500-0" cx="8" cy="9" r="5"/>
             </g>
             <g class="sld-line sld-top-feeder sld-constant-color sld-vl300to500-0" id="idtrf8_95_TWO" transform="translate(940.0,138.0)">
@@ -634,7 +634,7 @@ polyline {fill: none}
             </g>
             <g class="sld-two-wt sld-bottom-feeder sld-constant-color" id="idtrf3_95_ONE" transform="translate(295.0,499.5)">
                 <circle class="sld-vl300to500-1" cx="5" cy="10" r="5" transform="rotate(180.0,5.0,7.5)"/>
-                <circle class="sld-vl180to300-0" cx="5" cy="5" r="5" transform="rotate(180.0,5.0,7.5)"/>
+                <circle class="sld-disconnected" cx="5" cy="5" r="5" transform="rotate(180.0,5.0,7.5)"/>
                 <text class="sld-label" id="trf3_ONE_S_LABEL" transform="rotate(0,0,0)" x="-5.0" y="20.0">trf3</text>
             </g>
             <g class="sld-wire sld-constant-color sld-vl300to500-1" id="_95_vl1_95_bbs3_95_dtrf13">
@@ -676,8 +676,8 @@ polyline {fill: none}
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl1_95_trf7_95_fictif" transform="translate(652.0,438.0)">
-                <circle class="sld-vl50to70-0" cx="5" cy="5" r="5" transform="rotate(180.0,8.0,7.0)"/>
-                <circle class="sld-vl180to300-0" cx="11" cy="5" r="5" transform="rotate(180.0,8.0,7.0)"/>
+                <circle class="sld-disconnected" cx="5" cy="5" r="5" transform="rotate(180.0,8.0,7.0)"/>
+                <circle class="sld-disconnected" cx="11" cy="5" r="5" transform="rotate(180.0,8.0,7.0)"/>
                 <circle class="sld-vl300to500-1" cx="8" cy="9" r="5" transform="rotate(180.0,8.0,7.0)"/>
             </g>
             <g class="sld-line sld-bottom-feeder sld-constant-color sld-vl300to500-1" id="idtrf7_95_TWO" transform="translate(620.0,507.0)">
@@ -789,7 +789,7 @@ polyline {fill: none}
             </g>
             <g class="sld-two-wt sld-bottom-feeder sld-constant-color" id="idtrf4_95_ONE" transform="translate(1095.0,499.5)">
                 <circle class="sld-vl300to500-1" cx="5" cy="10" r="5" transform="rotate(180.0,5.0,7.5)"/>
-                <circle class="sld-vl180to300-0" cx="5" cy="5" r="5" transform="rotate(180.0,5.0,7.5)"/>
+                <circle class="sld-disconnected" cx="5" cy="5" r="5" transform="rotate(180.0,5.0,7.5)"/>
                 <text class="sld-label" id="trf4_ONE_S_LABEL" transform="rotate(0,0,0)" x="-5.0" y="20.0">trf4</text>
             </g>
             <g class="sld-wire sld-constant-color sld-vl300to500-1" id="_95_vl1_95_bbs4_95_dtrf14">


### PR DESCRIPTION
Signed-off-by: Slimane AMAR <slimane.amar@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Circles of a transformer inside a voltage level are not coloried with the topology style provider


**What is the new behavior (if this is a feature change)?**
Circles of a transformer inside a voltage level are now coloried with the topology style provider


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
No
