### PR TITLE
Add phase-shifter transformer arrow

### DIFF
--- a/network-area-diagram/src/main/java/com/powsybl/nad/build/iidm/NetworkGraphBuilder.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/build/iidm/NetworkGraphBuilder.java
@@ -78,7 +78,7 @@ public class NetworkGraphBuilder implements GraphBuilder {
     }
 
     private void visitTwoWindingsTransformer(VoltageLevel vl, TwoWindingsTransformer twt, Graph graph) {
-        addEdge(graph, twt, vl, BranchEdge.TWO_WT_EDGE);
+        addEdge(graph, twt, vl, twt.hasPhaseTapChanger() ? BranchEdge.PST_EDGE : BranchEdge.TWO_WT_EDGE);
     }
 
     private void visitThreeWindingsTransformer(VoltageLevel vl, ThreeWindingsTransformer thwt, Graph graph) {

--- a/network-area-diagram/src/main/java/com/powsybl/nad/model/BranchEdge.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/model/BranchEdge.java
@@ -25,6 +25,7 @@ public class BranchEdge extends AbstractEdge {
     }
 
     public static final String TWO_WT_EDGE = "TwoWtEdge";
+    public static final String PST_EDGE = "PstEdge";
     public static final String LINE_EDGE = "LineEdge";
     public static final String HVDC_LINE_EDGE = "HvdcLineEdge";
 
@@ -40,6 +41,10 @@ public class BranchEdge extends AbstractEdge {
 
     public String getType() {
         return type;
+    }
+
+    public boolean isTransformerEdge() {
+        return PST_EDGE.equals(type) || TWO_WT_EDGE.equals(type);
     }
 
     public List<Point> getPoints(Side side) {

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/DefaultEdgeRendering.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/DefaultEdgeRendering.java
@@ -42,7 +42,7 @@ public class DefaultEdgeRendering implements EdgeRendering {
         Point edgeStart2 = computeEdgeStart(node2, direction2, graph.getVoltageLevelNode2(edge), svgParameters);
 
         Point middle = Point.createMiddlePoint(edgeStart1, edgeStart2);
-        if (edge.getType().equals(BranchEdge.TWO_WT_EDGE)) {
+        if (edge.isTransformerEdge()) {
             double radius = svgParameters.getTransformerCircleRadius();
             edge.setPoints1(edgeStart1, middle.atDistance(1.5 * radius, direction2));
             edge.setPoints2(edgeStart2, middle.atDistance(1.5 * radius, direction1));
@@ -114,7 +114,7 @@ public class DefaultEdgeRendering implements EdgeRendering {
     private void computeHalfForkCoordinates(Graph graph, SvgParameters svgParameters, VoltageLevelNode node, BranchEdge edge, Point fork, Point middle, BranchEdge.Side side) {
         Node busNodeA = side == BranchEdge.Side.ONE ? graph.getBusGraphNode1(edge) : graph.getBusGraphNode2(edge);
         Point edgeStart = computeEdgeStart(busNodeA, fork, node, svgParameters);
-        Point endFork = edge.getType().equals(BranchEdge.TWO_WT_EDGE)
+        Point endFork = edge.isTransformerEdge()
                 ? middle.atDistance(1.5 * svgParameters.getTransformerCircleRadius(), fork)
                 : middle;
         edge.setPoints(side, edgeStart, fork, endFork);
@@ -138,14 +138,14 @@ public class DefaultEdgeRendering implements EdgeRendering {
         double startAngle = angle + sideSign * svgParameters.getLoopEdgesAperture() / 2;
         double radius = svgParameters.getTransformerCircleRadius();
         double controlsDist = svgParameters.getLoopControlDistance();
-        boolean isTwoWt = edge.getType().equals(BranchEdge.TWO_WT_EDGE);
+        boolean isTransformer = edge.isTransformerEdge();
         double endAngle = angle + sideSign * Math.PI / 2;
 
         Point fork = node.getPosition().atDistance(svgParameters.getEdgesForkLength(), startAngle);
         Point edgeStart = computeEdgeStart(graph.getBusGraphNode(edge, side), fork, node, svgParameters);
         Point control1a = fork.atDistance(controlsDist, startAngle);
-        Point middle1 = isTwoWt ? middle.atDistance(1.5 * radius, endAngle) : middle;
-        Point control1b = middle1.atDistance(isTwoWt ? Math.max(0, controlsDist - 1.5 * radius) : controlsDist, endAngle);
+        Point middle1 = isTransformer ? middle.atDistance(1.5 * radius, endAngle) : middle;
+        Point control1b = middle1.atDistance(isTransformer ? Math.max(0, controlsDist - 1.5 * radius) : controlsDist, endAngle);
 
         edge.setPoints(side, edgeStart, fork, control1a, control1b, middle1);
     }

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/StyleProvider.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/StyleProvider.java
@@ -38,6 +38,7 @@ public interface StyleProvider {
     String BUSNODE_CLASS = CLASSES_PREFIX + "busnode";
     String LABEL_BOX_CLASS = CLASSES_PREFIX + "label-box";
     String LEGEND_SQUARE_CLASS = CLASSES_PREFIX + "legend-square";
+    String PST_ARROW_CLASS = CLASSES_PREFIX + "pst-arrow";
 
     List<String> getCssFilenames();
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/SvgParameters.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/SvgParameters.java
@@ -100,6 +100,7 @@ public class SvgParameters {
         this.voltageValuePrecision = other.voltageValuePrecision;
         this.powerValuePrecision = other.powerValuePrecision;
         this.angleValuePrecision = other.angleValuePrecision;
+        this.pstArrowHeadSize = other.pstArrowHeadSize;
     }
 
     public Padding getDiagramPadding() {

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/SvgParameters.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/SvgParameters.java
@@ -51,6 +51,7 @@ public class SvgParameters {
     private int voltageValuePrecision = 1;
     private int powerValuePrecision = 0;
     private int angleValuePrecision = 1;
+    private double pstArrowHeadSize = 8;
 
     public enum CssLocation {
         INSERTED_IN_SVG, EXTERNAL_IMPORTED, EXTERNAL_NO_IMPORT
@@ -425,5 +426,14 @@ public class SvgParameters {
 
     public ValueFormatter createValueFormatter() {
         return new ValueFormatter(powerValuePrecision, voltageValuePrecision, angleValuePrecision, Locale.forLanguageTag(languageTag));
+    }
+
+    public double getPstArrowHeadSize() {
+        return pstArrowHeadSize;
+    }
+
+    public SvgParameters setPstArrowHeadSize(double pstArrowHeadSize) {
+        this.pstArrowHeadSize = pstArrowHeadSize;
+        return this;
     }
 }

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/SvgWriter.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/SvgWriter.java
@@ -125,6 +125,9 @@ public class SvgWriter {
             addStylesIfAny(writer, styleProvider.getEdgeStyleClasses(edge));
             insertName(writer, edge::getName);
 
+            if (BranchEdge.PST_EDGE.equals(edge.getType())) {
+                drawPstArrow(writer, edge);
+            }
             drawHalfEdge(graph, writer, edge, BranchEdge.Side.ONE);
             drawHalfEdge(graph, writer, edge, BranchEdge.Side.TWO);
 
@@ -135,6 +138,44 @@ public class SvgWriter {
             writer.writeEndElement();
         }
         writer.writeEndElement();
+    }
+
+    private void drawPstArrow(XMLStreamWriter writer, BranchEdge edge) throws XMLStreamException {
+        double arrowSize = 3 * svgParameters.getTransformerCircleRadius();
+        double rotationAngle = edge.getEdgeEndAngle(BranchEdge.Side.ONE);
+
+        List<Point> points1 = edge.getPoints1();
+        List<Point> points2 = edge.getPoints2();
+        Point middle = Point.createMiddlePoint(points1.get(points1.size() - 1), points2.get(points2.size() - 1));
+        double[] matrix = getTransformMatrix(arrowSize, arrowSize, rotationAngle, middle);
+
+        writer.writeEmptyElement(PATH_ELEMENT_NAME);
+        writer.writeAttribute(PATH_D_ATTRIBUTE, getPstArrowPath(arrowSize));
+        writer.writeAttribute(TRANSFORM_ATTRIBUTE, getMatrixString(matrix));
+        writer.writeAttribute(CLASS_ATTRIBUTE, StyleProvider.PST_ARROW_CLASS);
+    }
+
+    private double[] getTransformMatrix(double width, double height, double angle, Point center) {
+        double centerPosX = center.getX();
+        double centerPosY = center.getY();
+
+        double cosRo = Math.cos(angle);
+        double sinRo = Math.sin(angle);
+        double cdx = width / 2;
+        double cdy = height / 2;
+
+        double e1 = centerPosX - cdx * cosRo + cdy * sinRo;
+        double f1 = centerPosY - cdx * sinRo - cdy * cosRo;
+
+        return new double[]{+cosRo, sinRo, -sinRo, cosRo, e1, f1};
+    }
+
+
+private String getPstArrowPath(double arrowSize) {
+        String d1 = getFormattedValue(arrowSize); // arrow size
+        String dh = getFormattedValue(svgParameters.getPstArrowHeadSize()); // arrow head size
+        String d2 = getFormattedValue(arrowSize - svgParameters.getPstArrowHeadSize()); // arrow size without the arrow head
+        return String.format("M%s,0 0,%s M%s,0 %s,0 %s,%s", d1, d1, d2, d1, d1, dh);
     }
 
     private void drawConverterStation(XMLStreamWriter writer, BranchEdge edge) throws XMLStreamException {
@@ -173,7 +214,7 @@ public class SvgWriter {
 
     private void drawHalfEdge(Graph graph, XMLStreamWriter writer, BranchEdge edge, BranchEdge.Side side) throws XMLStreamException {
         // the half edge is only drawn if visible, but if the edge is a TwoWtEdge, the transformer is still drawn
-        if (!edge.isVisible(side) && !(edge.getType().equals(BranchEdge.TWO_WT_EDGE))) {
+        if (!edge.isVisible(side) && !(edge.isTransformerEdge())) {
             return;
         }
         writer.writeStartElement(GROUP_ELEMENT_NAME);
@@ -191,7 +232,7 @@ public class SvgWriter {
                 drawLoopEdgeInfo(writer, edge, side, labelProvider.getEdgeInfos(graph, edge, side));
             }
         }
-        if (edge.getType().equals(BranchEdge.TWO_WT_EDGE)) {
+        if (edge.isTransformerEdge()) {
             draw2WtWinding(writer, edge.getPoints(side));
         }
         writer.writeEndElement();
@@ -356,6 +397,13 @@ public class SvgWriter {
 
     private String getScaleString(double scale) {
         return "scale(" + getFormattedValue(scale) + ")";
+    }
+
+    private String getMatrixString(double[] matrix) {
+        return "matrix("
+                + getFormattedValue(matrix[0]) + "," + getFormattedValue(matrix[1]) + ","
+                + getFormattedValue(matrix[2]) + "," + getFormattedValue(matrix[3]) + ","
+                + getFormattedValue(matrix[4]) + "," + getFormattedValue(matrix[5]) + ")";
     }
 
     private Point getArrowCenter(VoltageLevelNode vlNode, BusNode busNode, List<Point> line) {

--- a/network-area-diagram/src/main/resources/nominalStyle.css
+++ b/network-area-diagram/src/main/resources/nominalStyle.css
@@ -5,6 +5,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/network-area-diagram/src/main/resources/topologicalStyle.css
+++ b/network-area-diagram/src/main/resources/topologicalStyle.css
@@ -5,6 +5,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightgrey)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/network-area-diagram/src/test/java/com/powsybl/nad/svg/SvgParametersTest.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/svg/SvgParametersTest.java
@@ -52,7 +52,8 @@ public class SvgParametersTest {
                 .setLanguageTag("de")
                 .setVoltageValuePrecision(0)
                 .setAngleValuePrecision(2)
-                .setPowerValuePrecision(3);
+                .setPowerValuePrecision(3)
+                .setPstArrowHeadSize(20);
 
         SvgParameters svgParameters1 = new SvgParameters(svgParameters0);
 
@@ -94,5 +95,6 @@ public class SvgParametersTest {
         assertEquals(svgParameters0.getVoltageValuePrecision(), svgParameters1.getVoltageValuePrecision());
         assertEquals(svgParameters0.getAngleValuePrecision(), svgParameters1.getAngleValuePrecision());
         assertEquals(svgParameters0.getPowerValuePrecision(), svgParameters1.getPowerValuePrecision());
+        assertEquals(svgParameters0.getPstArrowHeadSize(), svgParameters1.getPstArrowHeadSize(), 0);
     }
 }

--- a/network-area-diagram/src/test/resources/3wt.svg
+++ b/network-area-diagram/src/test/resources/3wt.svg
@@ -8,6 +8,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/network-area-diagram/src/test/resources/3wt_disconnected.svg
+++ b/network-area-diagram/src/test/resources/3wt_disconnected.svg
@@ -8,6 +8,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/network-area-diagram/src/test/resources/3wt_disconnected_topological.svg
+++ b/network-area-diagram/src/test/resources/3wt_disconnected_topological.svg
@@ -8,6 +8,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightgrey)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/network-area-diagram/src/test/resources/3wt_partial.svg
+++ b/network-area-diagram/src/test/resources/3wt_partial.svg
@@ -8,6 +8,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/network-area-diagram/src/test/resources/IEEE_118_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_118_bus.svg
@@ -8,6 +8,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightgrey)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/network-area-diagram/src/test/resources/IEEE_118_bus_partial.svg
+++ b/network-area-diagram/src/test/resources/IEEE_118_bus_partial.svg
@@ -8,6 +8,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightgrey)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/network-area-diagram/src/test/resources/IEEE_118_bus_partial_non_connected.svg
+++ b/network-area-diagram/src/test/resources/IEEE_118_bus_partial_non_connected.svg
@@ -8,6 +8,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightgrey)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/network-area-diagram/src/test/resources/IEEE_14_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus.svg
@@ -8,6 +8,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_disconnection.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_disconnection.svg
@@ -8,6 +8,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_fictitious.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_fictitious.svg
@@ -8,6 +8,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_text_nodes.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_text_nodes.svg
@@ -8,6 +8,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/network-area-diagram/src/test/resources/IEEE_14_id_prefixed.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_id_prefixed.svg
@@ -8,6 +8,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/network-area-diagram/src/test/resources/IEEE_24_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_24_bus.svg
@@ -8,6 +8,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/network-area-diagram/src/test/resources/IEEE_30_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_30_bus.svg
@@ -8,6 +8,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/network-area-diagram/src/test/resources/IEEE_57_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_57_bus.svg
@@ -8,6 +8,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightgrey)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/network-area-diagram/src/test/resources/current_limits.svg
+++ b/network-area-diagram/src/test/resources/current_limits.svg
@@ -8,6 +8,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/network-area-diagram/src/test/resources/detailed_text_node.svg
+++ b/network-area-diagram/src/test/resources/detailed_text_node.svg
@@ -8,6 +8,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightgrey)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/network-area-diagram/src/test/resources/detailed_text_node_no_legend.svg
+++ b/network-area-diagram/src/test/resources/detailed_text_node_no_legend.svg
@@ -8,6 +8,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightgrey)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.0.svg
+++ b/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.0.svg
@@ -8,6 +8,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.2.svg
+++ b/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.2.svg
@@ -8,6 +8,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/network-area-diagram/src/test/resources/edge_info_double_labels.svg
+++ b/network-area-diagram/src/test/resources/edge_info_double_labels.svg
@@ -8,6 +8,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/network-area-diagram/src/test/resources/edge_info_missing_label.svg
+++ b/network-area-diagram/src/test/resources/edge_info_missing_label.svg
@@ -8,6 +8,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/network-area-diagram/src/test/resources/edge_info_perpendicular_label.svg
+++ b/network-area-diagram/src/test/resources/edge_info_perpendicular_label.svg
@@ -8,6 +8,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/network-area-diagram/src/test/resources/edge_info_shift.svg
+++ b/network-area-diagram/src/test/resources/edge_info_shift.svg
@@ -8,6 +8,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/network-area-diagram/src/test/resources/hvdc-vl-depth-1.svg
+++ b/network-area-diagram/src/test/resources/hvdc-vl-depth-1.svg
@@ -8,6 +8,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/network-area-diagram/src/test/resources/hvdc.svg
+++ b/network-area-diagram/src/test/resources/hvdc.svg
@@ -8,6 +8,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -93,6 +94,7 @@
     <g class="nad-branch-edges">
         <g id="10">
             <desc>TWT</desc>
+            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(1.00,-0.04,0.04,1.00,-401.77,24.64)" class="nad-pst-arrow"/>
             <g class="nad-vl180to300">
                 <polyline class="nad-edge-path" points="-547.03,60.17 -400.64,54.62"/>
                 <g class="nad-edge-infos" transform="translate(-514.56,58.94)">

--- a/network-area-diagram/src/test/resources/hvdc.svg
+++ b/network-area-diagram/src/test/resources/hvdc.svg
@@ -94,7 +94,6 @@
     <g class="nad-branch-edges">
         <g id="10">
             <desc>TWT</desc>
-            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(1.00,-0.04,0.04,1.00,-401.77,24.64)" class="nad-pst-arrow"/>
             <g class="nad-vl180to300">
                 <polyline class="nad-edge-path" points="-547.03,60.17 -400.64,54.62"/>
                 <g class="nad-edge-infos" transform="translate(-514.56,58.94)">
@@ -135,6 +134,7 @@
                 </g>
                 <circle class="nad-winding" cx="-360.67" cy="53.11" r="20.00"/>
             </g>
+            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(1.00,-0.04,0.04,1.00,-401.77,24.64)" class="nad-pst-arrow"/>
         </g>
         <g id="11" class="nad-hvdc-edge">
             <desc>HVDC1</desc>

--- a/network-area-diagram/src/test/resources/parallel_transformers.svg
+++ b/network-area-diagram/src/test/resources/parallel_transformers.svg
@@ -8,6 +8,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/network-area-diagram/src/test/resources/simple-eu-loop100.svg
+++ b/network-area-diagram/src/test/resources/simple-eu-loop100.svg
@@ -8,6 +8,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightgrey)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -369,6 +370,7 @@
         </g>
         <g id="26">
             <desc>BBE1AA1  BBE3AA1  2</desc>
+            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(-0.68,0.74,-0.74,-0.68,-343.45,-128.61)" class="nad-pst-arrow"/>
             <g class="nad-vl300to500-line">
                 <path class="nad-edge-path" d="M-417.22,-215.40 L-394.91,-218.32 C-355.25,-223.50 -358.79,-156.26 -365.55,-148.90"/>
                 <g class="nad-edge-infos" transform="translate(-394.91,-218.32)">
@@ -781,6 +783,7 @@
         </g>
         <g id="36">
             <desc>FFR1AA1  FFR2AA1  2</desc>
+            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(0.88,-0.47,0.47,0.88,-61.10,613.77)" class="nad-pst-arrow"/>
             <g class="nad-vl300to500-line">
                 <path class="nad-edge-path" d="M-19.91,719.97 L-41.94,715.40 C-81.11,707.28 -55.69,644.93 -46.88,640.19"/>
                 <g class="nad-edge-infos" transform="translate(-41.94,715.40)">

--- a/network-area-diagram/src/test/resources/simple-eu-loop100.svg
+++ b/network-area-diagram/src/test/resources/simple-eu-loop100.svg
@@ -370,7 +370,6 @@
         </g>
         <g id="26">
             <desc>BBE1AA1  BBE3AA1  2</desc>
-            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(-0.68,0.74,-0.74,-0.68,-343.45,-128.61)" class="nad-pst-arrow"/>
             <g class="nad-vl300to500-line">
                 <path class="nad-edge-path" d="M-417.22,-215.40 L-394.91,-218.32 C-355.25,-223.50 -358.79,-156.26 -365.55,-148.90"/>
                 <g class="nad-edge-infos" transform="translate(-394.91,-218.32)">
@@ -411,6 +410,7 @@
                 </g>
                 <circle class="nad-winding" cx="-392.60" cy="-119.43" r="20.00"/>
             </g>
+            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(-0.68,0.74,-0.74,-0.68,-343.45,-128.61)" class="nad-pst-arrow"/>
         </g>
         <g id="27">
             <desc>BBE2AA1  FFR3AA1  1</desc>
@@ -783,7 +783,6 @@
         </g>
         <g id="36">
             <desc>FFR1AA1  FFR2AA1  2</desc>
-            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(0.88,-0.47,0.47,0.88,-61.10,613.77)" class="nad-pst-arrow"/>
             <g class="nad-vl300to500-line">
                 <path class="nad-edge-path" d="M-19.91,719.97 L-41.94,715.40 C-81.11,707.28 -55.69,644.93 -46.88,640.19"/>
                 <g class="nad-edge-infos" transform="translate(-41.94,715.40)">
@@ -824,6 +823,7 @@
                 </g>
                 <circle class="nad-winding" cx="-11.66" cy="621.24" r="20.00"/>
             </g>
+            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(0.88,-0.47,0.47,0.88,-61.10,613.77)" class="nad-pst-arrow"/>
         </g>
         <g id="37">
             <desc>NNL1AA1  NNL2AA1  1</desc>

--- a/network-area-diagram/src/test/resources/simple-eu-loop80.svg
+++ b/network-area-diagram/src/test/resources/simple-eu-loop80.svg
@@ -8,6 +8,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightgrey)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -369,6 +370,7 @@
         </g>
         <g id="26">
             <desc>BBE1AA1  BBE3AA1  2</desc>
+            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(0.68,-0.74,0.74,0.68,-605.02,-287.30)" class="nad-pst-arrow"/>
             <g class="nad-vl300to500-line">
                 <path class="nad-edge-path" d="M-531.68,-210.52 L-554.16,-211.52 C-594.12,-213.30 -589.68,-259.64 -582.92,-267.01"/>
                 <g class="nad-edge-infos" transform="translate(-554.16,-211.52)">
@@ -781,6 +783,7 @@
         </g>
         <g id="36">
             <desc>FFR1AA1  FFR2AA1  2</desc>
+            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(-0.94,-0.33,0.33,-0.94,15.10,883.13)" class="nad-pst-arrow"/>
             <g class="nad-vl300to500-line">
                 <path class="nad-edge-path" d="M56.71,785.44 L64.65,806.49 C78.79,843.91 34.46,858.13 25.02,854.82"/>
                 <g class="nad-edge-infos" transform="translate(64.65,806.49)">

--- a/network-area-diagram/src/test/resources/simple-eu-loop80.svg
+++ b/network-area-diagram/src/test/resources/simple-eu-loop80.svg
@@ -370,7 +370,6 @@
         </g>
         <g id="26">
             <desc>BBE1AA1  BBE3AA1  2</desc>
-            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(0.68,-0.74,0.74,0.68,-605.02,-287.30)" class="nad-pst-arrow"/>
             <g class="nad-vl300to500-line">
                 <path class="nad-edge-path" d="M-531.68,-210.52 L-554.16,-211.52 C-594.12,-213.30 -589.68,-259.64 -582.92,-267.01"/>
                 <g class="nad-edge-infos" transform="translate(-554.16,-211.52)">
@@ -411,6 +410,7 @@
                 </g>
                 <circle class="nad-winding" cx="-555.87" cy="-296.48" r="20.00"/>
             </g>
+            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(0.68,-0.74,0.74,0.68,-605.02,-287.30)" class="nad-pst-arrow"/>
         </g>
         <g id="27">
             <desc>BBE2AA1  FFR3AA1  1</desc>
@@ -783,7 +783,6 @@
         </g>
         <g id="36">
             <desc>FFR1AA1  FFR2AA1  2</desc>
-            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(-0.94,-0.33,0.33,-0.94,15.10,883.13)" class="nad-pst-arrow"/>
             <g class="nad-vl300to500-line">
                 <path class="nad-edge-path" d="M56.71,785.44 L64.65,806.49 C78.79,843.91 34.46,858.13 25.02,854.82"/>
                 <g class="nad-edge-infos" transform="translate(64.65,806.49)">
@@ -824,6 +823,7 @@
                 </g>
                 <circle class="nad-winding" cx="-12.73" cy="841.59" r="20.00"/>
             </g>
+            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(-0.94,-0.33,0.33,-0.94,15.10,883.13)" class="nad-pst-arrow"/>
         </g>
         <g id="37">
             <desc>NNL1AA1  NNL2AA1  1</desc>

--- a/network-area-diagram/src/test/resources/simple-eu.svg
+++ b/network-area-diagram/src/test/resources/simple-eu.svg
@@ -370,7 +370,6 @@
         </g>
         <g id="26">
             <desc>BBE1AA1  BBE3AA1  2</desc>
-            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(0.68,-0.74,0.74,0.68,-605.02,-287.30)" class="nad-pst-arrow"/>
             <g class="nad-vl300to500-line">
                 <path class="nad-edge-path" d="M-530.36,-220.45 L-552.32,-225.34 C-591.37,-234.04 -589.68,-259.64 -582.92,-267.01"/>
                 <g class="nad-edge-infos" transform="translate(-552.32,-225.34)">
@@ -411,6 +410,7 @@
                 </g>
                 <circle class="nad-winding" cx="-555.87" cy="-296.48" r="20.00"/>
             </g>
+            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(0.68,-0.74,0.74,0.68,-605.02,-287.30)" class="nad-pst-arrow"/>
         </g>
         <g id="27">
             <desc>BBE2AA1  FFR3AA1  1</desc>
@@ -783,7 +783,6 @@
         </g>
         <g id="36">
             <desc>FFR1AA1  FFR2AA1  2</desc>
-            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(-0.88,0.47,-0.47,-0.88,133.88,849.53)" class="nad-pst-arrow"/>
             <g class="nad-vl300to500-line">
                 <path class="nad-edge-path" d="M85.30,761.88 L104.44,773.71 C138.47,794.74 128.47,818.38 119.67,823.11"/>
                 <g class="nad-edge-infos" transform="translate(104.44,773.71)">
@@ -824,6 +823,7 @@
                 </g>
                 <circle class="nad-winding" cx="84.44" cy="842.07" r="20.00"/>
             </g>
+            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(-0.88,0.47,-0.47,-0.88,133.88,849.53)" class="nad-pst-arrow"/>
         </g>
         <g id="37">
             <desc>NNL1AA1  NNL2AA1  1</desc>

--- a/network-area-diagram/src/test/resources/simple-eu.svg
+++ b/network-area-diagram/src/test/resources/simple-eu.svg
@@ -8,6 +8,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightgrey)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -369,6 +370,7 @@
         </g>
         <g id="26">
             <desc>BBE1AA1  BBE3AA1  2</desc>
+            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(0.68,-0.74,0.74,0.68,-605.02,-287.30)" class="nad-pst-arrow"/>
             <g class="nad-vl300to500-line">
                 <path class="nad-edge-path" d="M-530.36,-220.45 L-552.32,-225.34 C-591.37,-234.04 -589.68,-259.64 -582.92,-267.01"/>
                 <g class="nad-edge-infos" transform="translate(-552.32,-225.34)">
@@ -781,6 +783,7 @@
         </g>
         <g id="36">
             <desc>FFR1AA1  FFR2AA1  2</desc>
+            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(-0.88,0.47,-0.47,-0.88,133.88,849.53)" class="nad-pst-arrow"/>
             <g class="nad-vl300to500-line">
                 <path class="nad-edge-path" d="M85.30,761.88 L104.44,773.71 C138.47,794.74 128.47,818.38 119.67,823.11"/>
                 <g class="nad-edge-infos" transform="translate(104.44,773.71)">

--- a/network-area-diagram/src/test/resources/vl_description_id.svg
+++ b/network-area-diagram/src/test/resources/vl_description_id.svg
@@ -8,6 +8,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightgrey)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/network-area-diagram/src/test/resources/vl_description_substation.svg
+++ b/network-area-diagram/src/test/resources/vl_description_substation.svg
@@ -8,6 +8,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightgrey)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/network-area-diagram/src/test/resources/vl_description_substation_id.svg
+++ b/network-area-diagram/src/test/resources/vl_description_substation_id.svg
@@ -8,6 +8,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightgrey)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/network-area-diagram/src/test/resources/voltage_limits.svg
+++ b/network-area-diagram/src/test/resources/voltage_limits.svg
@@ -8,6 +8,7 @@
 .nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No


**What kind of change does this PR introduce?**
Feature


**What is the current behavior?**
Phase-shifter transformer cannot be differentiated from two-winding transformers


**What is the new behavior (if this is a feature change)?**
Phase-shifter transformer can be differentiated from two-winding transformers: an arrow is displayed on them.
![screenshot](https://user-images.githubusercontent.com/66690739/202718000-7c9b0e10-6776-46d5-8c44-328bfcfe5505.png)
![screenshot](https://user-images.githubusercontent.com/66690739/202718053-a5b4b6c4-6df0-40ca-afe0-b1ae010b8391.png)


**Does this PR introduce a breaking change or deprecate an API?** yes, CSS changed
- [x] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
