### PR TITLE
[nad] Improve diagram metadata

### DIFF
--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/SvgWriter.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/SvgWriter.java
@@ -786,12 +786,13 @@ public class SvgWriter {
     private void addMetadata(Graph graph, XMLStreamWriter writer) throws XMLStreamException {
         DiagramMetadata metadata = new DiagramMetadata();
 
-        graph.getBusNodesStream().forEach(metadata::addBusNode);
-        graph.getNodesStream().forEach(metadata::addNode);
-        graph.getEdgesStream().forEach(metadata::addEdge);
+        graph.getBusNodesStream().forEach(busNode -> metadata.addBusNode(getPrefixedId(busNode.getDiagramId()), busNode.getEquipmentId()));
+        graph.getNodesStream().forEach(node -> metadata.addNode(getPrefixedId(node.getDiagramId()), node.getEquipmentId(),
+                getFormattedValue(node.getX()), getFormattedValue(node.getY())));
+        graph.getEdgesStream().forEach(edge -> metadata.addEdge(getPrefixedId(edge.getDiagramId()), edge.getEquipmentId()));
 
         writer.writeStartElement(METADATA_ELEMENT_NAME);
-        metadata.writeXml(this::getPrefixedId, writer);
+        metadata.writeXml(writer);
         writer.writeEndElement();
     }
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/AbstractMetadataItem.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/AbstractMetadataItem.java
@@ -33,8 +33,7 @@ public abstract class AbstractMetadataItem {
     abstract String getElementName();
 
     void write(DiagramMetadata.WritingContext ctx) throws XMLStreamException {
-        String elementName = ctx.overrideElementName ? ctx.elementName : getElementName();
-        ctx.writer.writeEmptyElement(DiagramMetadata.METADATA_PREFIX, elementName, DiagramMetadata.METADATA_NAMESPACE_URI);
+        ctx.writer.writeEmptyElement(DiagramMetadata.METADATA_PREFIX, getElementName(), DiagramMetadata.METADATA_NAMESPACE_URI);
         ctx.writer.writeAttribute(DIAGRAM_ID_ATTRIBUTE, ctx.diagramIdToSvgId.apply(identifiable.getDiagramId()));
         ctx.writer.writeAttribute(EQUIPMENT_ID_ATTRIBUTE, identifiable.getEquipmentId());
     }

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/AbstractMetadataItem.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/AbstractMetadataItem.java
@@ -7,12 +7,9 @@
  */
 package com.powsybl.nad.svg.metadata;
 
-import com.powsybl.nad.model.Identifiable;
-
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
-import java.util.Optional;
 
 /**
  * @author Luma Zamarreño <zamarrenolm at aia.es>

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/AbstractMetadataItem.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/AbstractMetadataItem.java
@@ -18,7 +18,7 @@ import java.util.Optional;
  * @author Luma Zamarreño <zamarrenolm at aia.es>
  */
 public abstract class AbstractMetadataItem {
-    private static final String DIAGRAM_ID_ATTRIBUTE = "diagramId";
+    private static final String DIAGRAM_ID_ATTRIBUTE = "svgId";
     private static final String EQUIPMENT_ID_ATTRIBUTE = "equipmentId";
 
     private final String svgId;

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/AbstractMetadataItem.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/AbstractMetadataItem.java
@@ -11,6 +11,7 @@ import com.powsybl.nad.model.Identifiable;
 
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
+import javax.xml.stream.XMLStreamWriter;
 import java.util.Optional;
 
 /**
@@ -20,22 +21,20 @@ public abstract class AbstractMetadataItem {
     private static final String DIAGRAM_ID_ATTRIBUTE = "diagramId";
     private static final String EQUIPMENT_ID_ATTRIBUTE = "equipmentId";
 
-    private final Identifiable identifiable;
+    private final String svgId;
+    private final String equipmentId;
 
-    protected AbstractMetadataItem(Identifiable identifiable) {
-        this.identifiable = identifiable;
-    }
-
-    public Identifiable getIdentifiable() {
-        return identifiable;
+    protected AbstractMetadataItem(String svgId, String equipmentId) {
+        this.svgId = svgId;
+        this.equipmentId = equipmentId;
     }
 
     abstract String getElementName();
 
-    void write(DiagramMetadata.WritingContext ctx) throws XMLStreamException {
-        ctx.writer.writeEmptyElement(DiagramMetadata.METADATA_PREFIX, getElementName(), DiagramMetadata.METADATA_NAMESPACE_URI);
-        ctx.writer.writeAttribute(DIAGRAM_ID_ATTRIBUTE, ctx.diagramIdToSvgId.apply(identifiable.getDiagramId()));
-        ctx.writer.writeAttribute(EQUIPMENT_ID_ATTRIBUTE, identifiable.getEquipmentId());
+    void write(XMLStreamWriter writer) throws XMLStreamException {
+        writer.writeEmptyElement(DiagramMetadata.METADATA_PREFIX, getElementName(), DiagramMetadata.METADATA_NAMESPACE_URI);
+        writer.writeAttribute(DIAGRAM_ID_ATTRIBUTE, svgId);
+        writer.writeAttribute(EQUIPMENT_ID_ATTRIBUTE, equipmentId);
     }
 
     interface MetadataItemReader<I extends AbstractMetadataItem> {
@@ -44,35 +43,11 @@ public abstract class AbstractMetadataItem {
         I read(XMLStreamReader reader);
     }
 
-    static Identifiable readIdentifiable(XMLStreamReader reader) {
-        String diagramId = reader.getAttributeValue(null, DIAGRAM_ID_ATTRIBUTE);
-        String equipmentId = reader.getAttributeValue(null, EQUIPMENT_ID_ATTRIBUTE);
-        return new DeserializedIdentifiable(diagramId, equipmentId);
+    static String readDiagramId(XMLStreamReader reader) {
+        return reader.getAttributeValue(null, DIAGRAM_ID_ATTRIBUTE);
     }
 
-    static class DeserializedIdentifiable implements Identifiable {
-
-        private final String diagramId;
-        private final String equipmentId;
-
-        DeserializedIdentifiable(String diagramId, String equipmentId) {
-            this.diagramId = diagramId;
-            this.equipmentId = equipmentId;
-        }
-
-        @Override
-        public String getDiagramId() {
-            return diagramId;
-        }
-
-        @Override
-        public String getEquipmentId() {
-            return equipmentId;
-        }
-
-        @Override
-        public Optional<String> getName() {
-            return Optional.empty();
-        }
+    static String readEquipmentId(XMLStreamReader reader) {
+        return reader.getAttributeValue(null, EQUIPMENT_ID_ATTRIBUTE);
     }
 }

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/BusNodeMetadata.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/BusNodeMetadata.java
@@ -1,0 +1,32 @@
+package com.powsybl.nad.svg.metadata;
+
+import com.powsybl.nad.model.Identifiable;
+
+import javax.xml.stream.XMLStreamReader;
+
+public class BusNodeMetadata extends AbstractMetadataItem {
+    private static final String ELEMENT_NAME = "busNode";
+
+    public BusNodeMetadata(Identifiable identifiable) {
+        super(identifiable);
+    }
+
+    @Override
+    String getElementName() {
+        return ELEMENT_NAME;
+    }
+
+    static class Reader implements AbstractMetadataItem.MetadataItemReader<BusNodeMetadata> {
+        @Override
+        public String getElementName() {
+            return ELEMENT_NAME;
+        }
+
+        public BusNodeMetadata read(XMLStreamReader reader) {
+            Identifiable deserializedIdentifiable = readIdentifiable(reader);
+            // Read busNode-specific metadata
+            // ...
+            return new BusNodeMetadata(deserializedIdentifiable);
+        }
+    }
+}

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/BusNodeMetadata.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/BusNodeMetadata.java
@@ -1,7 +1,5 @@
 package com.powsybl.nad.svg.metadata;
 
-import com.powsybl.nad.model.Identifiable;
-
 import javax.xml.stream.XMLStreamReader;
 
 public class BusNodeMetadata extends AbstractMetadataItem {

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/BusNodeMetadata.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/BusNodeMetadata.java
@@ -7,8 +7,8 @@ import javax.xml.stream.XMLStreamReader;
 public class BusNodeMetadata extends AbstractMetadataItem {
     private static final String ELEMENT_NAME = "busNode";
 
-    public BusNodeMetadata(Identifiable identifiable) {
-        super(identifiable);
+    public BusNodeMetadata(String svgId, String equipmentId) {
+        super(svgId, equipmentId);
     }
 
     @Override
@@ -23,10 +23,7 @@ public class BusNodeMetadata extends AbstractMetadataItem {
         }
 
         public BusNodeMetadata read(XMLStreamReader reader) {
-            Identifiable deserializedIdentifiable = readIdentifiable(reader);
-            // Read busNode-specific metadata
-            // ...
-            return new BusNodeMetadata(deserializedIdentifiable);
+            return new BusNodeMetadata(readDiagramId(reader), readEquipmentId(reader));
         }
     }
 }

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/DiagramMetadata.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/DiagramMetadata.java
@@ -77,58 +77,40 @@ public class DiagramMetadata {
         });
     }
 
-    static class WritingContext {
-        final XMLStreamWriter writer;
-        final UnaryOperator<String> diagramIdToSvgId;
-
-        WritingContext(UnaryOperator<String> diagramIdToSvgId, XMLStreamWriter writer) {
-            this.writer = writer;
-            this.diagramIdToSvgId = diagramIdToSvgId;
-        }
-    }
-
     public void writeXml(XMLStreamWriter writer) throws XMLStreamException {
-        writeXml(new WritingContext(UnaryOperator.identity(), writer));
-    }
+        writer.writeStartElement(METADATA_PREFIX, METADATA_DIAGRAM_ELEMENT_NAME, METADATA_NAMESPACE_URI);
+        writer.writeNamespace(METADATA_PREFIX, METADATA_NAMESPACE_URI);
 
-    public void writeXml(UnaryOperator<String> diagramIdToSvgId, XMLStreamWriter writer) throws XMLStreamException {
-        writeXml(new WritingContext(diagramIdToSvgId, writer));
-    }
-
-    public void writeXml(WritingContext ctx) throws XMLStreamException {
-        ctx.writer.writeStartElement(METADATA_PREFIX, METADATA_DIAGRAM_ELEMENT_NAME, METADATA_NAMESPACE_URI);
-        ctx.writer.writeNamespace(METADATA_PREFIX, METADATA_NAMESPACE_URI);
-
-        writeCollection(busNodesMetadata, METADATA_BUS_NODES_ELEMENT_NAME, ctx);
-        writeCollection(nodesMetadata, METADATA_NODES_ELEMENT_NAME, ctx);
-        writeCollection(edgesMetadata, METADATA_EDGES_ELEMENT_NAME, ctx);
-        ctx.writer.writeEndElement();
+        writeCollection(busNodesMetadata, METADATA_BUS_NODES_ELEMENT_NAME, writer);
+        writeCollection(nodesMetadata, METADATA_NODES_ELEMENT_NAME, writer);
+        writeCollection(edgesMetadata, METADATA_EDGES_ELEMENT_NAME, writer);
+        writer.writeEndElement();
     }
 
     private static <M extends AbstractMetadataItem> void writeCollection(
             Collection<M> items,
             String collectionElementName,
-            WritingContext ctx) throws XMLStreamException {
+            XMLStreamWriter writer) throws XMLStreamException {
         if (items.isEmpty()) {
-            ctx.writer.writeEmptyElement(METADATA_PREFIX, collectionElementName, METADATA_NAMESPACE_URI);
+            writer.writeEmptyElement(METADATA_PREFIX, collectionElementName, METADATA_NAMESPACE_URI);
         } else {
-            ctx.writer.writeStartElement(METADATA_PREFIX, collectionElementName, METADATA_NAMESPACE_URI);
+            writer.writeStartElement(METADATA_PREFIX, collectionElementName, METADATA_NAMESPACE_URI);
             for (M item : items) {
-                item.write(ctx);
+                item.write(writer);
             }
-            ctx.writer.writeEndElement();
+            writer.writeEndElement();
         }
     }
 
-    public void addBusNode(BusNode node) {
-        busNodesMetadata.add(new BusNodeMetadata(node));
+    public void addBusNode(String svgId, String equipmentId) {
+        busNodesMetadata.add(new BusNodeMetadata(svgId, equipmentId));
     }
 
-    public void addNode(Node node) {
-        nodesMetadata.add(new NodeMetadata(node, node.getPosition()));
+    public void addNode(String svgId, String equipmentId, String positionX, String positionY) {
+        nodesMetadata.add(new NodeMetadata(svgId, equipmentId, positionX, positionY));
     }
 
-    public void addEdge(Edge edge) {
-        edgesMetadata.add(new EdgeMetadata(edge));
+    public void addEdge(String svgId, String equipmentId) {
+        edgesMetadata.add(new EdgeMetadata(svgId, equipmentId));
     }
 }

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/DiagramMetadata.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/DiagramMetadata.java
@@ -35,7 +35,7 @@ public class DiagramMetadata {
     private static final String METADATA_NODES_ELEMENT_NAME = "nodes";
     private static final String METADATA_EDGES_ELEMENT_NAME = "edges";
 
-    private final List<NodeMetadata> busNodesMetadata = new ArrayList<>();
+    private final List<BusNodeMetadata> busNodesMetadata = new ArrayList<>();
     private final List<NodeMetadata> nodesMetadata = new ArrayList<>();
     private final List<EdgeMetadata> edgesMetadata = new ArrayList<>();
 
@@ -50,7 +50,7 @@ public class DiagramMetadata {
             String token = reader.getLocalName();
             switch (token) {
                 case METADATA_BUS_NODES_ELEMENT_NAME:
-                    readCollection(metadata.busNodesMetadata, METADATA_BUS_NODES_ELEMENT_NAME, NodeMetadata.Reader.forBusNodes(), reader);
+                    readCollection(metadata.busNodesMetadata, METADATA_BUS_NODES_ELEMENT_NAME, new BusNodeMetadata.Reader(), reader);
                     break;
                 case METADATA_NODES_ELEMENT_NAME:
                     readCollection(metadata.nodesMetadata, METADATA_NODES_ELEMENT_NAME, new NodeMetadata.Reader(), reader);
@@ -80,8 +80,6 @@ public class DiagramMetadata {
     static class WritingContext {
         final XMLStreamWriter writer;
         final UnaryOperator<String> diagramIdToSvgId;
-        boolean overrideElementName = false;
-        String elementName;
 
         WritingContext(UnaryOperator<String> diagramIdToSvgId, XMLStreamWriter writer) {
             this.writer = writer;
@@ -101,11 +99,7 @@ public class DiagramMetadata {
         ctx.writer.writeStartElement(METADATA_PREFIX, METADATA_DIAGRAM_ELEMENT_NAME, METADATA_NAMESPACE_URI);
         ctx.writer.writeNamespace(METADATA_PREFIX, METADATA_NAMESPACE_URI);
 
-        ctx.overrideElementName = true;
-        ctx.elementName = NodeMetadata.getBusNodeElementName();
         writeCollection(busNodesMetadata, METADATA_BUS_NODES_ELEMENT_NAME, ctx);
-        ctx.overrideElementName = false;
-
         writeCollection(nodesMetadata, METADATA_NODES_ELEMENT_NAME, ctx);
         writeCollection(edgesMetadata, METADATA_EDGES_ELEMENT_NAME, ctx);
         ctx.writer.writeEndElement();
@@ -127,7 +121,7 @@ public class DiagramMetadata {
     }
 
     public void addBusNode(BusNode node) {
-        busNodesMetadata.add(new NodeMetadata(node, node.getPosition()));
+        busNodesMetadata.add(new BusNodeMetadata(node));
     }
 
     public void addNode(Node node) {

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/DiagramMetadata.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/DiagramMetadata.java
@@ -8,9 +8,6 @@
 package com.powsybl.nad.svg.metadata;
 
 import com.powsybl.commons.xml.XmlUtil;
-import com.powsybl.nad.model.BusNode;
-import com.powsybl.nad.model.Edge;
-import com.powsybl.nad.model.Node;
 
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
@@ -20,7 +17,6 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.function.UnaryOperator;
 
 /**
  * @author Thomas Adam <tadam at silicom.fr>

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/EdgeMetadata.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/EdgeMetadata.java
@@ -18,8 +18,8 @@ public class EdgeMetadata extends AbstractMetadataItem {
 
     private static final String ELEMENT_NAME = "edge";
 
-    public EdgeMetadata(Identifiable identifiable) {
-        super(identifiable);
+    public EdgeMetadata(String svgId, String equipmentId) {
+        super(svgId, equipmentId);
     }
 
     @Override
@@ -34,10 +34,9 @@ public class EdgeMetadata extends AbstractMetadataItem {
         }
 
         public EdgeMetadata read(XMLStreamReader reader) {
-            Identifiable deserializedIdentifiable = readIdentifiable(reader);
             // Read edge-specific metadata
             // ...
-            return new EdgeMetadata(deserializedIdentifiable);
+            return new EdgeMetadata(readDiagramId(reader), readEquipmentId(reader));
         }
     }
 }

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/EdgeMetadata.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/EdgeMetadata.java
@@ -7,8 +7,6 @@
  */
 package com.powsybl.nad.svg.metadata;
 
-import com.powsybl.nad.model.Identifiable;
-
 import javax.xml.stream.XMLStreamReader;
 
 /**

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/NodeMetadata.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/NodeMetadata.java
@@ -12,26 +12,25 @@ import com.powsybl.nad.model.Point;
 
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
+import javax.xml.stream.XMLStreamWriter;
 import java.util.Locale;
 
 /**
  * @author Luma Zamarreño <zamarrenolm at aia.es>
  */
 public class NodeMetadata extends AbstractMetadataItem {
-    private final Point position;
-
     private static final String ELEMENT_NAME = "node";
     private static final String POSITION_X_ATTRIBUTE = "x";
     private static final String POSITION_Y_ATTRIBUTE = "y";
     private static final String POSITION_COORD_FORMAT = "%.2f";
 
-    public NodeMetadata(Identifiable identifiable, Point position) {
-        super(identifiable);
-        this.position = position;
-    }
+    private final String positionX;
+    private final String positionY;
 
-    public Point getPosition() {
-        return position;
+    public NodeMetadata(String svgId, String equipmentId, String positionX, String positionY) {
+        super(svgId, equipmentId);
+        this.positionX = positionX;
+        this.positionY = positionY;
     }
 
     @Override
@@ -40,14 +39,10 @@ public class NodeMetadata extends AbstractMetadataItem {
     }
 
     @Override
-    void write(DiagramMetadata.WritingContext ctx) throws XMLStreamException {
-        super.write(ctx);
-        ctx.writer.writeAttribute(POSITION_X_ATTRIBUTE, formatted(position.getX()));
-        ctx.writer.writeAttribute(POSITION_Y_ATTRIBUTE, formatted(position.getY()));
-    }
-
-    private static String formatted(double value) {
-        return String.format(Locale.US, POSITION_COORD_FORMAT, value);
+    void write(XMLStreamWriter writer) throws XMLStreamException {
+        super.write(writer);
+        writer.writeAttribute(POSITION_X_ATTRIBUTE, positionX);
+        writer.writeAttribute(POSITION_Y_ATTRIBUTE, positionY);
     }
 
     static class Reader implements MetadataItemReader<NodeMetadata> {
@@ -55,11 +50,7 @@ public class NodeMetadata extends AbstractMetadataItem {
         private final String elementName;
 
         Reader() {
-            this(ELEMENT_NAME);
-        }
-
-        private Reader(String elementName) {
-            this.elementName = elementName;
+            this.elementName = ELEMENT_NAME;
         }
 
         @Override
@@ -68,22 +59,9 @@ public class NodeMetadata extends AbstractMetadataItem {
         }
 
         public NodeMetadata read(XMLStreamReader reader) {
-            Identifiable deserializedIdentifiable = readIdentifiable(reader);
-            Point position = readPoint(reader);
-            return new NodeMetadata(deserializedIdentifiable, position);
-        }
-
-        private static Point readPoint(XMLStreamReader reader) {
-            double x = parseDouble(reader.getAttributeValue(null, POSITION_X_ATTRIBUTE));
-            double y = parseDouble(reader.getAttributeValue(null, POSITION_Y_ATTRIBUTE));
-            return new Point(x, y);
-        }
-
-        private static double parseDouble(String s) {
-            if (s == null || s.isEmpty()) {
-                return Double.NaN;
-            }
-            return Double.parseDouble(s);
+            return new NodeMetadata(readDiagramId(reader), readEquipmentId(reader),
+                    reader.getAttributeValue(null, POSITION_X_ATTRIBUTE),
+                    reader.getAttributeValue(null, POSITION_Y_ATTRIBUTE));
         }
     }
 }

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/NodeMetadata.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/NodeMetadata.java
@@ -12,6 +12,7 @@ import com.powsybl.nad.model.Point;
 
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
+import java.util.Locale;
 
 /**
  * @author Luma Zamarreño <zamarrenolm at aia.es>
@@ -51,7 +52,7 @@ public class NodeMetadata extends AbstractMetadataItem {
     }
 
     private static String formatted(double value) {
-        return String.format(POSITION_COORD_FORMAT, value);
+        return String.format(Locale.US, POSITION_COORD_FORMAT, value);
     }
 
     static class Reader implements MetadataItemReader<NodeMetadata> {

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/NodeMetadata.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/NodeMetadata.java
@@ -7,13 +7,9 @@
  */
 package com.powsybl.nad.svg.metadata;
 
-import com.powsybl.nad.model.Identifiable;
-import com.powsybl.nad.model.Point;
-
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
-import java.util.Locale;
 
 /**
  * @author Luma Zamarreño <zamarrenolm at aia.es>
@@ -22,7 +18,6 @@ public class NodeMetadata extends AbstractMetadataItem {
     private static final String ELEMENT_NAME = "node";
     private static final String POSITION_X_ATTRIBUTE = "x";
     private static final String POSITION_Y_ATTRIBUTE = "y";
-    private static final String POSITION_COORD_FORMAT = "%.2f";
 
     private final String positionX;
     private final String positionY;

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/NodeMetadata.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/NodeMetadata.java
@@ -21,7 +21,6 @@ public class NodeMetadata extends AbstractMetadataItem {
     private final Point position;
 
     private static final String ELEMENT_NAME = "node";
-    private static final String BUS_NODE_ELEMENT_NAME = "busNode";
     private static final String POSITION_X_ATTRIBUTE = "x";
     private static final String POSITION_Y_ATTRIBUTE = "y";
     private static final String POSITION_COORD_FORMAT = "%.2f";
@@ -29,10 +28,6 @@ public class NodeMetadata extends AbstractMetadataItem {
     public NodeMetadata(Identifiable identifiable, Point position) {
         super(identifiable);
         this.position = position;
-    }
-
-    public static String getBusNodeElementName() {
-        return BUS_NODE_ELEMENT_NAME;
     }
 
     public Point getPosition() {
@@ -61,10 +56,6 @@ public class NodeMetadata extends AbstractMetadataItem {
 
         Reader() {
             this(ELEMENT_NAME);
-        }
-
-        static Reader forBusNodes() {
-            return new Reader(BUS_NODE_ELEMENT_NAME);
         }
 
         private Reader(String elementName) {

--- a/network-area-diagram/src/main/resources/nad-metadata_V1_0.xsd
+++ b/network-area-diagram/src/main/resources/nad-metadata_V1_0.xsd
@@ -46,19 +46,17 @@
         </xs:complexType>
     </xs:element>
     <xs:complexType name="busNode">
-        <xs:attribute name="diagramId" use="required" type="nad:nonEmptyString"/>
+        <xs:attribute name="svgId" use="required" type="nad:nonEmptyString"/>
         <xs:attribute name="equipmentId" use="required" type="nad:nonEmptyString"/>
-        <xs:attribute name="x" type="xs:double"/>
-        <xs:attribute name="y" type="xs:double"/>
     </xs:complexType>
     <xs:complexType name="Node">
-        <xs:attribute name="diagramId" use="required" type="nad:nonEmptyString"/>
+        <xs:attribute name="svgId" use="required" type="nad:nonEmptyString"/>
         <xs:attribute name="equipmentId" use="required" type="nad:nonEmptyString"/>
         <xs:attribute name="x" type="xs:double"/>
         <xs:attribute name="y" type="xs:double"/>
     </xs:complexType>
     <xs:complexType name="Edge">
-        <xs:attribute name="diagramId" use="required" type="nad:nonEmptyString"/>
+        <xs:attribute name="svgId" use="required" type="nad:nonEmptyString"/>
         <xs:attribute name="equipmentId" use="required" type="nad:nonEmptyString"/>
     </xs:complexType>
 </xs:schema>

--- a/network-area-diagram/src/test/resources/3wt.svg
+++ b/network-area-diagram/src/test/resources/3wt.svg
@@ -49,18 +49,18 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="VL_11_0"/>
-                <nad:busNode diagramId="3" equipmentId="VL_132_0"/>
-                <nad:busNode diagramId="5" equipmentId="VL_33_0"/>
+                <nad:busNode svgId="1" equipmentId="VL_11_0"/>
+                <nad:busNode svgId="3" equipmentId="VL_132_0"/>
+                <nad:busNode svgId="5" equipmentId="VL_33_0"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node diagramId="0" equipmentId="VL_11" x="-198.78" y="-222.73"/>
-                <nad:node diagramId="2" equipmentId="VL_132" x="-179.95" y="359.14"/>
-                <nad:node diagramId="4" equipmentId="VL_33" x="454.74" y="-65.39"/>
-                <nad:node diagramId="6" equipmentId="3WT" x="72.67" y="53.08"/>
+                <nad:node svgId="0" equipmentId="VL_11" x="-198.78" y="-222.73"/>
+                <nad:node svgId="2" equipmentId="VL_132" x="-179.95" y="359.14"/>
+                <nad:node svgId="4" equipmentId="VL_33" x="454.74" y="-65.39"/>
+                <nad:node svgId="6" equipmentId="3WT" x="72.67" y="53.08"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge diagramId="9" equipmentId="3WT"/>
+                <nad:edge svgId="9" equipmentId="3WT"/>
             </nad:edges>
         </nad:nad>
     </metadata>

--- a/network-area-diagram/src/test/resources/3wt.svg
+++ b/network-area-diagram/src/test/resources/3wt.svg
@@ -49,9 +49,9 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="VL_11_0" x="-198.78" y="-222.73"/>
-                <nad:busNode diagramId="3" equipmentId="VL_132_0" x="-179.95" y="359.14"/>
-                <nad:busNode diagramId="5" equipmentId="VL_33_0" x="454.74" y="-65.39"/>
+                <nad:busNode diagramId="1" equipmentId="VL_11_0"/>
+                <nad:busNode diagramId="3" equipmentId="VL_132_0"/>
+                <nad:busNode diagramId="5" equipmentId="VL_33_0"/>
             </nad:busNodes>
             <nad:nodes>
                 <nad:node diagramId="0" equipmentId="VL_11" x="-198.78" y="-222.73"/>

--- a/network-area-diagram/src/test/resources/3wt_disconnected.svg
+++ b/network-area-diagram/src/test/resources/3wt_disconnected.svg
@@ -49,8 +49,8 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="VL_11_0" x="-198.78" y="-222.73"/>
-                <nad:busNode diagramId="3" equipmentId="VL_132_0" x="-179.95" y="359.14"/>
+                <nad:busNode diagramId="1" equipmentId="VL_11_0"/>
+                <nad:busNode diagramId="3" equipmentId="VL_132_0"/>
             </nad:busNodes>
             <nad:nodes>
                 <nad:node diagramId="0" equipmentId="VL_11" x="-198.78" y="-222.73"/>

--- a/network-area-diagram/src/test/resources/3wt_disconnected.svg
+++ b/network-area-diagram/src/test/resources/3wt_disconnected.svg
@@ -49,17 +49,17 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="VL_11_0"/>
-                <nad:busNode diagramId="3" equipmentId="VL_132_0"/>
+                <nad:busNode svgId="1" equipmentId="VL_11_0"/>
+                <nad:busNode svgId="3" equipmentId="VL_132_0"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node diagramId="0" equipmentId="VL_11" x="-198.78" y="-222.73"/>
-                <nad:node diagramId="2" equipmentId="VL_132" x="-179.95" y="359.14"/>
-                <nad:node diagramId="4" equipmentId="VL_33" x="454.74" y="-65.39"/>
-                <nad:node diagramId="5" equipmentId="3WT" x="72.67" y="53.08"/>
+                <nad:node svgId="0" equipmentId="VL_11" x="-198.78" y="-222.73"/>
+                <nad:node svgId="2" equipmentId="VL_132" x="-179.95" y="359.14"/>
+                <nad:node svgId="4" equipmentId="VL_33" x="454.74" y="-65.39"/>
+                <nad:node svgId="5" equipmentId="3WT" x="72.67" y="53.08"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge diagramId="8" equipmentId="3WT"/>
+                <nad:edge svgId="8" equipmentId="3WT"/>
             </nad:edges>
         </nad:nad>
     </metadata>

--- a/network-area-diagram/src/test/resources/3wt_disconnected_topological.svg
+++ b/network-area-diagram/src/test/resources/3wt_disconnected_topological.svg
@@ -114,17 +114,17 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="VL_11_0"/>
-                <nad:busNode diagramId="3" equipmentId="VL_132_0"/>
+                <nad:busNode svgId="1" equipmentId="VL_11_0"/>
+                <nad:busNode svgId="3" equipmentId="VL_132_0"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node diagramId="0" equipmentId="VL_11" x="-198.78" y="-222.73"/>
-                <nad:node diagramId="2" equipmentId="VL_132" x="-179.95" y="359.14"/>
-                <nad:node diagramId="4" equipmentId="VL_33" x="454.74" y="-65.39"/>
-                <nad:node diagramId="5" equipmentId="3WT" x="72.67" y="53.08"/>
+                <nad:node svgId="0" equipmentId="VL_11" x="-198.78" y="-222.73"/>
+                <nad:node svgId="2" equipmentId="VL_132" x="-179.95" y="359.14"/>
+                <nad:node svgId="4" equipmentId="VL_33" x="454.74" y="-65.39"/>
+                <nad:node svgId="5" equipmentId="3WT" x="72.67" y="53.08"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge diagramId="8" equipmentId="3WT"/>
+                <nad:edge svgId="8" equipmentId="3WT"/>
             </nad:edges>
         </nad:nad>
     </metadata>

--- a/network-area-diagram/src/test/resources/3wt_disconnected_topological.svg
+++ b/network-area-diagram/src/test/resources/3wt_disconnected_topological.svg
@@ -114,8 +114,8 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="VL_11_0" x="-198.78" y="-222.73"/>
-                <nad:busNode diagramId="3" equipmentId="VL_132_0" x="-179.95" y="359.14"/>
+                <nad:busNode diagramId="1" equipmentId="VL_11_0"/>
+                <nad:busNode diagramId="3" equipmentId="VL_132_0"/>
             </nad:busNodes>
             <nad:nodes>
                 <nad:node diagramId="0" equipmentId="VL_11" x="-198.78" y="-222.73"/>

--- a/network-area-diagram/src/test/resources/3wt_partial.svg
+++ b/network-area-diagram/src/test/resources/3wt_partial.svg
@@ -49,18 +49,18 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="VL_11_0"/>
-                <nad:busNode diagramId="5" equipmentId="VL_132_0"/>
-                <nad:busNode diagramId="8" equipmentId="VL_33_0"/>
+                <nad:busNode svgId="1" equipmentId="VL_11_0"/>
+                <nad:busNode svgId="5" equipmentId="VL_132_0"/>
+                <nad:busNode svgId="8" equipmentId="VL_33_0"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node diagramId="0" equipmentId="VL_11" x="-377.54" y="109.86"/>
-                <nad:node diagramId="2" equipmentId="3WT" x="5.94" y="4.19"/>
-                <nad:node diagramId="4" equipmentId="VL_132" x="252.09" y="302.44"/>
-                <nad:node diagramId="7" equipmentId="VL_33" x="261.19" y="-298.22"/>
+                <nad:node svgId="0" equipmentId="VL_11" x="-377.54" y="109.86"/>
+                <nad:node svgId="2" equipmentId="3WT" x="5.94" y="4.19"/>
+                <nad:node svgId="4" equipmentId="VL_132" x="252.09" y="302.44"/>
+                <nad:node svgId="7" equipmentId="VL_33" x="261.19" y="-298.22"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge diagramId="9" equipmentId="3WT"/>
+                <nad:edge svgId="9" equipmentId="3WT"/>
             </nad:edges>
         </nad:nad>
     </metadata>

--- a/network-area-diagram/src/test/resources/3wt_partial.svg
+++ b/network-area-diagram/src/test/resources/3wt_partial.svg
@@ -49,9 +49,9 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="VL_11_0" x="-377.54" y="109.86"/>
-                <nad:busNode diagramId="5" equipmentId="VL_132_0" x="252.09" y="302.44"/>
-                <nad:busNode diagramId="8" equipmentId="VL_33_0" x="261.19" y="-298.22"/>
+                <nad:busNode diagramId="1" equipmentId="VL_11_0"/>
+                <nad:busNode diagramId="5" equipmentId="VL_132_0"/>
+                <nad:busNode diagramId="8" equipmentId="VL_33_0"/>
             </nad:busNodes>
             <nad:nodes>
                 <nad:node diagramId="0" equipmentId="VL_11" x="-377.54" y="109.86"/>

--- a/network-area-diagram/src/test/resources/IEEE_118_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_118_bus.svg
@@ -114,432 +114,432 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="VL1_0"/>
-                <nad:busNode diagramId="3" equipmentId="VL10_0"/>
-                <nad:busNode diagramId="5" equipmentId="VL100_0"/>
-                <nad:busNode diagramId="7" equipmentId="VL101_0"/>
-                <nad:busNode diagramId="9" equipmentId="VL102_0"/>
-                <nad:busNode diagramId="11" equipmentId="VL103_0"/>
-                <nad:busNode diagramId="13" equipmentId="VL104_0"/>
-                <nad:busNode diagramId="15" equipmentId="VL105_0"/>
-                <nad:busNode diagramId="17" equipmentId="VL106_0"/>
-                <nad:busNode diagramId="19" equipmentId="VL107_0"/>
-                <nad:busNode diagramId="21" equipmentId="VL108_0"/>
-                <nad:busNode diagramId="23" equipmentId="VL109_0"/>
-                <nad:busNode diagramId="25" equipmentId="VL11_0"/>
-                <nad:busNode diagramId="27" equipmentId="VL110_0"/>
-                <nad:busNode diagramId="29" equipmentId="VL111_0"/>
-                <nad:busNode diagramId="31" equipmentId="VL112_0"/>
-                <nad:busNode diagramId="33" equipmentId="VL113_0"/>
-                <nad:busNode diagramId="35" equipmentId="VL114_0"/>
-                <nad:busNode diagramId="37" equipmentId="VL115_0"/>
-                <nad:busNode diagramId="39" equipmentId="VL116_0"/>
-                <nad:busNode diagramId="41" equipmentId="VL117_0"/>
-                <nad:busNode diagramId="43" equipmentId="VL118_0"/>
-                <nad:busNode diagramId="45" equipmentId="VL12_0"/>
-                <nad:busNode diagramId="47" equipmentId="VL13_0"/>
-                <nad:busNode diagramId="49" equipmentId="VL14_0"/>
-                <nad:busNode diagramId="51" equipmentId="VL15_0"/>
-                <nad:busNode diagramId="53" equipmentId="VL16_0"/>
-                <nad:busNode diagramId="55" equipmentId="VL17_0"/>
-                <nad:busNode diagramId="57" equipmentId="VL18_0"/>
-                <nad:busNode diagramId="59" equipmentId="VL19_0"/>
-                <nad:busNode diagramId="61" equipmentId="VL2_0"/>
-                <nad:busNode diagramId="63" equipmentId="VL20_0"/>
-                <nad:busNode diagramId="65" equipmentId="VL21_0"/>
-                <nad:busNode diagramId="67" equipmentId="VL22_0"/>
-                <nad:busNode diagramId="69" equipmentId="VL23_0"/>
-                <nad:busNode diagramId="71" equipmentId="VL24_0"/>
-                <nad:busNode diagramId="73" equipmentId="VL25_0"/>
-                <nad:busNode diagramId="75" equipmentId="VL26_0"/>
-                <nad:busNode diagramId="77" equipmentId="VL27_0"/>
-                <nad:busNode diagramId="79" equipmentId="VL28_0"/>
-                <nad:busNode diagramId="81" equipmentId="VL29_0"/>
-                <nad:busNode diagramId="83" equipmentId="VL3_0"/>
-                <nad:busNode diagramId="85" equipmentId="VL30_0"/>
-                <nad:busNode diagramId="87" equipmentId="VL31_0"/>
-                <nad:busNode diagramId="89" equipmentId="VL32_0"/>
-                <nad:busNode diagramId="91" equipmentId="VL33_0"/>
-                <nad:busNode diagramId="93" equipmentId="VL34_0"/>
-                <nad:busNode diagramId="95" equipmentId="VL35_0"/>
-                <nad:busNode diagramId="97" equipmentId="VL36_0"/>
-                <nad:busNode diagramId="99" equipmentId="VL37_0"/>
-                <nad:busNode diagramId="101" equipmentId="VL38_0"/>
-                <nad:busNode diagramId="103" equipmentId="VL39_0"/>
-                <nad:busNode diagramId="105" equipmentId="VL4_0"/>
-                <nad:busNode diagramId="107" equipmentId="VL40_0"/>
-                <nad:busNode diagramId="109" equipmentId="VL41_0"/>
-                <nad:busNode diagramId="111" equipmentId="VL42_0"/>
-                <nad:busNode diagramId="113" equipmentId="VL43_0"/>
-                <nad:busNode diagramId="115" equipmentId="VL44_0"/>
-                <nad:busNode diagramId="117" equipmentId="VL45_0"/>
-                <nad:busNode diagramId="119" equipmentId="VL46_0"/>
-                <nad:busNode diagramId="121" equipmentId="VL47_0"/>
-                <nad:busNode diagramId="123" equipmentId="VL48_0"/>
-                <nad:busNode diagramId="125" equipmentId="VL49_0"/>
-                <nad:busNode diagramId="127" equipmentId="VL5_0"/>
-                <nad:busNode diagramId="129" equipmentId="VL50_0"/>
-                <nad:busNode diagramId="131" equipmentId="VL51_0"/>
-                <nad:busNode diagramId="133" equipmentId="VL52_0"/>
-                <nad:busNode diagramId="135" equipmentId="VL53_0"/>
-                <nad:busNode diagramId="137" equipmentId="VL54_0"/>
-                <nad:busNode diagramId="139" equipmentId="VL55_0"/>
-                <nad:busNode diagramId="141" equipmentId="VL56_0"/>
-                <nad:busNode diagramId="143" equipmentId="VL57_0"/>
-                <nad:busNode diagramId="145" equipmentId="VL58_0"/>
-                <nad:busNode diagramId="147" equipmentId="VL59_0"/>
-                <nad:busNode diagramId="149" equipmentId="VL6_0"/>
-                <nad:busNode diagramId="151" equipmentId="VL60_0"/>
-                <nad:busNode diagramId="153" equipmentId="VL61_0"/>
-                <nad:busNode diagramId="155" equipmentId="VL62_0"/>
-                <nad:busNode diagramId="157" equipmentId="VL63_0"/>
-                <nad:busNode diagramId="159" equipmentId="VL64_0"/>
-                <nad:busNode diagramId="161" equipmentId="VL65_0"/>
-                <nad:busNode diagramId="163" equipmentId="VL66_0"/>
-                <nad:busNode diagramId="165" equipmentId="VL67_0"/>
-                <nad:busNode diagramId="167" equipmentId="VL68_0"/>
-                <nad:busNode diagramId="169" equipmentId="VL69_0"/>
-                <nad:busNode diagramId="171" equipmentId="VL7_0"/>
-                <nad:busNode diagramId="173" equipmentId="VL70_0"/>
-                <nad:busNode diagramId="175" equipmentId="VL71_0"/>
-                <nad:busNode diagramId="177" equipmentId="VL72_0"/>
-                <nad:busNode diagramId="179" equipmentId="VL73_0"/>
-                <nad:busNode diagramId="181" equipmentId="VL74_0"/>
-                <nad:busNode diagramId="183" equipmentId="VL75_0"/>
-                <nad:busNode diagramId="185" equipmentId="VL76_0"/>
-                <nad:busNode diagramId="187" equipmentId="VL77_0"/>
-                <nad:busNode diagramId="189" equipmentId="VL78_0"/>
-                <nad:busNode diagramId="191" equipmentId="VL79_0"/>
-                <nad:busNode diagramId="193" equipmentId="VL8_0"/>
-                <nad:busNode diagramId="195" equipmentId="VL80_0"/>
-                <nad:busNode diagramId="197" equipmentId="VL81_0"/>
-                <nad:busNode diagramId="199" equipmentId="VL82_0"/>
-                <nad:busNode diagramId="201" equipmentId="VL83_0"/>
-                <nad:busNode diagramId="203" equipmentId="VL84_0"/>
-                <nad:busNode diagramId="205" equipmentId="VL85_0"/>
-                <nad:busNode diagramId="207" equipmentId="VL86_0"/>
-                <nad:busNode diagramId="209" equipmentId="VL87_0"/>
-                <nad:busNode diagramId="211" equipmentId="VL88_0"/>
-                <nad:busNode diagramId="213" equipmentId="VL89_0"/>
-                <nad:busNode diagramId="215" equipmentId="VL9_0"/>
-                <nad:busNode diagramId="217" equipmentId="VL90_0"/>
-                <nad:busNode diagramId="219" equipmentId="VL91_0"/>
-                <nad:busNode diagramId="221" equipmentId="VL92_0"/>
-                <nad:busNode diagramId="223" equipmentId="VL93_0"/>
-                <nad:busNode diagramId="225" equipmentId="VL94_0"/>
-                <nad:busNode diagramId="227" equipmentId="VL95_0"/>
-                <nad:busNode diagramId="229" equipmentId="VL96_0"/>
-                <nad:busNode diagramId="231" equipmentId="VL97_0"/>
-                <nad:busNode diagramId="233" equipmentId="VL98_0"/>
-                <nad:busNode diagramId="235" equipmentId="VL99_0"/>
+                <nad:busNode svgId="1" equipmentId="VL1_0"/>
+                <nad:busNode svgId="3" equipmentId="VL10_0"/>
+                <nad:busNode svgId="5" equipmentId="VL100_0"/>
+                <nad:busNode svgId="7" equipmentId="VL101_0"/>
+                <nad:busNode svgId="9" equipmentId="VL102_0"/>
+                <nad:busNode svgId="11" equipmentId="VL103_0"/>
+                <nad:busNode svgId="13" equipmentId="VL104_0"/>
+                <nad:busNode svgId="15" equipmentId="VL105_0"/>
+                <nad:busNode svgId="17" equipmentId="VL106_0"/>
+                <nad:busNode svgId="19" equipmentId="VL107_0"/>
+                <nad:busNode svgId="21" equipmentId="VL108_0"/>
+                <nad:busNode svgId="23" equipmentId="VL109_0"/>
+                <nad:busNode svgId="25" equipmentId="VL11_0"/>
+                <nad:busNode svgId="27" equipmentId="VL110_0"/>
+                <nad:busNode svgId="29" equipmentId="VL111_0"/>
+                <nad:busNode svgId="31" equipmentId="VL112_0"/>
+                <nad:busNode svgId="33" equipmentId="VL113_0"/>
+                <nad:busNode svgId="35" equipmentId="VL114_0"/>
+                <nad:busNode svgId="37" equipmentId="VL115_0"/>
+                <nad:busNode svgId="39" equipmentId="VL116_0"/>
+                <nad:busNode svgId="41" equipmentId="VL117_0"/>
+                <nad:busNode svgId="43" equipmentId="VL118_0"/>
+                <nad:busNode svgId="45" equipmentId="VL12_0"/>
+                <nad:busNode svgId="47" equipmentId="VL13_0"/>
+                <nad:busNode svgId="49" equipmentId="VL14_0"/>
+                <nad:busNode svgId="51" equipmentId="VL15_0"/>
+                <nad:busNode svgId="53" equipmentId="VL16_0"/>
+                <nad:busNode svgId="55" equipmentId="VL17_0"/>
+                <nad:busNode svgId="57" equipmentId="VL18_0"/>
+                <nad:busNode svgId="59" equipmentId="VL19_0"/>
+                <nad:busNode svgId="61" equipmentId="VL2_0"/>
+                <nad:busNode svgId="63" equipmentId="VL20_0"/>
+                <nad:busNode svgId="65" equipmentId="VL21_0"/>
+                <nad:busNode svgId="67" equipmentId="VL22_0"/>
+                <nad:busNode svgId="69" equipmentId="VL23_0"/>
+                <nad:busNode svgId="71" equipmentId="VL24_0"/>
+                <nad:busNode svgId="73" equipmentId="VL25_0"/>
+                <nad:busNode svgId="75" equipmentId="VL26_0"/>
+                <nad:busNode svgId="77" equipmentId="VL27_0"/>
+                <nad:busNode svgId="79" equipmentId="VL28_0"/>
+                <nad:busNode svgId="81" equipmentId="VL29_0"/>
+                <nad:busNode svgId="83" equipmentId="VL3_0"/>
+                <nad:busNode svgId="85" equipmentId="VL30_0"/>
+                <nad:busNode svgId="87" equipmentId="VL31_0"/>
+                <nad:busNode svgId="89" equipmentId="VL32_0"/>
+                <nad:busNode svgId="91" equipmentId="VL33_0"/>
+                <nad:busNode svgId="93" equipmentId="VL34_0"/>
+                <nad:busNode svgId="95" equipmentId="VL35_0"/>
+                <nad:busNode svgId="97" equipmentId="VL36_0"/>
+                <nad:busNode svgId="99" equipmentId="VL37_0"/>
+                <nad:busNode svgId="101" equipmentId="VL38_0"/>
+                <nad:busNode svgId="103" equipmentId="VL39_0"/>
+                <nad:busNode svgId="105" equipmentId="VL4_0"/>
+                <nad:busNode svgId="107" equipmentId="VL40_0"/>
+                <nad:busNode svgId="109" equipmentId="VL41_0"/>
+                <nad:busNode svgId="111" equipmentId="VL42_0"/>
+                <nad:busNode svgId="113" equipmentId="VL43_0"/>
+                <nad:busNode svgId="115" equipmentId="VL44_0"/>
+                <nad:busNode svgId="117" equipmentId="VL45_0"/>
+                <nad:busNode svgId="119" equipmentId="VL46_0"/>
+                <nad:busNode svgId="121" equipmentId="VL47_0"/>
+                <nad:busNode svgId="123" equipmentId="VL48_0"/>
+                <nad:busNode svgId="125" equipmentId="VL49_0"/>
+                <nad:busNode svgId="127" equipmentId="VL5_0"/>
+                <nad:busNode svgId="129" equipmentId="VL50_0"/>
+                <nad:busNode svgId="131" equipmentId="VL51_0"/>
+                <nad:busNode svgId="133" equipmentId="VL52_0"/>
+                <nad:busNode svgId="135" equipmentId="VL53_0"/>
+                <nad:busNode svgId="137" equipmentId="VL54_0"/>
+                <nad:busNode svgId="139" equipmentId="VL55_0"/>
+                <nad:busNode svgId="141" equipmentId="VL56_0"/>
+                <nad:busNode svgId="143" equipmentId="VL57_0"/>
+                <nad:busNode svgId="145" equipmentId="VL58_0"/>
+                <nad:busNode svgId="147" equipmentId="VL59_0"/>
+                <nad:busNode svgId="149" equipmentId="VL6_0"/>
+                <nad:busNode svgId="151" equipmentId="VL60_0"/>
+                <nad:busNode svgId="153" equipmentId="VL61_0"/>
+                <nad:busNode svgId="155" equipmentId="VL62_0"/>
+                <nad:busNode svgId="157" equipmentId="VL63_0"/>
+                <nad:busNode svgId="159" equipmentId="VL64_0"/>
+                <nad:busNode svgId="161" equipmentId="VL65_0"/>
+                <nad:busNode svgId="163" equipmentId="VL66_0"/>
+                <nad:busNode svgId="165" equipmentId="VL67_0"/>
+                <nad:busNode svgId="167" equipmentId="VL68_0"/>
+                <nad:busNode svgId="169" equipmentId="VL69_0"/>
+                <nad:busNode svgId="171" equipmentId="VL7_0"/>
+                <nad:busNode svgId="173" equipmentId="VL70_0"/>
+                <nad:busNode svgId="175" equipmentId="VL71_0"/>
+                <nad:busNode svgId="177" equipmentId="VL72_0"/>
+                <nad:busNode svgId="179" equipmentId="VL73_0"/>
+                <nad:busNode svgId="181" equipmentId="VL74_0"/>
+                <nad:busNode svgId="183" equipmentId="VL75_0"/>
+                <nad:busNode svgId="185" equipmentId="VL76_0"/>
+                <nad:busNode svgId="187" equipmentId="VL77_0"/>
+                <nad:busNode svgId="189" equipmentId="VL78_0"/>
+                <nad:busNode svgId="191" equipmentId="VL79_0"/>
+                <nad:busNode svgId="193" equipmentId="VL8_0"/>
+                <nad:busNode svgId="195" equipmentId="VL80_0"/>
+                <nad:busNode svgId="197" equipmentId="VL81_0"/>
+                <nad:busNode svgId="199" equipmentId="VL82_0"/>
+                <nad:busNode svgId="201" equipmentId="VL83_0"/>
+                <nad:busNode svgId="203" equipmentId="VL84_0"/>
+                <nad:busNode svgId="205" equipmentId="VL85_0"/>
+                <nad:busNode svgId="207" equipmentId="VL86_0"/>
+                <nad:busNode svgId="209" equipmentId="VL87_0"/>
+                <nad:busNode svgId="211" equipmentId="VL88_0"/>
+                <nad:busNode svgId="213" equipmentId="VL89_0"/>
+                <nad:busNode svgId="215" equipmentId="VL9_0"/>
+                <nad:busNode svgId="217" equipmentId="VL90_0"/>
+                <nad:busNode svgId="219" equipmentId="VL91_0"/>
+                <nad:busNode svgId="221" equipmentId="VL92_0"/>
+                <nad:busNode svgId="223" equipmentId="VL93_0"/>
+                <nad:busNode svgId="225" equipmentId="VL94_0"/>
+                <nad:busNode svgId="227" equipmentId="VL95_0"/>
+                <nad:busNode svgId="229" equipmentId="VL96_0"/>
+                <nad:busNode svgId="231" equipmentId="VL97_0"/>
+                <nad:busNode svgId="233" equipmentId="VL98_0"/>
+                <nad:busNode svgId="235" equipmentId="VL99_0"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node diagramId="0" equipmentId="VL1" x="736.99" y="-2973.24"/>
-                <nad:node diagramId="2" equipmentId="VL10" x="-1307.45" y="-2918.68"/>
-                <nad:node diagramId="4" equipmentId="VL100" x="2323.85" y="-469.66"/>
-                <nad:node diagramId="6" equipmentId="VL101" x="2787.74" y="-301.89"/>
-                <nad:node diagramId="8" equipmentId="VL102" x="3037.91" y="-0.61"/>
-                <nad:node diagramId="10" equipmentId="VL103" x="2317.93" y="-1246.85"/>
-                <nad:node diagramId="12" equipmentId="VL104" x="2390.66" y="-930.45"/>
-                <nad:node diagramId="14" equipmentId="VL105" x="2741.45" y="-1230.14"/>
-                <nad:node diagramId="16" equipmentId="VL106" x="2817.56" y="-835.52"/>
-                <nad:node diagramId="18" equipmentId="VL107" x="3127.02" y="-1083.37"/>
-                <nad:node diagramId="20" equipmentId="VL108" x="2896.05" y="-1690.56"/>
-                <nad:node diagramId="22" equipmentId="VL109" x="2665.31" y="-2006.62"/>
-                <nad:node diagramId="24" equipmentId="VL11" x="-67.16" y="-2211.79"/>
-                <nad:node diagramId="26" equipmentId="VL110" x="2247.63" y="-1899.10"/>
-                <nad:node diagramId="28" equipmentId="VL111" x="1858.44" y="-2031.11"/>
-                <nad:node diagramId="30" equipmentId="VL112" x="2235.01" y="-2372.34"/>
-                <nad:node diagramId="32" equipmentId="VL113" x="-1385.76" y="-1526.69"/>
-                <nad:node diagramId="34" equipmentId="VL114" x="-2615.39" y="-1823.06"/>
-                <nad:node diagramId="36" equipmentId="VL115" x="-2868.05" y="-1598.59"/>
-                <nad:node diagramId="38" equipmentId="VL116" x="-1070.76" y="880.20"/>
-                <nad:node diagramId="40" equipmentId="VL117" x="783.39" y="-2129.92"/>
-                <nad:node diagramId="42" equipmentId="VL118" x="-668.39" y="-83.87"/>
-                <nad:node diagramId="44" equipmentId="VL12" x="327.25" y="-2285.46"/>
-                <nad:node diagramId="46" equipmentId="VL13" x="-13.23" y="-1620.95"/>
-                <nad:node diagramId="48" equipmentId="VL14" x="361.41" y="-1657.12"/>
-                <nad:node diagramId="50" equipmentId="VL15" x="-94.90" y="-1143.77"/>
-                <nad:node diagramId="52" equipmentId="VL16" x="-312.60" y="-1868.75"/>
-                <nad:node diagramId="54" equipmentId="VL17" x="-811.77" y="-1466.12"/>
-                <nad:node diagramId="56" equipmentId="VL18" x="-548.51" y="-1044.94"/>
-                <nad:node diagramId="58" equipmentId="VL19" x="-410.89" y="-569.38"/>
-                <nad:node diagramId="60" equipmentId="VL2" x="795.95" y="-2616.31"/>
-                <nad:node diagramId="62" equipmentId="VL20" x="-1002.04" y="-540.85"/>
-                <nad:node diagramId="64" equipmentId="VL21" x="-1496.32" y="-509.09"/>
-                <nad:node diagramId="66" equipmentId="VL22" x="-1926.57" y="-571.94"/>
-                <nad:node diagramId="68" equipmentId="VL23" x="-2201.77" y="-810.71"/>
-                <nad:node diagramId="70" equipmentId="VL24" x="-2121.97" y="-123.57"/>
-                <nad:node diagramId="72" equipmentId="VL25" x="-2150.42" y="-1162.58"/>
-                <nad:node diagramId="74" equipmentId="VL26" x="-1584.83" y="-1094.99"/>
-                <nad:node diagramId="76" equipmentId="VL27" x="-2396.03" y="-1575.73"/>
-                <nad:node diagramId="78" equipmentId="VL28" x="-2282.12" y="-2114.64"/>
-                <nad:node diagramId="80" equipmentId="VL29" x="-1895.57" y="-2216.66"/>
-                <nad:node diagramId="82" equipmentId="VL3" x="348.88" y="-2691.09"/>
-                <nad:node diagramId="84" equipmentId="VL30" x="-967.99" y="-1064.51"/>
-                <nad:node diagramId="86" equipmentId="VL31" x="-1563.34" y="-1851.27"/>
-                <nad:node diagramId="88" equipmentId="VL32" x="-2016.14" y="-1543.90"/>
-                <nad:node diagramId="90" equipmentId="VL33" x="140.90" y="-456.36"/>
-                <nad:node diagramId="92" equipmentId="VL34" x="-87.82" y="499.20"/>
-                <nad:node diagramId="94" equipmentId="VL35" x="523.57" y="737.58"/>
-                <nad:node diagramId="96" equipmentId="VL36" x="165.15" y="857.17"/>
-                <nad:node diagramId="98" equipmentId="VL37" x="241.65" y="538.50"/>
-                <nad:node diagramId="100" equipmentId="VL38" x="-515.99" y="257.27"/>
-                <nad:node diagramId="102" equipmentId="VL39" x="707.42" y="1039.26"/>
-                <nad:node diagramId="104" equipmentId="VL4" x="-456.43" y="-2436.67"/>
-                <nad:node diagramId="106" equipmentId="VL40" x="512.74" y="1337.72"/>
-                <nad:node diagramId="108" equipmentId="VL41" x="634.21" y="1767.75"/>
-                <nad:node diagramId="110" equipmentId="VL42" x="149.99" y="1701.48"/>
-                <nad:node diagramId="112" equipmentId="VL43" x="55.03" y="1306.70"/>
-                <nad:node diagramId="114" equipmentId="VL44" x="202.50" y="2053.81"/>
-                <nad:node diagramId="116" equipmentId="VL45" x="-204.25" y="2143.02"/>
-                <nad:node diagramId="118" equipmentId="VL46" x="-307.65" y="1800.48"/>
-                <nad:node diagramId="120" equipmentId="VL47" x="-561.68" y="1442.10"/>
-                <nad:node diagramId="122" equipmentId="VL48" x="-567.75" y="1972.26"/>
-                <nad:node diagramId="124" equipmentId="VL49" x="-865.91" y="1803.56"/>
-                <nad:node diagramId="126" equipmentId="VL5" x="-226.14" y="-2597.43"/>
-                <nad:node diagramId="128" equipmentId="VL50" x="-1216.28" y="2348.42"/>
-                <nad:node diagramId="130" equipmentId="VL51" x="-1735.70" y="1570.73"/>
-                <nad:node diagramId="132" equipmentId="VL52" x="-2270.25" y="1451.22"/>
-                <nad:node diagramId="134" equipmentId="VL53" x="-2450.66" y="1826.24"/>
-                <nad:node diagramId="136" equipmentId="VL54" x="-1871.19" y="2164.77"/>
-                <nad:node diagramId="138" equipmentId="VL55" x="-2172.24" y="2632.80"/>
-                <nad:node diagramId="140" equipmentId="VL56" x="-2047.32" y="2402.77"/>
-                <nad:node diagramId="142" equipmentId="VL57" x="-1757.65" y="2835.12"/>
-                <nad:node diagramId="144" equipmentId="VL58" x="-2080.07" y="1873.46"/>
-                <nad:node diagramId="146" equipmentId="VL59" x="-1684.36" y="2545.40"/>
-                <nad:node diagramId="148" equipmentId="VL6" x="-227.75" y="-3078.89"/>
-                <nad:node diagramId="150" equipmentId="VL60" x="-1272.84" y="2998.10"/>
-                <nad:node diagramId="152" equipmentId="VL61" x="-1237.34" y="2662.22"/>
-                <nad:node diagramId="154" equipmentId="VL62" x="-856.69" y="2833.88"/>
-                <nad:node diagramId="156" equipmentId="VL63" x="-1522.71" y="2138.63"/>
-                <nad:node diagramId="158" equipmentId="VL64" x="-1223.07" y="1924.77"/>
-                <nad:node diagramId="160" equipmentId="VL65" x="-838.01" y="1302.47"/>
-                <nad:node diagramId="162" equipmentId="VL66" x="-724.94" y="2291.00"/>
-                <nad:node diagramId="164" equipmentId="VL67" x="-485.47" y="2800.21"/>
-                <nad:node diagramId="166" equipmentId="VL68" x="-432.82" y="839.16"/>
-                <nad:node diagramId="168" equipmentId="VL69" x="-737.13" y="811.74"/>
-                <nad:node diagramId="170" equipmentId="VL7" x="119.58" y="-2950.52"/>
-                <nad:node diagramId="172" equipmentId="VL70" x="-1569.94" y="376.64"/>
-                <nad:node diagramId="174" equipmentId="VL71" x="-2262.47" y="427.94"/>
-                <nad:node diagramId="176" equipmentId="VL72" x="-2481.37" y="82.57"/>
-                <nad:node diagramId="178" equipmentId="VL73" x="-2719.03" y="566.35"/>
-                <nad:node diagramId="180" equipmentId="VL74" x="-1291.18" y="229.09"/>
-                <nad:node diagramId="182" equipmentId="VL75" x="-873.64" y="301.84"/>
-                <nad:node diagramId="184" equipmentId="VL76" x="-207.79" y="-92.40"/>
-                <nad:node diagramId="186" equipmentId="VL77" x="183.20" y="161.49"/>
-                <nad:node diagramId="188" equipmentId="VL78" x="565.97" y="-268.02"/>
-                <nad:node diagramId="190" equipmentId="VL79" x="911.14" y="-480.58"/>
-                <nad:node diagramId="192" equipmentId="VL8" x="-822.77" y="-2072.63"/>
-                <nad:node diagramId="194" equipmentId="VL80" x="1115.02" y="-106.19"/>
-                <nad:node diagramId="196" equipmentId="VL81" x="555.40" y="284.23"/>
-                <nad:node diagramId="198" equipmentId="VL82" x="1185.49" y="633.29"/>
-                <nad:node diagramId="200" equipmentId="VL83" x="1720.46" y="1225.26"/>
-                <nad:node diagramId="202" equipmentId="VL84" x="1872.65" y="1592.24"/>
-                <nad:node diagramId="204" equipmentId="VL85" x="2254.32" y="1505.38"/>
-                <nad:node diagramId="206" equipmentId="VL86" x="2297.43" y="2057.25"/>
-                <nad:node diagramId="208" equipmentId="VL87" x="2281.30" y="2465.48"/>
-                <nad:node diagramId="210" equipmentId="VL88" x="2651.27" y="1470.48"/>
-                <nad:node diagramId="212" equipmentId="VL89" x="2679.94" y="1059.28"/>
-                <nad:node diagramId="214" equipmentId="VL9" x="-1110.36" y="-2546.02"/>
-                <nad:node diagramId="216" equipmentId="VL90" x="3119.18" y="992.09"/>
-                <nad:node diagramId="218" equipmentId="VL91" x="3112.24" y="597.31"/>
-                <nad:node diagramId="220" equipmentId="VL92" x="2692.64" y="288.03"/>
-                <nad:node diagramId="222" equipmentId="VL93" x="2425.16" y="462.49"/>
-                <nad:node diagramId="224" equipmentId="VL94" x="2198.12" y="143.57"/>
-                <nad:node diagramId="226" equipmentId="VL95" x="1924.07" y="428.77"/>
-                <nad:node diagramId="228" equipmentId="VL96" x="1578.37" y="285.28"/>
-                <nad:node diagramId="230" equipmentId="VL97" x="1406.49" y="11.44"/>
-                <nad:node diagramId="232" equipmentId="VL98" x="1634.60" y="-576.38"/>
-                <nad:node diagramId="234" equipmentId="VL99" x="1794.79" y="-295.58"/>
+                <nad:node svgId="0" equipmentId="VL1" x="736.99" y="-2973.24"/>
+                <nad:node svgId="2" equipmentId="VL10" x="-1307.45" y="-2918.68"/>
+                <nad:node svgId="4" equipmentId="VL100" x="2323.85" y="-469.66"/>
+                <nad:node svgId="6" equipmentId="VL101" x="2787.74" y="-301.89"/>
+                <nad:node svgId="8" equipmentId="VL102" x="3037.91" y="-0.61"/>
+                <nad:node svgId="10" equipmentId="VL103" x="2317.93" y="-1246.85"/>
+                <nad:node svgId="12" equipmentId="VL104" x="2390.66" y="-930.45"/>
+                <nad:node svgId="14" equipmentId="VL105" x="2741.45" y="-1230.14"/>
+                <nad:node svgId="16" equipmentId="VL106" x="2817.56" y="-835.52"/>
+                <nad:node svgId="18" equipmentId="VL107" x="3127.02" y="-1083.37"/>
+                <nad:node svgId="20" equipmentId="VL108" x="2896.05" y="-1690.56"/>
+                <nad:node svgId="22" equipmentId="VL109" x="2665.31" y="-2006.62"/>
+                <nad:node svgId="24" equipmentId="VL11" x="-67.16" y="-2211.79"/>
+                <nad:node svgId="26" equipmentId="VL110" x="2247.63" y="-1899.10"/>
+                <nad:node svgId="28" equipmentId="VL111" x="1858.44" y="-2031.11"/>
+                <nad:node svgId="30" equipmentId="VL112" x="2235.01" y="-2372.34"/>
+                <nad:node svgId="32" equipmentId="VL113" x="-1385.76" y="-1526.69"/>
+                <nad:node svgId="34" equipmentId="VL114" x="-2615.39" y="-1823.06"/>
+                <nad:node svgId="36" equipmentId="VL115" x="-2868.05" y="-1598.59"/>
+                <nad:node svgId="38" equipmentId="VL116" x="-1070.76" y="880.20"/>
+                <nad:node svgId="40" equipmentId="VL117" x="783.39" y="-2129.92"/>
+                <nad:node svgId="42" equipmentId="VL118" x="-668.39" y="-83.87"/>
+                <nad:node svgId="44" equipmentId="VL12" x="327.25" y="-2285.46"/>
+                <nad:node svgId="46" equipmentId="VL13" x="-13.23" y="-1620.95"/>
+                <nad:node svgId="48" equipmentId="VL14" x="361.41" y="-1657.12"/>
+                <nad:node svgId="50" equipmentId="VL15" x="-94.90" y="-1143.77"/>
+                <nad:node svgId="52" equipmentId="VL16" x="-312.60" y="-1868.75"/>
+                <nad:node svgId="54" equipmentId="VL17" x="-811.77" y="-1466.12"/>
+                <nad:node svgId="56" equipmentId="VL18" x="-548.51" y="-1044.94"/>
+                <nad:node svgId="58" equipmentId="VL19" x="-410.89" y="-569.38"/>
+                <nad:node svgId="60" equipmentId="VL2" x="795.95" y="-2616.31"/>
+                <nad:node svgId="62" equipmentId="VL20" x="-1002.04" y="-540.85"/>
+                <nad:node svgId="64" equipmentId="VL21" x="-1496.32" y="-509.09"/>
+                <nad:node svgId="66" equipmentId="VL22" x="-1926.57" y="-571.94"/>
+                <nad:node svgId="68" equipmentId="VL23" x="-2201.77" y="-810.71"/>
+                <nad:node svgId="70" equipmentId="VL24" x="-2121.97" y="-123.57"/>
+                <nad:node svgId="72" equipmentId="VL25" x="-2150.42" y="-1162.58"/>
+                <nad:node svgId="74" equipmentId="VL26" x="-1584.83" y="-1094.99"/>
+                <nad:node svgId="76" equipmentId="VL27" x="-2396.03" y="-1575.73"/>
+                <nad:node svgId="78" equipmentId="VL28" x="-2282.12" y="-2114.64"/>
+                <nad:node svgId="80" equipmentId="VL29" x="-1895.57" y="-2216.66"/>
+                <nad:node svgId="82" equipmentId="VL3" x="348.88" y="-2691.09"/>
+                <nad:node svgId="84" equipmentId="VL30" x="-967.99" y="-1064.51"/>
+                <nad:node svgId="86" equipmentId="VL31" x="-1563.34" y="-1851.27"/>
+                <nad:node svgId="88" equipmentId="VL32" x="-2016.14" y="-1543.90"/>
+                <nad:node svgId="90" equipmentId="VL33" x="140.90" y="-456.36"/>
+                <nad:node svgId="92" equipmentId="VL34" x="-87.82" y="499.20"/>
+                <nad:node svgId="94" equipmentId="VL35" x="523.57" y="737.58"/>
+                <nad:node svgId="96" equipmentId="VL36" x="165.15" y="857.17"/>
+                <nad:node svgId="98" equipmentId="VL37" x="241.65" y="538.50"/>
+                <nad:node svgId="100" equipmentId="VL38" x="-515.99" y="257.27"/>
+                <nad:node svgId="102" equipmentId="VL39" x="707.42" y="1039.26"/>
+                <nad:node svgId="104" equipmentId="VL4" x="-456.43" y="-2436.67"/>
+                <nad:node svgId="106" equipmentId="VL40" x="512.74" y="1337.72"/>
+                <nad:node svgId="108" equipmentId="VL41" x="634.21" y="1767.75"/>
+                <nad:node svgId="110" equipmentId="VL42" x="149.99" y="1701.48"/>
+                <nad:node svgId="112" equipmentId="VL43" x="55.03" y="1306.70"/>
+                <nad:node svgId="114" equipmentId="VL44" x="202.50" y="2053.81"/>
+                <nad:node svgId="116" equipmentId="VL45" x="-204.25" y="2143.02"/>
+                <nad:node svgId="118" equipmentId="VL46" x="-307.65" y="1800.48"/>
+                <nad:node svgId="120" equipmentId="VL47" x="-561.68" y="1442.10"/>
+                <nad:node svgId="122" equipmentId="VL48" x="-567.75" y="1972.26"/>
+                <nad:node svgId="124" equipmentId="VL49" x="-865.91" y="1803.56"/>
+                <nad:node svgId="126" equipmentId="VL5" x="-226.14" y="-2597.43"/>
+                <nad:node svgId="128" equipmentId="VL50" x="-1216.28" y="2348.42"/>
+                <nad:node svgId="130" equipmentId="VL51" x="-1735.70" y="1570.73"/>
+                <nad:node svgId="132" equipmentId="VL52" x="-2270.25" y="1451.22"/>
+                <nad:node svgId="134" equipmentId="VL53" x="-2450.66" y="1826.24"/>
+                <nad:node svgId="136" equipmentId="VL54" x="-1871.19" y="2164.77"/>
+                <nad:node svgId="138" equipmentId="VL55" x="-2172.24" y="2632.80"/>
+                <nad:node svgId="140" equipmentId="VL56" x="-2047.32" y="2402.77"/>
+                <nad:node svgId="142" equipmentId="VL57" x="-1757.65" y="2835.12"/>
+                <nad:node svgId="144" equipmentId="VL58" x="-2080.07" y="1873.46"/>
+                <nad:node svgId="146" equipmentId="VL59" x="-1684.36" y="2545.40"/>
+                <nad:node svgId="148" equipmentId="VL6" x="-227.75" y="-3078.89"/>
+                <nad:node svgId="150" equipmentId="VL60" x="-1272.84" y="2998.10"/>
+                <nad:node svgId="152" equipmentId="VL61" x="-1237.34" y="2662.22"/>
+                <nad:node svgId="154" equipmentId="VL62" x="-856.69" y="2833.88"/>
+                <nad:node svgId="156" equipmentId="VL63" x="-1522.71" y="2138.63"/>
+                <nad:node svgId="158" equipmentId="VL64" x="-1223.07" y="1924.77"/>
+                <nad:node svgId="160" equipmentId="VL65" x="-838.01" y="1302.47"/>
+                <nad:node svgId="162" equipmentId="VL66" x="-724.94" y="2291.00"/>
+                <nad:node svgId="164" equipmentId="VL67" x="-485.47" y="2800.21"/>
+                <nad:node svgId="166" equipmentId="VL68" x="-432.82" y="839.16"/>
+                <nad:node svgId="168" equipmentId="VL69" x="-737.13" y="811.74"/>
+                <nad:node svgId="170" equipmentId="VL7" x="119.58" y="-2950.52"/>
+                <nad:node svgId="172" equipmentId="VL70" x="-1569.94" y="376.64"/>
+                <nad:node svgId="174" equipmentId="VL71" x="-2262.47" y="427.94"/>
+                <nad:node svgId="176" equipmentId="VL72" x="-2481.37" y="82.57"/>
+                <nad:node svgId="178" equipmentId="VL73" x="-2719.03" y="566.35"/>
+                <nad:node svgId="180" equipmentId="VL74" x="-1291.18" y="229.09"/>
+                <nad:node svgId="182" equipmentId="VL75" x="-873.64" y="301.84"/>
+                <nad:node svgId="184" equipmentId="VL76" x="-207.79" y="-92.40"/>
+                <nad:node svgId="186" equipmentId="VL77" x="183.20" y="161.49"/>
+                <nad:node svgId="188" equipmentId="VL78" x="565.97" y="-268.02"/>
+                <nad:node svgId="190" equipmentId="VL79" x="911.14" y="-480.58"/>
+                <nad:node svgId="192" equipmentId="VL8" x="-822.77" y="-2072.63"/>
+                <nad:node svgId="194" equipmentId="VL80" x="1115.02" y="-106.19"/>
+                <nad:node svgId="196" equipmentId="VL81" x="555.40" y="284.23"/>
+                <nad:node svgId="198" equipmentId="VL82" x="1185.49" y="633.29"/>
+                <nad:node svgId="200" equipmentId="VL83" x="1720.46" y="1225.26"/>
+                <nad:node svgId="202" equipmentId="VL84" x="1872.65" y="1592.24"/>
+                <nad:node svgId="204" equipmentId="VL85" x="2254.32" y="1505.38"/>
+                <nad:node svgId="206" equipmentId="VL86" x="2297.43" y="2057.25"/>
+                <nad:node svgId="208" equipmentId="VL87" x="2281.30" y="2465.48"/>
+                <nad:node svgId="210" equipmentId="VL88" x="2651.27" y="1470.48"/>
+                <nad:node svgId="212" equipmentId="VL89" x="2679.94" y="1059.28"/>
+                <nad:node svgId="214" equipmentId="VL9" x="-1110.36" y="-2546.02"/>
+                <nad:node svgId="216" equipmentId="VL90" x="3119.18" y="992.09"/>
+                <nad:node svgId="218" equipmentId="VL91" x="3112.24" y="597.31"/>
+                <nad:node svgId="220" equipmentId="VL92" x="2692.64" y="288.03"/>
+                <nad:node svgId="222" equipmentId="VL93" x="2425.16" y="462.49"/>
+                <nad:node svgId="224" equipmentId="VL94" x="2198.12" y="143.57"/>
+                <nad:node svgId="226" equipmentId="VL95" x="1924.07" y="428.77"/>
+                <nad:node svgId="228" equipmentId="VL96" x="1578.37" y="285.28"/>
+                <nad:node svgId="230" equipmentId="VL97" x="1406.49" y="11.44"/>
+                <nad:node svgId="232" equipmentId="VL98" x="1634.60" y="-576.38"/>
+                <nad:node svgId="234" equipmentId="VL99" x="1794.79" y="-295.58"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge diagramId="236" equipmentId="L1-2-1"/>
-                <nad:edge diagramId="237" equipmentId="L1-3-1"/>
-                <nad:edge diagramId="238" equipmentId="L9-10-1"/>
-                <nad:edge diagramId="239" equipmentId="L92-100-1"/>
-                <nad:edge diagramId="240" equipmentId="L94-100-1"/>
-                <nad:edge diagramId="241" equipmentId="L98-100-1"/>
-                <nad:edge diagramId="242" equipmentId="L99-100-1"/>
-                <nad:edge diagramId="243" equipmentId="L100-101-1"/>
-                <nad:edge diagramId="244" equipmentId="L100-103-1"/>
-                <nad:edge diagramId="245" equipmentId="L100-104-1"/>
-                <nad:edge diagramId="246" equipmentId="L100-106-1"/>
-                <nad:edge diagramId="247" equipmentId="L101-102-1"/>
-                <nad:edge diagramId="248" equipmentId="L92-102-1"/>
-                <nad:edge diagramId="249" equipmentId="L103-104-1"/>
-                <nad:edge diagramId="250" equipmentId="L103-105-1"/>
-                <nad:edge diagramId="251" equipmentId="L103-110-1"/>
-                <nad:edge diagramId="252" equipmentId="L104-105-1"/>
-                <nad:edge diagramId="253" equipmentId="L105-106-1"/>
-                <nad:edge diagramId="254" equipmentId="L105-107-1"/>
-                <nad:edge diagramId="255" equipmentId="L105-108-1"/>
-                <nad:edge diagramId="256" equipmentId="L106-107-1"/>
-                <nad:edge diagramId="257" equipmentId="L108-109-1"/>
-                <nad:edge diagramId="258" equipmentId="L109-110-1"/>
-                <nad:edge diagramId="259" equipmentId="L4-11-1"/>
-                <nad:edge diagramId="260" equipmentId="L5-11-1"/>
-                <nad:edge diagramId="261" equipmentId="L11-12-1"/>
-                <nad:edge diagramId="262" equipmentId="L11-13-1"/>
-                <nad:edge diagramId="263" equipmentId="L110-111-1"/>
-                <nad:edge diagramId="264" equipmentId="L110-112-1"/>
-                <nad:edge diagramId="265" equipmentId="L17-113-1"/>
-                <nad:edge diagramId="266" equipmentId="L32-113-1"/>
-                <nad:edge diagramId="267" equipmentId="L32-114-1"/>
-                <nad:edge diagramId="268" equipmentId="L114-115-1"/>
-                <nad:edge diagramId="269" equipmentId="L27-115-1"/>
-                <nad:edge diagramId="270" equipmentId="L68-116-1"/>
-                <nad:edge diagramId="271" equipmentId="L12-117-1"/>
-                <nad:edge diagramId="272" equipmentId="L75-118-1"/>
-                <nad:edge diagramId="273" equipmentId="L76-118-1"/>
-                <nad:edge diagramId="274" equipmentId="L2-12-1"/>
-                <nad:edge diagramId="275" equipmentId="L3-12-1"/>
-                <nad:edge diagramId="276" equipmentId="L7-12-1"/>
-                <nad:edge diagramId="277" equipmentId="L12-14-1"/>
-                <nad:edge diagramId="278" equipmentId="L12-16-1"/>
-                <nad:edge diagramId="279" equipmentId="L13-15-1"/>
-                <nad:edge diagramId="280" equipmentId="L14-15-1"/>
-                <nad:edge diagramId="281" equipmentId="L15-17-1"/>
-                <nad:edge diagramId="282" equipmentId="L15-19-1"/>
-                <nad:edge diagramId="283" equipmentId="L15-33-1"/>
-                <nad:edge diagramId="284" equipmentId="L16-17-1"/>
-                <nad:edge diagramId="285" equipmentId="L17-18-1"/>
-                <nad:edge diagramId="286" equipmentId="L17-31-1"/>
-                <nad:edge diagramId="287" equipmentId="T30-17-1"/>
-                <nad:edge diagramId="288" equipmentId="L18-19-1"/>
-                <nad:edge diagramId="289" equipmentId="L19-20-1"/>
-                <nad:edge diagramId="290" equipmentId="L19-34-1"/>
-                <nad:edge diagramId="291" equipmentId="L20-21-1"/>
-                <nad:edge diagramId="292" equipmentId="L21-22-1"/>
-                <nad:edge diagramId="293" equipmentId="L22-23-1"/>
-                <nad:edge diagramId="294" equipmentId="L23-24-1"/>
-                <nad:edge diagramId="295" equipmentId="L23-25-1"/>
-                <nad:edge diagramId="296" equipmentId="L23-32-1"/>
-                <nad:edge diagramId="297" equipmentId="L24-70-1"/>
-                <nad:edge diagramId="298" equipmentId="L24-72-1"/>
-                <nad:edge diagramId="299" equipmentId="L25-27-1"/>
-                <nad:edge diagramId="300" equipmentId="T26-25-1"/>
-                <nad:edge diagramId="301" equipmentId="L26-30-1"/>
-                <nad:edge diagramId="302" equipmentId="L27-28-1"/>
-                <nad:edge diagramId="303" equipmentId="L27-32-1"/>
-                <nad:edge diagramId="304" equipmentId="L28-29-1"/>
-                <nad:edge diagramId="305" equipmentId="L29-31-1"/>
-                <nad:edge diagramId="306" equipmentId="L3-5-1"/>
-                <nad:edge diagramId="307" equipmentId="L8-30-1"/>
-                <nad:edge diagramId="308" equipmentId="L30-38-1"/>
-                <nad:edge diagramId="309" equipmentId="L31-32-1"/>
-                <nad:edge diagramId="310" equipmentId="L33-37-1"/>
-                <nad:edge diagramId="311" equipmentId="L34-36-1"/>
-                <nad:edge diagramId="312" equipmentId="L34-37-1"/>
-                <nad:edge diagramId="313" equipmentId="L34-43-1"/>
-                <nad:edge diagramId="314" equipmentId="L35-36-1"/>
-                <nad:edge diagramId="315" equipmentId="L35-37-1"/>
-                <nad:edge diagramId="316" equipmentId="L37-39-1"/>
-                <nad:edge diagramId="317" equipmentId="L37-40-1"/>
-                <nad:edge diagramId="318" equipmentId="T38-37-1"/>
-                <nad:edge diagramId="319" equipmentId="L38-65-1"/>
-                <nad:edge diagramId="320" equipmentId="L39-40-1"/>
-                <nad:edge diagramId="321" equipmentId="L4-5-1"/>
-                <nad:edge diagramId="322" equipmentId="L40-41-1"/>
-                <nad:edge diagramId="323" equipmentId="L40-42-1"/>
-                <nad:edge diagramId="324" equipmentId="L41-42-1"/>
-                <nad:edge diagramId="325" equipmentId="L42-49-1"/>
-                <nad:edge diagramId="326" equipmentId="L42-49-2"/>
-                <nad:edge diagramId="327" equipmentId="L43-44-1"/>
-                <nad:edge diagramId="328" equipmentId="L44-45-1"/>
-                <nad:edge diagramId="329" equipmentId="L45-46-1"/>
-                <nad:edge diagramId="330" equipmentId="L45-49-1"/>
-                <nad:edge diagramId="331" equipmentId="L46-47-1"/>
-                <nad:edge diagramId="332" equipmentId="L46-48-1"/>
-                <nad:edge diagramId="333" equipmentId="L47-49-1"/>
-                <nad:edge diagramId="334" equipmentId="L47-69-1"/>
-                <nad:edge diagramId="335" equipmentId="L48-49-1"/>
-                <nad:edge diagramId="336" equipmentId="L49-50-1"/>
-                <nad:edge diagramId="337" equipmentId="L49-51-1"/>
-                <nad:edge diagramId="338" equipmentId="L49-54-1"/>
-                <nad:edge diagramId="339" equipmentId="L49-54-2"/>
-                <nad:edge diagramId="340" equipmentId="L49-66-1"/>
-                <nad:edge diagramId="341" equipmentId="L49-66-2"/>
-                <nad:edge diagramId="342" equipmentId="L49-69-1"/>
-                <nad:edge diagramId="343" equipmentId="L5-6-1"/>
-                <nad:edge diagramId="344" equipmentId="T8-5-1"/>
-                <nad:edge diagramId="345" equipmentId="L50-57-1"/>
-                <nad:edge diagramId="346" equipmentId="L51-52-1"/>
-                <nad:edge diagramId="347" equipmentId="L51-58-1"/>
-                <nad:edge diagramId="348" equipmentId="L52-53-1"/>
-                <nad:edge diagramId="349" equipmentId="L53-54-1"/>
-                <nad:edge diagramId="350" equipmentId="L54-55-1"/>
-                <nad:edge diagramId="351" equipmentId="L54-56-1"/>
-                <nad:edge diagramId="352" equipmentId="L54-59-1"/>
-                <nad:edge diagramId="353" equipmentId="L55-56-1"/>
-                <nad:edge diagramId="354" equipmentId="L55-59-1"/>
-                <nad:edge diagramId="355" equipmentId="L56-57-1"/>
-                <nad:edge diagramId="356" equipmentId="L56-58-1"/>
-                <nad:edge diagramId="357" equipmentId="L56-59-1"/>
-                <nad:edge diagramId="358" equipmentId="L56-59-2"/>
-                <nad:edge diagramId="359" equipmentId="L59-60-1"/>
-                <nad:edge diagramId="360" equipmentId="L59-61-1"/>
-                <nad:edge diagramId="361" equipmentId="T63-59-1"/>
-                <nad:edge diagramId="362" equipmentId="L6-7-1"/>
-                <nad:edge diagramId="363" equipmentId="L60-61-1"/>
-                <nad:edge diagramId="364" equipmentId="L60-62-1"/>
-                <nad:edge diagramId="365" equipmentId="L61-62-1"/>
-                <nad:edge diagramId="366" equipmentId="T64-61-1"/>
-                <nad:edge diagramId="367" equipmentId="L62-66-1"/>
-                <nad:edge diagramId="368" equipmentId="L62-67-1"/>
-                <nad:edge diagramId="369" equipmentId="L63-64-1"/>
-                <nad:edge diagramId="370" equipmentId="L64-65-1"/>
-                <nad:edge diagramId="371" equipmentId="L65-68-1"/>
-                <nad:edge diagramId="372" equipmentId="T65-66-1"/>
-                <nad:edge diagramId="373" equipmentId="L66-67-1"/>
-                <nad:edge diagramId="374" equipmentId="L68-81-1"/>
-                <nad:edge diagramId="375" equipmentId="T68-69-1"/>
-                <nad:edge diagramId="376" equipmentId="L69-70-1"/>
-                <nad:edge diagramId="377" equipmentId="L69-75-1"/>
-                <nad:edge diagramId="378" equipmentId="L69-77-1"/>
-                <nad:edge diagramId="379" equipmentId="L70-71-1"/>
-                <nad:edge diagramId="380" equipmentId="L70-74-1"/>
-                <nad:edge diagramId="381" equipmentId="L70-75-1"/>
-                <nad:edge diagramId="382" equipmentId="L71-72-1"/>
-                <nad:edge diagramId="383" equipmentId="L71-73-1"/>
-                <nad:edge diagramId="384" equipmentId="L74-75-1"/>
-                <nad:edge diagramId="385" equipmentId="L75-77-1"/>
-                <nad:edge diagramId="386" equipmentId="L76-77-1"/>
-                <nad:edge diagramId="387" equipmentId="L77-78-1"/>
-                <nad:edge diagramId="388" equipmentId="L77-80-1"/>
-                <nad:edge diagramId="389" equipmentId="L77-80-2"/>
-                <nad:edge diagramId="390" equipmentId="L77-82-1"/>
-                <nad:edge diagramId="391" equipmentId="L78-79-1"/>
-                <nad:edge diagramId="392" equipmentId="L79-80-1"/>
-                <nad:edge diagramId="393" equipmentId="L8-9-1"/>
-                <nad:edge diagramId="394" equipmentId="L80-96-1"/>
-                <nad:edge diagramId="395" equipmentId="L80-97-1"/>
-                <nad:edge diagramId="396" equipmentId="L80-98-1"/>
-                <nad:edge diagramId="397" equipmentId="L80-99-1"/>
-                <nad:edge diagramId="398" equipmentId="T81-80-1"/>
-                <nad:edge diagramId="399" equipmentId="L82-83-1"/>
-                <nad:edge diagramId="400" equipmentId="L82-96-1"/>
-                <nad:edge diagramId="401" equipmentId="L83-84-1"/>
-                <nad:edge diagramId="402" equipmentId="L83-85-1"/>
-                <nad:edge diagramId="403" equipmentId="L84-85-1"/>
-                <nad:edge diagramId="404" equipmentId="L85-86-1"/>
-                <nad:edge diagramId="405" equipmentId="L85-88-1"/>
-                <nad:edge diagramId="406" equipmentId="L85-89-1"/>
-                <nad:edge diagramId="407" equipmentId="L86-87-1"/>
-                <nad:edge diagramId="408" equipmentId="L88-89-1"/>
-                <nad:edge diagramId="409" equipmentId="L89-90-1"/>
-                <nad:edge diagramId="410" equipmentId="L89-90-2"/>
-                <nad:edge diagramId="411" equipmentId="L89-92-1"/>
-                <nad:edge diagramId="412" equipmentId="L89-92-2"/>
-                <nad:edge diagramId="413" equipmentId="L90-91-1"/>
-                <nad:edge diagramId="414" equipmentId="L91-92-1"/>
-                <nad:edge diagramId="415" equipmentId="L92-93-1"/>
-                <nad:edge diagramId="416" equipmentId="L92-94-1"/>
-                <nad:edge diagramId="417" equipmentId="L93-94-1"/>
-                <nad:edge diagramId="418" equipmentId="L94-95-1"/>
-                <nad:edge diagramId="419" equipmentId="L94-96-1"/>
-                <nad:edge diagramId="420" equipmentId="L95-96-1"/>
-                <nad:edge diagramId="421" equipmentId="L96-97-1"/>
+                <nad:edge svgId="236" equipmentId="L1-2-1"/>
+                <nad:edge svgId="237" equipmentId="L1-3-1"/>
+                <nad:edge svgId="238" equipmentId="L9-10-1"/>
+                <nad:edge svgId="239" equipmentId="L92-100-1"/>
+                <nad:edge svgId="240" equipmentId="L94-100-1"/>
+                <nad:edge svgId="241" equipmentId="L98-100-1"/>
+                <nad:edge svgId="242" equipmentId="L99-100-1"/>
+                <nad:edge svgId="243" equipmentId="L100-101-1"/>
+                <nad:edge svgId="244" equipmentId="L100-103-1"/>
+                <nad:edge svgId="245" equipmentId="L100-104-1"/>
+                <nad:edge svgId="246" equipmentId="L100-106-1"/>
+                <nad:edge svgId="247" equipmentId="L101-102-1"/>
+                <nad:edge svgId="248" equipmentId="L92-102-1"/>
+                <nad:edge svgId="249" equipmentId="L103-104-1"/>
+                <nad:edge svgId="250" equipmentId="L103-105-1"/>
+                <nad:edge svgId="251" equipmentId="L103-110-1"/>
+                <nad:edge svgId="252" equipmentId="L104-105-1"/>
+                <nad:edge svgId="253" equipmentId="L105-106-1"/>
+                <nad:edge svgId="254" equipmentId="L105-107-1"/>
+                <nad:edge svgId="255" equipmentId="L105-108-1"/>
+                <nad:edge svgId="256" equipmentId="L106-107-1"/>
+                <nad:edge svgId="257" equipmentId="L108-109-1"/>
+                <nad:edge svgId="258" equipmentId="L109-110-1"/>
+                <nad:edge svgId="259" equipmentId="L4-11-1"/>
+                <nad:edge svgId="260" equipmentId="L5-11-1"/>
+                <nad:edge svgId="261" equipmentId="L11-12-1"/>
+                <nad:edge svgId="262" equipmentId="L11-13-1"/>
+                <nad:edge svgId="263" equipmentId="L110-111-1"/>
+                <nad:edge svgId="264" equipmentId="L110-112-1"/>
+                <nad:edge svgId="265" equipmentId="L17-113-1"/>
+                <nad:edge svgId="266" equipmentId="L32-113-1"/>
+                <nad:edge svgId="267" equipmentId="L32-114-1"/>
+                <nad:edge svgId="268" equipmentId="L114-115-1"/>
+                <nad:edge svgId="269" equipmentId="L27-115-1"/>
+                <nad:edge svgId="270" equipmentId="L68-116-1"/>
+                <nad:edge svgId="271" equipmentId="L12-117-1"/>
+                <nad:edge svgId="272" equipmentId="L75-118-1"/>
+                <nad:edge svgId="273" equipmentId="L76-118-1"/>
+                <nad:edge svgId="274" equipmentId="L2-12-1"/>
+                <nad:edge svgId="275" equipmentId="L3-12-1"/>
+                <nad:edge svgId="276" equipmentId="L7-12-1"/>
+                <nad:edge svgId="277" equipmentId="L12-14-1"/>
+                <nad:edge svgId="278" equipmentId="L12-16-1"/>
+                <nad:edge svgId="279" equipmentId="L13-15-1"/>
+                <nad:edge svgId="280" equipmentId="L14-15-1"/>
+                <nad:edge svgId="281" equipmentId="L15-17-1"/>
+                <nad:edge svgId="282" equipmentId="L15-19-1"/>
+                <nad:edge svgId="283" equipmentId="L15-33-1"/>
+                <nad:edge svgId="284" equipmentId="L16-17-1"/>
+                <nad:edge svgId="285" equipmentId="L17-18-1"/>
+                <nad:edge svgId="286" equipmentId="L17-31-1"/>
+                <nad:edge svgId="287" equipmentId="T30-17-1"/>
+                <nad:edge svgId="288" equipmentId="L18-19-1"/>
+                <nad:edge svgId="289" equipmentId="L19-20-1"/>
+                <nad:edge svgId="290" equipmentId="L19-34-1"/>
+                <nad:edge svgId="291" equipmentId="L20-21-1"/>
+                <nad:edge svgId="292" equipmentId="L21-22-1"/>
+                <nad:edge svgId="293" equipmentId="L22-23-1"/>
+                <nad:edge svgId="294" equipmentId="L23-24-1"/>
+                <nad:edge svgId="295" equipmentId="L23-25-1"/>
+                <nad:edge svgId="296" equipmentId="L23-32-1"/>
+                <nad:edge svgId="297" equipmentId="L24-70-1"/>
+                <nad:edge svgId="298" equipmentId="L24-72-1"/>
+                <nad:edge svgId="299" equipmentId="L25-27-1"/>
+                <nad:edge svgId="300" equipmentId="T26-25-1"/>
+                <nad:edge svgId="301" equipmentId="L26-30-1"/>
+                <nad:edge svgId="302" equipmentId="L27-28-1"/>
+                <nad:edge svgId="303" equipmentId="L27-32-1"/>
+                <nad:edge svgId="304" equipmentId="L28-29-1"/>
+                <nad:edge svgId="305" equipmentId="L29-31-1"/>
+                <nad:edge svgId="306" equipmentId="L3-5-1"/>
+                <nad:edge svgId="307" equipmentId="L8-30-1"/>
+                <nad:edge svgId="308" equipmentId="L30-38-1"/>
+                <nad:edge svgId="309" equipmentId="L31-32-1"/>
+                <nad:edge svgId="310" equipmentId="L33-37-1"/>
+                <nad:edge svgId="311" equipmentId="L34-36-1"/>
+                <nad:edge svgId="312" equipmentId="L34-37-1"/>
+                <nad:edge svgId="313" equipmentId="L34-43-1"/>
+                <nad:edge svgId="314" equipmentId="L35-36-1"/>
+                <nad:edge svgId="315" equipmentId="L35-37-1"/>
+                <nad:edge svgId="316" equipmentId="L37-39-1"/>
+                <nad:edge svgId="317" equipmentId="L37-40-1"/>
+                <nad:edge svgId="318" equipmentId="T38-37-1"/>
+                <nad:edge svgId="319" equipmentId="L38-65-1"/>
+                <nad:edge svgId="320" equipmentId="L39-40-1"/>
+                <nad:edge svgId="321" equipmentId="L4-5-1"/>
+                <nad:edge svgId="322" equipmentId="L40-41-1"/>
+                <nad:edge svgId="323" equipmentId="L40-42-1"/>
+                <nad:edge svgId="324" equipmentId="L41-42-1"/>
+                <nad:edge svgId="325" equipmentId="L42-49-1"/>
+                <nad:edge svgId="326" equipmentId="L42-49-2"/>
+                <nad:edge svgId="327" equipmentId="L43-44-1"/>
+                <nad:edge svgId="328" equipmentId="L44-45-1"/>
+                <nad:edge svgId="329" equipmentId="L45-46-1"/>
+                <nad:edge svgId="330" equipmentId="L45-49-1"/>
+                <nad:edge svgId="331" equipmentId="L46-47-1"/>
+                <nad:edge svgId="332" equipmentId="L46-48-1"/>
+                <nad:edge svgId="333" equipmentId="L47-49-1"/>
+                <nad:edge svgId="334" equipmentId="L47-69-1"/>
+                <nad:edge svgId="335" equipmentId="L48-49-1"/>
+                <nad:edge svgId="336" equipmentId="L49-50-1"/>
+                <nad:edge svgId="337" equipmentId="L49-51-1"/>
+                <nad:edge svgId="338" equipmentId="L49-54-1"/>
+                <nad:edge svgId="339" equipmentId="L49-54-2"/>
+                <nad:edge svgId="340" equipmentId="L49-66-1"/>
+                <nad:edge svgId="341" equipmentId="L49-66-2"/>
+                <nad:edge svgId="342" equipmentId="L49-69-1"/>
+                <nad:edge svgId="343" equipmentId="L5-6-1"/>
+                <nad:edge svgId="344" equipmentId="T8-5-1"/>
+                <nad:edge svgId="345" equipmentId="L50-57-1"/>
+                <nad:edge svgId="346" equipmentId="L51-52-1"/>
+                <nad:edge svgId="347" equipmentId="L51-58-1"/>
+                <nad:edge svgId="348" equipmentId="L52-53-1"/>
+                <nad:edge svgId="349" equipmentId="L53-54-1"/>
+                <nad:edge svgId="350" equipmentId="L54-55-1"/>
+                <nad:edge svgId="351" equipmentId="L54-56-1"/>
+                <nad:edge svgId="352" equipmentId="L54-59-1"/>
+                <nad:edge svgId="353" equipmentId="L55-56-1"/>
+                <nad:edge svgId="354" equipmentId="L55-59-1"/>
+                <nad:edge svgId="355" equipmentId="L56-57-1"/>
+                <nad:edge svgId="356" equipmentId="L56-58-1"/>
+                <nad:edge svgId="357" equipmentId="L56-59-1"/>
+                <nad:edge svgId="358" equipmentId="L56-59-2"/>
+                <nad:edge svgId="359" equipmentId="L59-60-1"/>
+                <nad:edge svgId="360" equipmentId="L59-61-1"/>
+                <nad:edge svgId="361" equipmentId="T63-59-1"/>
+                <nad:edge svgId="362" equipmentId="L6-7-1"/>
+                <nad:edge svgId="363" equipmentId="L60-61-1"/>
+                <nad:edge svgId="364" equipmentId="L60-62-1"/>
+                <nad:edge svgId="365" equipmentId="L61-62-1"/>
+                <nad:edge svgId="366" equipmentId="T64-61-1"/>
+                <nad:edge svgId="367" equipmentId="L62-66-1"/>
+                <nad:edge svgId="368" equipmentId="L62-67-1"/>
+                <nad:edge svgId="369" equipmentId="L63-64-1"/>
+                <nad:edge svgId="370" equipmentId="L64-65-1"/>
+                <nad:edge svgId="371" equipmentId="L65-68-1"/>
+                <nad:edge svgId="372" equipmentId="T65-66-1"/>
+                <nad:edge svgId="373" equipmentId="L66-67-1"/>
+                <nad:edge svgId="374" equipmentId="L68-81-1"/>
+                <nad:edge svgId="375" equipmentId="T68-69-1"/>
+                <nad:edge svgId="376" equipmentId="L69-70-1"/>
+                <nad:edge svgId="377" equipmentId="L69-75-1"/>
+                <nad:edge svgId="378" equipmentId="L69-77-1"/>
+                <nad:edge svgId="379" equipmentId="L70-71-1"/>
+                <nad:edge svgId="380" equipmentId="L70-74-1"/>
+                <nad:edge svgId="381" equipmentId="L70-75-1"/>
+                <nad:edge svgId="382" equipmentId="L71-72-1"/>
+                <nad:edge svgId="383" equipmentId="L71-73-1"/>
+                <nad:edge svgId="384" equipmentId="L74-75-1"/>
+                <nad:edge svgId="385" equipmentId="L75-77-1"/>
+                <nad:edge svgId="386" equipmentId="L76-77-1"/>
+                <nad:edge svgId="387" equipmentId="L77-78-1"/>
+                <nad:edge svgId="388" equipmentId="L77-80-1"/>
+                <nad:edge svgId="389" equipmentId="L77-80-2"/>
+                <nad:edge svgId="390" equipmentId="L77-82-1"/>
+                <nad:edge svgId="391" equipmentId="L78-79-1"/>
+                <nad:edge svgId="392" equipmentId="L79-80-1"/>
+                <nad:edge svgId="393" equipmentId="L8-9-1"/>
+                <nad:edge svgId="394" equipmentId="L80-96-1"/>
+                <nad:edge svgId="395" equipmentId="L80-97-1"/>
+                <nad:edge svgId="396" equipmentId="L80-98-1"/>
+                <nad:edge svgId="397" equipmentId="L80-99-1"/>
+                <nad:edge svgId="398" equipmentId="T81-80-1"/>
+                <nad:edge svgId="399" equipmentId="L82-83-1"/>
+                <nad:edge svgId="400" equipmentId="L82-96-1"/>
+                <nad:edge svgId="401" equipmentId="L83-84-1"/>
+                <nad:edge svgId="402" equipmentId="L83-85-1"/>
+                <nad:edge svgId="403" equipmentId="L84-85-1"/>
+                <nad:edge svgId="404" equipmentId="L85-86-1"/>
+                <nad:edge svgId="405" equipmentId="L85-88-1"/>
+                <nad:edge svgId="406" equipmentId="L85-89-1"/>
+                <nad:edge svgId="407" equipmentId="L86-87-1"/>
+                <nad:edge svgId="408" equipmentId="L88-89-1"/>
+                <nad:edge svgId="409" equipmentId="L89-90-1"/>
+                <nad:edge svgId="410" equipmentId="L89-90-2"/>
+                <nad:edge svgId="411" equipmentId="L89-92-1"/>
+                <nad:edge svgId="412" equipmentId="L89-92-2"/>
+                <nad:edge svgId="413" equipmentId="L90-91-1"/>
+                <nad:edge svgId="414" equipmentId="L91-92-1"/>
+                <nad:edge svgId="415" equipmentId="L92-93-1"/>
+                <nad:edge svgId="416" equipmentId="L92-94-1"/>
+                <nad:edge svgId="417" equipmentId="L93-94-1"/>
+                <nad:edge svgId="418" equipmentId="L94-95-1"/>
+                <nad:edge svgId="419" equipmentId="L94-96-1"/>
+                <nad:edge svgId="420" equipmentId="L95-96-1"/>
+                <nad:edge svgId="421" equipmentId="L96-97-1"/>
             </nad:edges>
         </nad:nad>
     </metadata>

--- a/network-area-diagram/src/test/resources/IEEE_118_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_118_bus.svg
@@ -114,124 +114,124 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="VL1_0" x="736.99" y="-2973.24"/>
-                <nad:busNode diagramId="3" equipmentId="VL10_0" x="-1307.45" y="-2918.68"/>
-                <nad:busNode diagramId="5" equipmentId="VL100_0" x="2323.85" y="-469.66"/>
-                <nad:busNode diagramId="7" equipmentId="VL101_0" x="2787.74" y="-301.89"/>
-                <nad:busNode diagramId="9" equipmentId="VL102_0" x="3037.91" y="-0.61"/>
-                <nad:busNode diagramId="11" equipmentId="VL103_0" x="2317.93" y="-1246.85"/>
-                <nad:busNode diagramId="13" equipmentId="VL104_0" x="2390.66" y="-930.45"/>
-                <nad:busNode diagramId="15" equipmentId="VL105_0" x="2741.45" y="-1230.14"/>
-                <nad:busNode diagramId="17" equipmentId="VL106_0" x="2817.56" y="-835.52"/>
-                <nad:busNode diagramId="19" equipmentId="VL107_0" x="3127.02" y="-1083.37"/>
-                <nad:busNode diagramId="21" equipmentId="VL108_0" x="2896.05" y="-1690.56"/>
-                <nad:busNode diagramId="23" equipmentId="VL109_0" x="2665.31" y="-2006.62"/>
-                <nad:busNode diagramId="25" equipmentId="VL11_0" x="-67.16" y="-2211.79"/>
-                <nad:busNode diagramId="27" equipmentId="VL110_0" x="2247.63" y="-1899.10"/>
-                <nad:busNode diagramId="29" equipmentId="VL111_0" x="1858.44" y="-2031.11"/>
-                <nad:busNode diagramId="31" equipmentId="VL112_0" x="2235.01" y="-2372.34"/>
-                <nad:busNode diagramId="33" equipmentId="VL113_0" x="-1385.76" y="-1526.69"/>
-                <nad:busNode diagramId="35" equipmentId="VL114_0" x="-2615.39" y="-1823.06"/>
-                <nad:busNode diagramId="37" equipmentId="VL115_0" x="-2868.05" y="-1598.59"/>
-                <nad:busNode diagramId="39" equipmentId="VL116_0" x="-1070.76" y="880.20"/>
-                <nad:busNode diagramId="41" equipmentId="VL117_0" x="783.39" y="-2129.92"/>
-                <nad:busNode diagramId="43" equipmentId="VL118_0" x="-668.39" y="-83.87"/>
-                <nad:busNode diagramId="45" equipmentId="VL12_0" x="327.25" y="-2285.46"/>
-                <nad:busNode diagramId="47" equipmentId="VL13_0" x="-13.23" y="-1620.95"/>
-                <nad:busNode diagramId="49" equipmentId="VL14_0" x="361.41" y="-1657.12"/>
-                <nad:busNode diagramId="51" equipmentId="VL15_0" x="-94.90" y="-1143.77"/>
-                <nad:busNode diagramId="53" equipmentId="VL16_0" x="-312.60" y="-1868.75"/>
-                <nad:busNode diagramId="55" equipmentId="VL17_0" x="-811.77" y="-1466.12"/>
-                <nad:busNode diagramId="57" equipmentId="VL18_0" x="-548.51" y="-1044.94"/>
-                <nad:busNode diagramId="59" equipmentId="VL19_0" x="-410.89" y="-569.38"/>
-                <nad:busNode diagramId="61" equipmentId="VL2_0" x="795.95" y="-2616.31"/>
-                <nad:busNode diagramId="63" equipmentId="VL20_0" x="-1002.04" y="-540.85"/>
-                <nad:busNode diagramId="65" equipmentId="VL21_0" x="-1496.32" y="-509.09"/>
-                <nad:busNode diagramId="67" equipmentId="VL22_0" x="-1926.57" y="-571.94"/>
-                <nad:busNode diagramId="69" equipmentId="VL23_0" x="-2201.77" y="-810.71"/>
-                <nad:busNode diagramId="71" equipmentId="VL24_0" x="-2121.97" y="-123.57"/>
-                <nad:busNode diagramId="73" equipmentId="VL25_0" x="-2150.42" y="-1162.58"/>
-                <nad:busNode diagramId="75" equipmentId="VL26_0" x="-1584.83" y="-1094.99"/>
-                <nad:busNode diagramId="77" equipmentId="VL27_0" x="-2396.03" y="-1575.73"/>
-                <nad:busNode diagramId="79" equipmentId="VL28_0" x="-2282.12" y="-2114.64"/>
-                <nad:busNode diagramId="81" equipmentId="VL29_0" x="-1895.57" y="-2216.66"/>
-                <nad:busNode diagramId="83" equipmentId="VL3_0" x="348.88" y="-2691.09"/>
-                <nad:busNode diagramId="85" equipmentId="VL30_0" x="-967.99" y="-1064.51"/>
-                <nad:busNode diagramId="87" equipmentId="VL31_0" x="-1563.34" y="-1851.27"/>
-                <nad:busNode diagramId="89" equipmentId="VL32_0" x="-2016.14" y="-1543.90"/>
-                <nad:busNode diagramId="91" equipmentId="VL33_0" x="140.90" y="-456.36"/>
-                <nad:busNode diagramId="93" equipmentId="VL34_0" x="-87.82" y="499.20"/>
-                <nad:busNode diagramId="95" equipmentId="VL35_0" x="523.57" y="737.58"/>
-                <nad:busNode diagramId="97" equipmentId="VL36_0" x="165.15" y="857.17"/>
-                <nad:busNode diagramId="99" equipmentId="VL37_0" x="241.65" y="538.50"/>
-                <nad:busNode diagramId="101" equipmentId="VL38_0" x="-515.99" y="257.27"/>
-                <nad:busNode diagramId="103" equipmentId="VL39_0" x="707.42" y="1039.26"/>
-                <nad:busNode diagramId="105" equipmentId="VL4_0" x="-456.43" y="-2436.67"/>
-                <nad:busNode diagramId="107" equipmentId="VL40_0" x="512.74" y="1337.72"/>
-                <nad:busNode diagramId="109" equipmentId="VL41_0" x="634.21" y="1767.75"/>
-                <nad:busNode diagramId="111" equipmentId="VL42_0" x="149.99" y="1701.48"/>
-                <nad:busNode diagramId="113" equipmentId="VL43_0" x="55.03" y="1306.70"/>
-                <nad:busNode diagramId="115" equipmentId="VL44_0" x="202.50" y="2053.81"/>
-                <nad:busNode diagramId="117" equipmentId="VL45_0" x="-204.25" y="2143.02"/>
-                <nad:busNode diagramId="119" equipmentId="VL46_0" x="-307.65" y="1800.48"/>
-                <nad:busNode diagramId="121" equipmentId="VL47_0" x="-561.68" y="1442.10"/>
-                <nad:busNode diagramId="123" equipmentId="VL48_0" x="-567.75" y="1972.26"/>
-                <nad:busNode diagramId="125" equipmentId="VL49_0" x="-865.91" y="1803.56"/>
-                <nad:busNode diagramId="127" equipmentId="VL5_0" x="-226.14" y="-2597.43"/>
-                <nad:busNode diagramId="129" equipmentId="VL50_0" x="-1216.28" y="2348.42"/>
-                <nad:busNode diagramId="131" equipmentId="VL51_0" x="-1735.70" y="1570.73"/>
-                <nad:busNode diagramId="133" equipmentId="VL52_0" x="-2270.25" y="1451.22"/>
-                <nad:busNode diagramId="135" equipmentId="VL53_0" x="-2450.66" y="1826.24"/>
-                <nad:busNode diagramId="137" equipmentId="VL54_0" x="-1871.19" y="2164.77"/>
-                <nad:busNode diagramId="139" equipmentId="VL55_0" x="-2172.24" y="2632.80"/>
-                <nad:busNode diagramId="141" equipmentId="VL56_0" x="-2047.32" y="2402.77"/>
-                <nad:busNode diagramId="143" equipmentId="VL57_0" x="-1757.65" y="2835.12"/>
-                <nad:busNode diagramId="145" equipmentId="VL58_0" x="-2080.07" y="1873.46"/>
-                <nad:busNode diagramId="147" equipmentId="VL59_0" x="-1684.36" y="2545.40"/>
-                <nad:busNode diagramId="149" equipmentId="VL6_0" x="-227.75" y="-3078.89"/>
-                <nad:busNode diagramId="151" equipmentId="VL60_0" x="-1272.84" y="2998.10"/>
-                <nad:busNode diagramId="153" equipmentId="VL61_0" x="-1237.34" y="2662.22"/>
-                <nad:busNode diagramId="155" equipmentId="VL62_0" x="-856.69" y="2833.88"/>
-                <nad:busNode diagramId="157" equipmentId="VL63_0" x="-1522.71" y="2138.63"/>
-                <nad:busNode diagramId="159" equipmentId="VL64_0" x="-1223.07" y="1924.77"/>
-                <nad:busNode diagramId="161" equipmentId="VL65_0" x="-838.01" y="1302.47"/>
-                <nad:busNode diagramId="163" equipmentId="VL66_0" x="-724.94" y="2291.00"/>
-                <nad:busNode diagramId="165" equipmentId="VL67_0" x="-485.47" y="2800.21"/>
-                <nad:busNode diagramId="167" equipmentId="VL68_0" x="-432.82" y="839.16"/>
-                <nad:busNode diagramId="169" equipmentId="VL69_0" x="-737.13" y="811.74"/>
-                <nad:busNode diagramId="171" equipmentId="VL7_0" x="119.58" y="-2950.52"/>
-                <nad:busNode diagramId="173" equipmentId="VL70_0" x="-1569.94" y="376.64"/>
-                <nad:busNode diagramId="175" equipmentId="VL71_0" x="-2262.47" y="427.94"/>
-                <nad:busNode diagramId="177" equipmentId="VL72_0" x="-2481.37" y="82.57"/>
-                <nad:busNode diagramId="179" equipmentId="VL73_0" x="-2719.03" y="566.35"/>
-                <nad:busNode diagramId="181" equipmentId="VL74_0" x="-1291.18" y="229.09"/>
-                <nad:busNode diagramId="183" equipmentId="VL75_0" x="-873.64" y="301.84"/>
-                <nad:busNode diagramId="185" equipmentId="VL76_0" x="-207.79" y="-92.40"/>
-                <nad:busNode diagramId="187" equipmentId="VL77_0" x="183.20" y="161.49"/>
-                <nad:busNode diagramId="189" equipmentId="VL78_0" x="565.97" y="-268.02"/>
-                <nad:busNode diagramId="191" equipmentId="VL79_0" x="911.14" y="-480.58"/>
-                <nad:busNode diagramId="193" equipmentId="VL8_0" x="-822.77" y="-2072.63"/>
-                <nad:busNode diagramId="195" equipmentId="VL80_0" x="1115.02" y="-106.19"/>
-                <nad:busNode diagramId="197" equipmentId="VL81_0" x="555.40" y="284.23"/>
-                <nad:busNode diagramId="199" equipmentId="VL82_0" x="1185.49" y="633.29"/>
-                <nad:busNode diagramId="201" equipmentId="VL83_0" x="1720.46" y="1225.26"/>
-                <nad:busNode diagramId="203" equipmentId="VL84_0" x="1872.65" y="1592.24"/>
-                <nad:busNode diagramId="205" equipmentId="VL85_0" x="2254.32" y="1505.38"/>
-                <nad:busNode diagramId="207" equipmentId="VL86_0" x="2297.43" y="2057.25"/>
-                <nad:busNode diagramId="209" equipmentId="VL87_0" x="2281.30" y="2465.48"/>
-                <nad:busNode diagramId="211" equipmentId="VL88_0" x="2651.27" y="1470.48"/>
-                <nad:busNode diagramId="213" equipmentId="VL89_0" x="2679.94" y="1059.28"/>
-                <nad:busNode diagramId="215" equipmentId="VL9_0" x="-1110.36" y="-2546.02"/>
-                <nad:busNode diagramId="217" equipmentId="VL90_0" x="3119.18" y="992.09"/>
-                <nad:busNode diagramId="219" equipmentId="VL91_0" x="3112.24" y="597.31"/>
-                <nad:busNode diagramId="221" equipmentId="VL92_0" x="2692.64" y="288.03"/>
-                <nad:busNode diagramId="223" equipmentId="VL93_0" x="2425.16" y="462.49"/>
-                <nad:busNode diagramId="225" equipmentId="VL94_0" x="2198.12" y="143.57"/>
-                <nad:busNode diagramId="227" equipmentId="VL95_0" x="1924.07" y="428.77"/>
-                <nad:busNode diagramId="229" equipmentId="VL96_0" x="1578.37" y="285.28"/>
-                <nad:busNode diagramId="231" equipmentId="VL97_0" x="1406.49" y="11.44"/>
-                <nad:busNode diagramId="233" equipmentId="VL98_0" x="1634.60" y="-576.38"/>
-                <nad:busNode diagramId="235" equipmentId="VL99_0" x="1794.79" y="-295.58"/>
+                <nad:busNode diagramId="1" equipmentId="VL1_0"/>
+                <nad:busNode diagramId="3" equipmentId="VL10_0"/>
+                <nad:busNode diagramId="5" equipmentId="VL100_0"/>
+                <nad:busNode diagramId="7" equipmentId="VL101_0"/>
+                <nad:busNode diagramId="9" equipmentId="VL102_0"/>
+                <nad:busNode diagramId="11" equipmentId="VL103_0"/>
+                <nad:busNode diagramId="13" equipmentId="VL104_0"/>
+                <nad:busNode diagramId="15" equipmentId="VL105_0"/>
+                <nad:busNode diagramId="17" equipmentId="VL106_0"/>
+                <nad:busNode diagramId="19" equipmentId="VL107_0"/>
+                <nad:busNode diagramId="21" equipmentId="VL108_0"/>
+                <nad:busNode diagramId="23" equipmentId="VL109_0"/>
+                <nad:busNode diagramId="25" equipmentId="VL11_0"/>
+                <nad:busNode diagramId="27" equipmentId="VL110_0"/>
+                <nad:busNode diagramId="29" equipmentId="VL111_0"/>
+                <nad:busNode diagramId="31" equipmentId="VL112_0"/>
+                <nad:busNode diagramId="33" equipmentId="VL113_0"/>
+                <nad:busNode diagramId="35" equipmentId="VL114_0"/>
+                <nad:busNode diagramId="37" equipmentId="VL115_0"/>
+                <nad:busNode diagramId="39" equipmentId="VL116_0"/>
+                <nad:busNode diagramId="41" equipmentId="VL117_0"/>
+                <nad:busNode diagramId="43" equipmentId="VL118_0"/>
+                <nad:busNode diagramId="45" equipmentId="VL12_0"/>
+                <nad:busNode diagramId="47" equipmentId="VL13_0"/>
+                <nad:busNode diagramId="49" equipmentId="VL14_0"/>
+                <nad:busNode diagramId="51" equipmentId="VL15_0"/>
+                <nad:busNode diagramId="53" equipmentId="VL16_0"/>
+                <nad:busNode diagramId="55" equipmentId="VL17_0"/>
+                <nad:busNode diagramId="57" equipmentId="VL18_0"/>
+                <nad:busNode diagramId="59" equipmentId="VL19_0"/>
+                <nad:busNode diagramId="61" equipmentId="VL2_0"/>
+                <nad:busNode diagramId="63" equipmentId="VL20_0"/>
+                <nad:busNode diagramId="65" equipmentId="VL21_0"/>
+                <nad:busNode diagramId="67" equipmentId="VL22_0"/>
+                <nad:busNode diagramId="69" equipmentId="VL23_0"/>
+                <nad:busNode diagramId="71" equipmentId="VL24_0"/>
+                <nad:busNode diagramId="73" equipmentId="VL25_0"/>
+                <nad:busNode diagramId="75" equipmentId="VL26_0"/>
+                <nad:busNode diagramId="77" equipmentId="VL27_0"/>
+                <nad:busNode diagramId="79" equipmentId="VL28_0"/>
+                <nad:busNode diagramId="81" equipmentId="VL29_0"/>
+                <nad:busNode diagramId="83" equipmentId="VL3_0"/>
+                <nad:busNode diagramId="85" equipmentId="VL30_0"/>
+                <nad:busNode diagramId="87" equipmentId="VL31_0"/>
+                <nad:busNode diagramId="89" equipmentId="VL32_0"/>
+                <nad:busNode diagramId="91" equipmentId="VL33_0"/>
+                <nad:busNode diagramId="93" equipmentId="VL34_0"/>
+                <nad:busNode diagramId="95" equipmentId="VL35_0"/>
+                <nad:busNode diagramId="97" equipmentId="VL36_0"/>
+                <nad:busNode diagramId="99" equipmentId="VL37_0"/>
+                <nad:busNode diagramId="101" equipmentId="VL38_0"/>
+                <nad:busNode diagramId="103" equipmentId="VL39_0"/>
+                <nad:busNode diagramId="105" equipmentId="VL4_0"/>
+                <nad:busNode diagramId="107" equipmentId="VL40_0"/>
+                <nad:busNode diagramId="109" equipmentId="VL41_0"/>
+                <nad:busNode diagramId="111" equipmentId="VL42_0"/>
+                <nad:busNode diagramId="113" equipmentId="VL43_0"/>
+                <nad:busNode diagramId="115" equipmentId="VL44_0"/>
+                <nad:busNode diagramId="117" equipmentId="VL45_0"/>
+                <nad:busNode diagramId="119" equipmentId="VL46_0"/>
+                <nad:busNode diagramId="121" equipmentId="VL47_0"/>
+                <nad:busNode diagramId="123" equipmentId="VL48_0"/>
+                <nad:busNode diagramId="125" equipmentId="VL49_0"/>
+                <nad:busNode diagramId="127" equipmentId="VL5_0"/>
+                <nad:busNode diagramId="129" equipmentId="VL50_0"/>
+                <nad:busNode diagramId="131" equipmentId="VL51_0"/>
+                <nad:busNode diagramId="133" equipmentId="VL52_0"/>
+                <nad:busNode diagramId="135" equipmentId="VL53_0"/>
+                <nad:busNode diagramId="137" equipmentId="VL54_0"/>
+                <nad:busNode diagramId="139" equipmentId="VL55_0"/>
+                <nad:busNode diagramId="141" equipmentId="VL56_0"/>
+                <nad:busNode diagramId="143" equipmentId="VL57_0"/>
+                <nad:busNode diagramId="145" equipmentId="VL58_0"/>
+                <nad:busNode diagramId="147" equipmentId="VL59_0"/>
+                <nad:busNode diagramId="149" equipmentId="VL6_0"/>
+                <nad:busNode diagramId="151" equipmentId="VL60_0"/>
+                <nad:busNode diagramId="153" equipmentId="VL61_0"/>
+                <nad:busNode diagramId="155" equipmentId="VL62_0"/>
+                <nad:busNode diagramId="157" equipmentId="VL63_0"/>
+                <nad:busNode diagramId="159" equipmentId="VL64_0"/>
+                <nad:busNode diagramId="161" equipmentId="VL65_0"/>
+                <nad:busNode diagramId="163" equipmentId="VL66_0"/>
+                <nad:busNode diagramId="165" equipmentId="VL67_0"/>
+                <nad:busNode diagramId="167" equipmentId="VL68_0"/>
+                <nad:busNode diagramId="169" equipmentId="VL69_0"/>
+                <nad:busNode diagramId="171" equipmentId="VL7_0"/>
+                <nad:busNode diagramId="173" equipmentId="VL70_0"/>
+                <nad:busNode diagramId="175" equipmentId="VL71_0"/>
+                <nad:busNode diagramId="177" equipmentId="VL72_0"/>
+                <nad:busNode diagramId="179" equipmentId="VL73_0"/>
+                <nad:busNode diagramId="181" equipmentId="VL74_0"/>
+                <nad:busNode diagramId="183" equipmentId="VL75_0"/>
+                <nad:busNode diagramId="185" equipmentId="VL76_0"/>
+                <nad:busNode diagramId="187" equipmentId="VL77_0"/>
+                <nad:busNode diagramId="189" equipmentId="VL78_0"/>
+                <nad:busNode diagramId="191" equipmentId="VL79_0"/>
+                <nad:busNode diagramId="193" equipmentId="VL8_0"/>
+                <nad:busNode diagramId="195" equipmentId="VL80_0"/>
+                <nad:busNode diagramId="197" equipmentId="VL81_0"/>
+                <nad:busNode diagramId="199" equipmentId="VL82_0"/>
+                <nad:busNode diagramId="201" equipmentId="VL83_0"/>
+                <nad:busNode diagramId="203" equipmentId="VL84_0"/>
+                <nad:busNode diagramId="205" equipmentId="VL85_0"/>
+                <nad:busNode diagramId="207" equipmentId="VL86_0"/>
+                <nad:busNode diagramId="209" equipmentId="VL87_0"/>
+                <nad:busNode diagramId="211" equipmentId="VL88_0"/>
+                <nad:busNode diagramId="213" equipmentId="VL89_0"/>
+                <nad:busNode diagramId="215" equipmentId="VL9_0"/>
+                <nad:busNode diagramId="217" equipmentId="VL90_0"/>
+                <nad:busNode diagramId="219" equipmentId="VL91_0"/>
+                <nad:busNode diagramId="221" equipmentId="VL92_0"/>
+                <nad:busNode diagramId="223" equipmentId="VL93_0"/>
+                <nad:busNode diagramId="225" equipmentId="VL94_0"/>
+                <nad:busNode diagramId="227" equipmentId="VL95_0"/>
+                <nad:busNode diagramId="229" equipmentId="VL96_0"/>
+                <nad:busNode diagramId="231" equipmentId="VL97_0"/>
+                <nad:busNode diagramId="233" equipmentId="VL98_0"/>
+                <nad:busNode diagramId="235" equipmentId="VL99_0"/>
             </nad:busNodes>
             <nad:nodes>
                 <nad:node diagramId="0" equipmentId="VL1" x="736.99" y="-2973.24"/>

--- a/network-area-diagram/src/test/resources/IEEE_118_bus_partial.svg
+++ b/network-area-diagram/src/test/resources/IEEE_118_bus_partial.svg
@@ -114,122 +114,122 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="VL42_0"/>
-                <nad:busNode diagramId="3" equipmentId="VL45_0"/>
-                <nad:busNode diagramId="5" equipmentId="VL47_0"/>
-                <nad:busNode diagramId="7" equipmentId="VL48_0"/>
-                <nad:busNode diagramId="9" equipmentId="VL49_0"/>
-                <nad:busNode diagramId="11" equipmentId="VL50_0"/>
-                <nad:busNode diagramId="13" equipmentId="VL51_0"/>
-                <nad:busNode diagramId="15" equipmentId="VL52_0"/>
-                <nad:busNode diagramId="17" equipmentId="VL53_0"/>
-                <nad:busNode diagramId="19" equipmentId="VL54_0"/>
-                <nad:busNode diagramId="21" equipmentId="VL55_0"/>
-                <nad:busNode diagramId="23" equipmentId="VL56_0"/>
-                <nad:busNode diagramId="25" equipmentId="VL57_0"/>
-                <nad:busNode diagramId="27" equipmentId="VL58_0"/>
-                <nad:busNode diagramId="29" equipmentId="VL59_0"/>
-                <nad:busNode diagramId="31" equipmentId="VL60_0"/>
-                <nad:busNode diagramId="33" equipmentId="VL61_0"/>
-                <nad:busNode diagramId="35" equipmentId="VL63_0"/>
-                <nad:busNode diagramId="37" equipmentId="VL66_0"/>
-                <nad:busNode diagramId="39" equipmentId="VL69_0"/>
-                <nad:busNode diagramId="41" equipmentId="VL40_0"/>
-                <nad:busNode diagramId="44" equipmentId="VL41_0"/>
-                <nad:busNode diagramId="49" equipmentId="VL44_0"/>
-                <nad:busNode diagramId="52" equipmentId="VL46_0"/>
-                <nad:busNode diagramId="86" equipmentId="VL62_0"/>
-                <nad:busNode diagramId="90" equipmentId="VL64_0"/>
-                <nad:busNode diagramId="95" equipmentId="VL67_0"/>
-                <nad:busNode diagramId="98" equipmentId="VL65_0"/>
-                <nad:busNode diagramId="101" equipmentId="VL70_0"/>
-                <nad:busNode diagramId="104" equipmentId="VL75_0"/>
-                <nad:busNode diagramId="107" equipmentId="VL77_0"/>
-                <nad:busNode diagramId="110" equipmentId="VL68_0"/>
+                <nad:busNode svgId="1" equipmentId="VL42_0"/>
+                <nad:busNode svgId="3" equipmentId="VL45_0"/>
+                <nad:busNode svgId="5" equipmentId="VL47_0"/>
+                <nad:busNode svgId="7" equipmentId="VL48_0"/>
+                <nad:busNode svgId="9" equipmentId="VL49_0"/>
+                <nad:busNode svgId="11" equipmentId="VL50_0"/>
+                <nad:busNode svgId="13" equipmentId="VL51_0"/>
+                <nad:busNode svgId="15" equipmentId="VL52_0"/>
+                <nad:busNode svgId="17" equipmentId="VL53_0"/>
+                <nad:busNode svgId="19" equipmentId="VL54_0"/>
+                <nad:busNode svgId="21" equipmentId="VL55_0"/>
+                <nad:busNode svgId="23" equipmentId="VL56_0"/>
+                <nad:busNode svgId="25" equipmentId="VL57_0"/>
+                <nad:busNode svgId="27" equipmentId="VL58_0"/>
+                <nad:busNode svgId="29" equipmentId="VL59_0"/>
+                <nad:busNode svgId="31" equipmentId="VL60_0"/>
+                <nad:busNode svgId="33" equipmentId="VL61_0"/>
+                <nad:busNode svgId="35" equipmentId="VL63_0"/>
+                <nad:busNode svgId="37" equipmentId="VL66_0"/>
+                <nad:busNode svgId="39" equipmentId="VL69_0"/>
+                <nad:busNode svgId="41" equipmentId="VL40_0"/>
+                <nad:busNode svgId="44" equipmentId="VL41_0"/>
+                <nad:busNode svgId="49" equipmentId="VL44_0"/>
+                <nad:busNode svgId="52" equipmentId="VL46_0"/>
+                <nad:busNode svgId="86" equipmentId="VL62_0"/>
+                <nad:busNode svgId="90" equipmentId="VL64_0"/>
+                <nad:busNode svgId="95" equipmentId="VL67_0"/>
+                <nad:busNode svgId="98" equipmentId="VL65_0"/>
+                <nad:busNode svgId="101" equipmentId="VL70_0"/>
+                <nad:busNode svgId="104" equipmentId="VL75_0"/>
+                <nad:busNode svgId="107" equipmentId="VL77_0"/>
+                <nad:busNode svgId="110" equipmentId="VL68_0"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node diagramId="0" equipmentId="VL42" x="-384.73" y="205.05"/>
-                <nad:node diagramId="2" equipmentId="VL45" x="412.94" y="570.23"/>
-                <nad:node diagramId="4" equipmentId="VL47" x="-23.01" y="891.24"/>
-                <nad:node diagramId="6" equipmentId="VL48" x="639.20" y="864.66"/>
-                <nad:node diagramId="8" equipmentId="VL49" x="141.33" y="400.64"/>
-                <nad:node diagramId="10" equipmentId="VL50" x="890.72" y="392.93"/>
-                <nad:node diagramId="12" equipmentId="VL51" x="778.38" y="-198.28"/>
-                <nad:node diagramId="14" equipmentId="VL52" x="1112.17" y="-769.45"/>
-                <nad:node diagramId="16" equipmentId="VL53" x="777.95" y="-957.28"/>
-                <nad:node diagramId="18" equipmentId="VL54" x="289.01" y="-494.56"/>
-                <nad:node diagramId="20" equipmentId="VL55" x="327.81" y="-853.45"/>
-                <nad:node diagramId="22" equipmentId="VL56" x="612.02" y="-544.18"/>
-                <nad:node diagramId="24" equipmentId="VL57" x="1098.74" y="20.20"/>
-                <nad:node diagramId="26" equipmentId="VL58" x="1078.77" y="-408.41"/>
-                <nad:node diagramId="28" equipmentId="VL59" x="-35.94" y="-870.64"/>
-                <nad:node diagramId="30" equipmentId="VL60" x="-478.40" y="-719.94"/>
-                <nad:node diagramId="32" equipmentId="VL61" x="-609.70" y="-985.82"/>
-                <nad:node diagramId="34" equipmentId="VL63" x="-211.93" y="-1369.90"/>
-                <nad:node diagramId="36" equipmentId="VL66" x="-800.22" y="310.03"/>
-                <nad:node diagramId="38" equipmentId="VL69" x="-71.36" y="1313.89"/>
-                <nad:node diagramId="40" equipmentId="VL40" x="-391.40" y="-124.65"/>
-                <nad:node diagramId="43" equipmentId="VL41" x="-903.72" y="-19.65"/>
-                <nad:node diagramId="48" equipmentId="VL44" x="524.94" y="229.74"/>
-                <nad:node diagramId="51" equipmentId="VL46" x="339.97" y="951.65"/>
-                <nad:node diagramId="85" equipmentId="VL62" x="-811.18" y="-479.70"/>
-                <nad:node diagramId="89" equipmentId="VL64" x="-608.79" y="-1421.47"/>
-                <nad:node diagramId="94" equipmentId="VL67" x="-1080.25" y="705.24"/>
-                <nad:node diagramId="97" equipmentId="VL65" x="-1339.67" y="317.19"/>
-                <nad:node diagramId="100" equipmentId="VL70" x="374.18" y="1568.83"/>
-                <nad:node diagramId="103" equipmentId="VL75" x="-378.07" y="1738.21"/>
-                <nad:node diagramId="106" equipmentId="VL77" x="-539.53" y="1344.42"/>
-                <nad:node diagramId="109" equipmentId="VL68" x="39.39" y="1818.52"/>
+                <nad:node svgId="0" equipmentId="VL42" x="-384.73" y="205.05"/>
+                <nad:node svgId="2" equipmentId="VL45" x="412.94" y="570.23"/>
+                <nad:node svgId="4" equipmentId="VL47" x="-23.01" y="891.24"/>
+                <nad:node svgId="6" equipmentId="VL48" x="639.20" y="864.66"/>
+                <nad:node svgId="8" equipmentId="VL49" x="141.33" y="400.64"/>
+                <nad:node svgId="10" equipmentId="VL50" x="890.72" y="392.93"/>
+                <nad:node svgId="12" equipmentId="VL51" x="778.38" y="-198.28"/>
+                <nad:node svgId="14" equipmentId="VL52" x="1112.17" y="-769.45"/>
+                <nad:node svgId="16" equipmentId="VL53" x="777.95" y="-957.28"/>
+                <nad:node svgId="18" equipmentId="VL54" x="289.01" y="-494.56"/>
+                <nad:node svgId="20" equipmentId="VL55" x="327.81" y="-853.45"/>
+                <nad:node svgId="22" equipmentId="VL56" x="612.02" y="-544.18"/>
+                <nad:node svgId="24" equipmentId="VL57" x="1098.74" y="20.20"/>
+                <nad:node svgId="26" equipmentId="VL58" x="1078.77" y="-408.41"/>
+                <nad:node svgId="28" equipmentId="VL59" x="-35.94" y="-870.64"/>
+                <nad:node svgId="30" equipmentId="VL60" x="-478.40" y="-719.94"/>
+                <nad:node svgId="32" equipmentId="VL61" x="-609.70" y="-985.82"/>
+                <nad:node svgId="34" equipmentId="VL63" x="-211.93" y="-1369.90"/>
+                <nad:node svgId="36" equipmentId="VL66" x="-800.22" y="310.03"/>
+                <nad:node svgId="38" equipmentId="VL69" x="-71.36" y="1313.89"/>
+                <nad:node svgId="40" equipmentId="VL40" x="-391.40" y="-124.65"/>
+                <nad:node svgId="43" equipmentId="VL41" x="-903.72" y="-19.65"/>
+                <nad:node svgId="48" equipmentId="VL44" x="524.94" y="229.74"/>
+                <nad:node svgId="51" equipmentId="VL46" x="339.97" y="951.65"/>
+                <nad:node svgId="85" equipmentId="VL62" x="-811.18" y="-479.70"/>
+                <nad:node svgId="89" equipmentId="VL64" x="-608.79" y="-1421.47"/>
+                <nad:node svgId="94" equipmentId="VL67" x="-1080.25" y="705.24"/>
+                <nad:node svgId="97" equipmentId="VL65" x="-1339.67" y="317.19"/>
+                <nad:node svgId="100" equipmentId="VL70" x="374.18" y="1568.83"/>
+                <nad:node svgId="103" equipmentId="VL75" x="-378.07" y="1738.21"/>
+                <nad:node svgId="106" equipmentId="VL77" x="-539.53" y="1344.42"/>
+                <nad:node svgId="109" equipmentId="VL68" x="39.39" y="1818.52"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge diagramId="42" equipmentId="L40-42-1"/>
-                <nad:edge diagramId="45" equipmentId="L41-42-1"/>
-                <nad:edge diagramId="46" equipmentId="L42-49-1"/>
-                <nad:edge diagramId="47" equipmentId="L42-49-2"/>
-                <nad:edge diagramId="50" equipmentId="L44-45-1"/>
-                <nad:edge diagramId="53" equipmentId="L45-46-1"/>
-                <nad:edge diagramId="54" equipmentId="L45-49-1"/>
-                <nad:edge diagramId="55" equipmentId="L46-47-1"/>
-                <nad:edge diagramId="56" equipmentId="L47-49-1"/>
-                <nad:edge diagramId="57" equipmentId="L47-69-1"/>
-                <nad:edge diagramId="58" equipmentId="L46-48-1"/>
-                <nad:edge diagramId="59" equipmentId="L48-49-1"/>
-                <nad:edge diagramId="60" equipmentId="L49-50-1"/>
-                <nad:edge diagramId="61" equipmentId="L49-51-1"/>
-                <nad:edge diagramId="62" equipmentId="L49-54-1"/>
-                <nad:edge diagramId="63" equipmentId="L49-54-2"/>
-                <nad:edge diagramId="64" equipmentId="L49-66-1"/>
-                <nad:edge diagramId="65" equipmentId="L49-66-2"/>
-                <nad:edge diagramId="66" equipmentId="L49-69-1"/>
-                <nad:edge diagramId="67" equipmentId="L50-57-1"/>
-                <nad:edge diagramId="68" equipmentId="L51-52-1"/>
-                <nad:edge diagramId="69" equipmentId="L51-58-1"/>
-                <nad:edge diagramId="70" equipmentId="L52-53-1"/>
-                <nad:edge diagramId="71" equipmentId="L53-54-1"/>
-                <nad:edge diagramId="72" equipmentId="L54-55-1"/>
-                <nad:edge diagramId="73" equipmentId="L54-56-1"/>
-                <nad:edge diagramId="74" equipmentId="L54-59-1"/>
-                <nad:edge diagramId="75" equipmentId="L55-56-1"/>
-                <nad:edge diagramId="76" equipmentId="L55-59-1"/>
-                <nad:edge diagramId="77" equipmentId="L56-57-1"/>
-                <nad:edge diagramId="78" equipmentId="L56-58-1"/>
-                <nad:edge diagramId="79" equipmentId="L56-59-1"/>
-                <nad:edge diagramId="80" equipmentId="L56-59-2"/>
-                <nad:edge diagramId="81" equipmentId="L59-60-1"/>
-                <nad:edge diagramId="82" equipmentId="L59-61-1"/>
-                <nad:edge diagramId="83" equipmentId="T63-59-1"/>
-                <nad:edge diagramId="84" equipmentId="L60-61-1"/>
-                <nad:edge diagramId="87" equipmentId="L60-62-1"/>
-                <nad:edge diagramId="88" equipmentId="L61-62-1"/>
-                <nad:edge diagramId="91" equipmentId="T64-61-1"/>
-                <nad:edge diagramId="92" equipmentId="L63-64-1"/>
-                <nad:edge diagramId="93" equipmentId="L62-66-1"/>
-                <nad:edge diagramId="96" equipmentId="L66-67-1"/>
-                <nad:edge diagramId="99" equipmentId="T65-66-1"/>
-                <nad:edge diagramId="102" equipmentId="L69-70-1"/>
-                <nad:edge diagramId="105" equipmentId="L69-75-1"/>
-                <nad:edge diagramId="108" equipmentId="L69-77-1"/>
-                <nad:edge diagramId="111" equipmentId="T68-69-1"/>
+                <nad:edge svgId="42" equipmentId="L40-42-1"/>
+                <nad:edge svgId="45" equipmentId="L41-42-1"/>
+                <nad:edge svgId="46" equipmentId="L42-49-1"/>
+                <nad:edge svgId="47" equipmentId="L42-49-2"/>
+                <nad:edge svgId="50" equipmentId="L44-45-1"/>
+                <nad:edge svgId="53" equipmentId="L45-46-1"/>
+                <nad:edge svgId="54" equipmentId="L45-49-1"/>
+                <nad:edge svgId="55" equipmentId="L46-47-1"/>
+                <nad:edge svgId="56" equipmentId="L47-49-1"/>
+                <nad:edge svgId="57" equipmentId="L47-69-1"/>
+                <nad:edge svgId="58" equipmentId="L46-48-1"/>
+                <nad:edge svgId="59" equipmentId="L48-49-1"/>
+                <nad:edge svgId="60" equipmentId="L49-50-1"/>
+                <nad:edge svgId="61" equipmentId="L49-51-1"/>
+                <nad:edge svgId="62" equipmentId="L49-54-1"/>
+                <nad:edge svgId="63" equipmentId="L49-54-2"/>
+                <nad:edge svgId="64" equipmentId="L49-66-1"/>
+                <nad:edge svgId="65" equipmentId="L49-66-2"/>
+                <nad:edge svgId="66" equipmentId="L49-69-1"/>
+                <nad:edge svgId="67" equipmentId="L50-57-1"/>
+                <nad:edge svgId="68" equipmentId="L51-52-1"/>
+                <nad:edge svgId="69" equipmentId="L51-58-1"/>
+                <nad:edge svgId="70" equipmentId="L52-53-1"/>
+                <nad:edge svgId="71" equipmentId="L53-54-1"/>
+                <nad:edge svgId="72" equipmentId="L54-55-1"/>
+                <nad:edge svgId="73" equipmentId="L54-56-1"/>
+                <nad:edge svgId="74" equipmentId="L54-59-1"/>
+                <nad:edge svgId="75" equipmentId="L55-56-1"/>
+                <nad:edge svgId="76" equipmentId="L55-59-1"/>
+                <nad:edge svgId="77" equipmentId="L56-57-1"/>
+                <nad:edge svgId="78" equipmentId="L56-58-1"/>
+                <nad:edge svgId="79" equipmentId="L56-59-1"/>
+                <nad:edge svgId="80" equipmentId="L56-59-2"/>
+                <nad:edge svgId="81" equipmentId="L59-60-1"/>
+                <nad:edge svgId="82" equipmentId="L59-61-1"/>
+                <nad:edge svgId="83" equipmentId="T63-59-1"/>
+                <nad:edge svgId="84" equipmentId="L60-61-1"/>
+                <nad:edge svgId="87" equipmentId="L60-62-1"/>
+                <nad:edge svgId="88" equipmentId="L61-62-1"/>
+                <nad:edge svgId="91" equipmentId="T64-61-1"/>
+                <nad:edge svgId="92" equipmentId="L63-64-1"/>
+                <nad:edge svgId="93" equipmentId="L62-66-1"/>
+                <nad:edge svgId="96" equipmentId="L66-67-1"/>
+                <nad:edge svgId="99" equipmentId="T65-66-1"/>
+                <nad:edge svgId="102" equipmentId="L69-70-1"/>
+                <nad:edge svgId="105" equipmentId="L69-75-1"/>
+                <nad:edge svgId="108" equipmentId="L69-77-1"/>
+                <nad:edge svgId="111" equipmentId="T68-69-1"/>
             </nad:edges>
         </nad:nad>
     </metadata>

--- a/network-area-diagram/src/test/resources/IEEE_118_bus_partial.svg
+++ b/network-area-diagram/src/test/resources/IEEE_118_bus_partial.svg
@@ -114,38 +114,38 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="VL42_0" x="-384.73" y="205.05"/>
-                <nad:busNode diagramId="3" equipmentId="VL45_0" x="412.94" y="570.23"/>
-                <nad:busNode diagramId="5" equipmentId="VL47_0" x="-23.01" y="891.24"/>
-                <nad:busNode diagramId="7" equipmentId="VL48_0" x="639.20" y="864.66"/>
-                <nad:busNode diagramId="9" equipmentId="VL49_0" x="141.33" y="400.64"/>
-                <nad:busNode diagramId="11" equipmentId="VL50_0" x="890.72" y="392.93"/>
-                <nad:busNode diagramId="13" equipmentId="VL51_0" x="778.38" y="-198.28"/>
-                <nad:busNode diagramId="15" equipmentId="VL52_0" x="1112.17" y="-769.45"/>
-                <nad:busNode diagramId="17" equipmentId="VL53_0" x="777.95" y="-957.28"/>
-                <nad:busNode diagramId="19" equipmentId="VL54_0" x="289.01" y="-494.56"/>
-                <nad:busNode diagramId="21" equipmentId="VL55_0" x="327.81" y="-853.45"/>
-                <nad:busNode diagramId="23" equipmentId="VL56_0" x="612.02" y="-544.18"/>
-                <nad:busNode diagramId="25" equipmentId="VL57_0" x="1098.74" y="20.20"/>
-                <nad:busNode diagramId="27" equipmentId="VL58_0" x="1078.77" y="-408.41"/>
-                <nad:busNode diagramId="29" equipmentId="VL59_0" x="-35.94" y="-870.64"/>
-                <nad:busNode diagramId="31" equipmentId="VL60_0" x="-478.40" y="-719.94"/>
-                <nad:busNode diagramId="33" equipmentId="VL61_0" x="-609.70" y="-985.82"/>
-                <nad:busNode diagramId="35" equipmentId="VL63_0" x="-211.93" y="-1369.90"/>
-                <nad:busNode diagramId="37" equipmentId="VL66_0" x="-800.22" y="310.03"/>
-                <nad:busNode diagramId="39" equipmentId="VL69_0" x="-71.36" y="1313.89"/>
-                <nad:busNode diagramId="41" equipmentId="VL40_0" x="-391.40" y="-124.65"/>
-                <nad:busNode diagramId="44" equipmentId="VL41_0" x="-903.72" y="-19.65"/>
-                <nad:busNode diagramId="49" equipmentId="VL44_0" x="524.94" y="229.74"/>
-                <nad:busNode diagramId="52" equipmentId="VL46_0" x="339.97" y="951.65"/>
-                <nad:busNode diagramId="86" equipmentId="VL62_0" x="-811.18" y="-479.70"/>
-                <nad:busNode diagramId="90" equipmentId="VL64_0" x="-608.79" y="-1421.47"/>
-                <nad:busNode diagramId="95" equipmentId="VL67_0" x="-1080.25" y="705.24"/>
-                <nad:busNode diagramId="98" equipmentId="VL65_0" x="-1339.67" y="317.19"/>
-                <nad:busNode diagramId="101" equipmentId="VL70_0" x="374.18" y="1568.83"/>
-                <nad:busNode diagramId="104" equipmentId="VL75_0" x="-378.07" y="1738.21"/>
-                <nad:busNode diagramId="107" equipmentId="VL77_0" x="-539.53" y="1344.42"/>
-                <nad:busNode diagramId="110" equipmentId="VL68_0" x="39.39" y="1818.52"/>
+                <nad:busNode diagramId="1" equipmentId="VL42_0"/>
+                <nad:busNode diagramId="3" equipmentId="VL45_0"/>
+                <nad:busNode diagramId="5" equipmentId="VL47_0"/>
+                <nad:busNode diagramId="7" equipmentId="VL48_0"/>
+                <nad:busNode diagramId="9" equipmentId="VL49_0"/>
+                <nad:busNode diagramId="11" equipmentId="VL50_0"/>
+                <nad:busNode diagramId="13" equipmentId="VL51_0"/>
+                <nad:busNode diagramId="15" equipmentId="VL52_0"/>
+                <nad:busNode diagramId="17" equipmentId="VL53_0"/>
+                <nad:busNode diagramId="19" equipmentId="VL54_0"/>
+                <nad:busNode diagramId="21" equipmentId="VL55_0"/>
+                <nad:busNode diagramId="23" equipmentId="VL56_0"/>
+                <nad:busNode diagramId="25" equipmentId="VL57_0"/>
+                <nad:busNode diagramId="27" equipmentId="VL58_0"/>
+                <nad:busNode diagramId="29" equipmentId="VL59_0"/>
+                <nad:busNode diagramId="31" equipmentId="VL60_0"/>
+                <nad:busNode diagramId="33" equipmentId="VL61_0"/>
+                <nad:busNode diagramId="35" equipmentId="VL63_0"/>
+                <nad:busNode diagramId="37" equipmentId="VL66_0"/>
+                <nad:busNode diagramId="39" equipmentId="VL69_0"/>
+                <nad:busNode diagramId="41" equipmentId="VL40_0"/>
+                <nad:busNode diagramId="44" equipmentId="VL41_0"/>
+                <nad:busNode diagramId="49" equipmentId="VL44_0"/>
+                <nad:busNode diagramId="52" equipmentId="VL46_0"/>
+                <nad:busNode diagramId="86" equipmentId="VL62_0"/>
+                <nad:busNode diagramId="90" equipmentId="VL64_0"/>
+                <nad:busNode diagramId="95" equipmentId="VL67_0"/>
+                <nad:busNode diagramId="98" equipmentId="VL65_0"/>
+                <nad:busNode diagramId="101" equipmentId="VL70_0"/>
+                <nad:busNode diagramId="104" equipmentId="VL75_0"/>
+                <nad:busNode diagramId="107" equipmentId="VL77_0"/>
+                <nad:busNode diagramId="110" equipmentId="VL68_0"/>
             </nad:busNodes>
             <nad:nodes>
                 <nad:node diagramId="0" equipmentId="VL42" x="-384.73" y="205.05"/>

--- a/network-area-diagram/src/test/resources/IEEE_118_bus_partial_non_connected.svg
+++ b/network-area-diagram/src/test/resources/IEEE_118_bus_partial_non_connected.svg
@@ -114,93 +114,93 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="VL113_0"/>
-                <nad:busNode diagramId="3" equipmentId="VL114_0"/>
-                <nad:busNode diagramId="5" equipmentId="VL23_0"/>
-                <nad:busNode diagramId="7" equipmentId="VL27_0"/>
-                <nad:busNode diagramId="9" equipmentId="VL30_0"/>
-                <nad:busNode diagramId="11" equipmentId="VL31_0"/>
-                <nad:busNode diagramId="13" equipmentId="VL32_0"/>
-                <nad:busNode diagramId="15" equipmentId="VL37_0"/>
-                <nad:busNode diagramId="17" equipmentId="VL38_0"/>
-                <nad:busNode diagramId="19" equipmentId="VL65_0"/>
-                <nad:busNode diagramId="21" equipmentId="VL17_0"/>
-                <nad:busNode diagramId="26" equipmentId="VL115_0"/>
-                <nad:busNode diagramId="29" equipmentId="VL22_0"/>
-                <nad:busNode diagramId="32" equipmentId="VL24_0"/>
-                <nad:busNode diagramId="35" equipmentId="VL25_0"/>
-                <nad:busNode diagramId="40" equipmentId="VL28_0"/>
-                <nad:busNode diagramId="45" equipmentId="VL8_0"/>
-                <nad:busNode diagramId="48" equipmentId="VL26_0"/>
-                <nad:busNode diagramId="54" equipmentId="VL29_0"/>
-                <nad:busNode diagramId="58" equipmentId="VL35_0"/>
-                <nad:busNode diagramId="61" equipmentId="VL33_0"/>
-                <nad:busNode diagramId="64" equipmentId="VL34_0"/>
-                <nad:busNode diagramId="67" equipmentId="VL39_0"/>
-                <nad:busNode diagramId="70" equipmentId="VL40_0"/>
-                <nad:busNode diagramId="75" equipmentId="VL64_0"/>
-                <nad:busNode diagramId="78" equipmentId="VL68_0"/>
-                <nad:busNode diagramId="81" equipmentId="VL66_0"/>
+                <nad:busNode svgId="1" equipmentId="VL113_0"/>
+                <nad:busNode svgId="3" equipmentId="VL114_0"/>
+                <nad:busNode svgId="5" equipmentId="VL23_0"/>
+                <nad:busNode svgId="7" equipmentId="VL27_0"/>
+                <nad:busNode svgId="9" equipmentId="VL30_0"/>
+                <nad:busNode svgId="11" equipmentId="VL31_0"/>
+                <nad:busNode svgId="13" equipmentId="VL32_0"/>
+                <nad:busNode svgId="15" equipmentId="VL37_0"/>
+                <nad:busNode svgId="17" equipmentId="VL38_0"/>
+                <nad:busNode svgId="19" equipmentId="VL65_0"/>
+                <nad:busNode svgId="21" equipmentId="VL17_0"/>
+                <nad:busNode svgId="26" equipmentId="VL115_0"/>
+                <nad:busNode svgId="29" equipmentId="VL22_0"/>
+                <nad:busNode svgId="32" equipmentId="VL24_0"/>
+                <nad:busNode svgId="35" equipmentId="VL25_0"/>
+                <nad:busNode svgId="40" equipmentId="VL28_0"/>
+                <nad:busNode svgId="45" equipmentId="VL8_0"/>
+                <nad:busNode svgId="48" equipmentId="VL26_0"/>
+                <nad:busNode svgId="54" equipmentId="VL29_0"/>
+                <nad:busNode svgId="58" equipmentId="VL35_0"/>
+                <nad:busNode svgId="61" equipmentId="VL33_0"/>
+                <nad:busNode svgId="64" equipmentId="VL34_0"/>
+                <nad:busNode svgId="67" equipmentId="VL39_0"/>
+                <nad:busNode svgId="70" equipmentId="VL40_0"/>
+                <nad:busNode svgId="75" equipmentId="VL64_0"/>
+                <nad:busNode svgId="78" equipmentId="VL68_0"/>
+                <nad:busNode svgId="81" equipmentId="VL66_0"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node diagramId="0" equipmentId="VL113" x="-178.77" y="407.56"/>
-                <nad:node diagramId="2" equipmentId="VL114" x="-641.86" y="1404.47"/>
-                <nad:node diagramId="4" equipmentId="VL23" x="95.73" y="1251.53"/>
-                <nad:node diagramId="6" equipmentId="VL27" x="-777.31" y="1072.53"/>
-                <nad:node diagramId="8" equipmentId="VL30" x="158.89" y="-689.41"/>
-                <nad:node diagramId="10" equipmentId="VL31" x="-609.09" y="288.76"/>
-                <nad:node diagramId="12" equipmentId="VL32" x="-399.08" y="854.10"/>
-                <nad:node diagramId="14" equipmentId="VL37" x="1109.61" y="-122.88"/>
-                <nad:node diagramId="16" equipmentId="VL38" x="393.66" y="-484.06"/>
-                <nad:node diagramId="18" equipmentId="VL65" x="-335.40" y="-921.45"/>
-                <nad:node diagramId="20" equipmentId="VL17" x="-205.59" y="-64.00"/>
-                <nad:node diagramId="25" equipmentId="VL115" x="-991.06" y="1448.86"/>
-                <nad:node diagramId="28" equipmentId="VL22" x="288.14" y="1671.63"/>
-                <nad:node diagramId="31" equipmentId="VL24" x="539.83" y="1234.73"/>
-                <nad:node diagramId="34" equipmentId="VL25" x="-281.45" y="1289.33"/>
-                <nad:node diagramId="39" equipmentId="VL28" x="-1213.35" y="929.27"/>
-                <nad:node diagramId="44" equipmentId="VL8" x="203.29" y="-1160.79"/>
-                <nad:node diagramId="47" equipmentId="VL26" x="574.78" y="-961.99"/>
-                <nad:node diagramId="53" equipmentId="VL29" x="-1033.90" y="140.31"/>
-                <nad:node diagramId="57" equipmentId="VL35" x="988.11" y="322.96"/>
-                <nad:node diagramId="60" equipmentId="VL33" x="1425.97" y="280.88"/>
-                <nad:node diagramId="63" equipmentId="VL34" x="770.45" y="-110.26"/>
-                <nad:node diagramId="66" equipmentId="VL39" x="1321.52" y="-523.30"/>
-                <nad:node diagramId="69" equipmentId="VL40" x="1591.73" y="-138.04"/>
-                <nad:node diagramId="74" equipmentId="VL64" x="-350.07" y="-1381.18"/>
-                <nad:node diagramId="77" equipmentId="VL68" x="-766.93" y="-1158.44"/>
-                <nad:node diagramId="80" equipmentId="VL66" x="-706.77" y="-708.71"/>
+                <nad:node svgId="0" equipmentId="VL113" x="-178.77" y="407.56"/>
+                <nad:node svgId="2" equipmentId="VL114" x="-641.86" y="1404.47"/>
+                <nad:node svgId="4" equipmentId="VL23" x="95.73" y="1251.53"/>
+                <nad:node svgId="6" equipmentId="VL27" x="-777.31" y="1072.53"/>
+                <nad:node svgId="8" equipmentId="VL30" x="158.89" y="-689.41"/>
+                <nad:node svgId="10" equipmentId="VL31" x="-609.09" y="288.76"/>
+                <nad:node svgId="12" equipmentId="VL32" x="-399.08" y="854.10"/>
+                <nad:node svgId="14" equipmentId="VL37" x="1109.61" y="-122.88"/>
+                <nad:node svgId="16" equipmentId="VL38" x="393.66" y="-484.06"/>
+                <nad:node svgId="18" equipmentId="VL65" x="-335.40" y="-921.45"/>
+                <nad:node svgId="20" equipmentId="VL17" x="-205.59" y="-64.00"/>
+                <nad:node svgId="25" equipmentId="VL115" x="-991.06" y="1448.86"/>
+                <nad:node svgId="28" equipmentId="VL22" x="288.14" y="1671.63"/>
+                <nad:node svgId="31" equipmentId="VL24" x="539.83" y="1234.73"/>
+                <nad:node svgId="34" equipmentId="VL25" x="-281.45" y="1289.33"/>
+                <nad:node svgId="39" equipmentId="VL28" x="-1213.35" y="929.27"/>
+                <nad:node svgId="44" equipmentId="VL8" x="203.29" y="-1160.79"/>
+                <nad:node svgId="47" equipmentId="VL26" x="574.78" y="-961.99"/>
+                <nad:node svgId="53" equipmentId="VL29" x="-1033.90" y="140.31"/>
+                <nad:node svgId="57" equipmentId="VL35" x="988.11" y="322.96"/>
+                <nad:node svgId="60" equipmentId="VL33" x="1425.97" y="280.88"/>
+                <nad:node svgId="63" equipmentId="VL34" x="770.45" y="-110.26"/>
+                <nad:node svgId="66" equipmentId="VL39" x="1321.52" y="-523.30"/>
+                <nad:node svgId="69" equipmentId="VL40" x="1591.73" y="-138.04"/>
+                <nad:node svgId="74" equipmentId="VL64" x="-350.07" y="-1381.18"/>
+                <nad:node svgId="77" equipmentId="VL68" x="-766.93" y="-1158.44"/>
+                <nad:node svgId="80" equipmentId="VL66" x="-706.77" y="-708.71"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge diagramId="22" equipmentId="L17-113-1"/>
-                <nad:edge diagramId="23" equipmentId="L32-113-1"/>
-                <nad:edge diagramId="24" equipmentId="L32-114-1"/>
-                <nad:edge diagramId="27" equipmentId="L114-115-1"/>
-                <nad:edge diagramId="30" equipmentId="L22-23-1"/>
-                <nad:edge diagramId="33" equipmentId="L23-24-1"/>
-                <nad:edge diagramId="36" equipmentId="L23-25-1"/>
-                <nad:edge diagramId="37" equipmentId="L23-32-1"/>
-                <nad:edge diagramId="38" equipmentId="L25-27-1"/>
-                <nad:edge diagramId="41" equipmentId="L27-28-1"/>
-                <nad:edge diagramId="42" equipmentId="L27-32-1"/>
-                <nad:edge diagramId="43" equipmentId="L27-115-1"/>
-                <nad:edge diagramId="46" equipmentId="L8-30-1"/>
-                <nad:edge diagramId="49" equipmentId="L26-30-1"/>
-                <nad:edge diagramId="50" equipmentId="L30-38-1"/>
-                <nad:edge diagramId="51" equipmentId="T30-17-1"/>
-                <nad:edge diagramId="52" equipmentId="L17-31-1"/>
-                <nad:edge diagramId="55" equipmentId="L29-31-1"/>
-                <nad:edge diagramId="56" equipmentId="L31-32-1"/>
-                <nad:edge diagramId="59" equipmentId="L35-37-1"/>
-                <nad:edge diagramId="62" equipmentId="L33-37-1"/>
-                <nad:edge diagramId="65" equipmentId="L34-37-1"/>
-                <nad:edge diagramId="68" equipmentId="L37-39-1"/>
-                <nad:edge diagramId="71" equipmentId="L37-40-1"/>
-                <nad:edge diagramId="72" equipmentId="T38-37-1"/>
-                <nad:edge diagramId="73" equipmentId="L38-65-1"/>
-                <nad:edge diagramId="76" equipmentId="L64-65-1"/>
-                <nad:edge diagramId="79" equipmentId="L65-68-1"/>
-                <nad:edge diagramId="82" equipmentId="T65-66-1"/>
+                <nad:edge svgId="22" equipmentId="L17-113-1"/>
+                <nad:edge svgId="23" equipmentId="L32-113-1"/>
+                <nad:edge svgId="24" equipmentId="L32-114-1"/>
+                <nad:edge svgId="27" equipmentId="L114-115-1"/>
+                <nad:edge svgId="30" equipmentId="L22-23-1"/>
+                <nad:edge svgId="33" equipmentId="L23-24-1"/>
+                <nad:edge svgId="36" equipmentId="L23-25-1"/>
+                <nad:edge svgId="37" equipmentId="L23-32-1"/>
+                <nad:edge svgId="38" equipmentId="L25-27-1"/>
+                <nad:edge svgId="41" equipmentId="L27-28-1"/>
+                <nad:edge svgId="42" equipmentId="L27-32-1"/>
+                <nad:edge svgId="43" equipmentId="L27-115-1"/>
+                <nad:edge svgId="46" equipmentId="L8-30-1"/>
+                <nad:edge svgId="49" equipmentId="L26-30-1"/>
+                <nad:edge svgId="50" equipmentId="L30-38-1"/>
+                <nad:edge svgId="51" equipmentId="T30-17-1"/>
+                <nad:edge svgId="52" equipmentId="L17-31-1"/>
+                <nad:edge svgId="55" equipmentId="L29-31-1"/>
+                <nad:edge svgId="56" equipmentId="L31-32-1"/>
+                <nad:edge svgId="59" equipmentId="L35-37-1"/>
+                <nad:edge svgId="62" equipmentId="L33-37-1"/>
+                <nad:edge svgId="65" equipmentId="L34-37-1"/>
+                <nad:edge svgId="68" equipmentId="L37-39-1"/>
+                <nad:edge svgId="71" equipmentId="L37-40-1"/>
+                <nad:edge svgId="72" equipmentId="T38-37-1"/>
+                <nad:edge svgId="73" equipmentId="L38-65-1"/>
+                <nad:edge svgId="76" equipmentId="L64-65-1"/>
+                <nad:edge svgId="79" equipmentId="L65-68-1"/>
+                <nad:edge svgId="82" equipmentId="T65-66-1"/>
             </nad:edges>
         </nad:nad>
     </metadata>

--- a/network-area-diagram/src/test/resources/IEEE_118_bus_partial_non_connected.svg
+++ b/network-area-diagram/src/test/resources/IEEE_118_bus_partial_non_connected.svg
@@ -114,33 +114,33 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="VL113_0" x="-178.77" y="407.56"/>
-                <nad:busNode diagramId="3" equipmentId="VL114_0" x="-641.86" y="1404.47"/>
-                <nad:busNode diagramId="5" equipmentId="VL23_0" x="95.73" y="1251.53"/>
-                <nad:busNode diagramId="7" equipmentId="VL27_0" x="-777.31" y="1072.53"/>
-                <nad:busNode diagramId="9" equipmentId="VL30_0" x="158.89" y="-689.41"/>
-                <nad:busNode diagramId="11" equipmentId="VL31_0" x="-609.09" y="288.76"/>
-                <nad:busNode diagramId="13" equipmentId="VL32_0" x="-399.08" y="854.10"/>
-                <nad:busNode diagramId="15" equipmentId="VL37_0" x="1109.61" y="-122.88"/>
-                <nad:busNode diagramId="17" equipmentId="VL38_0" x="393.66" y="-484.06"/>
-                <nad:busNode diagramId="19" equipmentId="VL65_0" x="-335.40" y="-921.45"/>
-                <nad:busNode diagramId="21" equipmentId="VL17_0" x="-205.59" y="-64.00"/>
-                <nad:busNode diagramId="26" equipmentId="VL115_0" x="-991.06" y="1448.86"/>
-                <nad:busNode diagramId="29" equipmentId="VL22_0" x="288.14" y="1671.63"/>
-                <nad:busNode diagramId="32" equipmentId="VL24_0" x="539.83" y="1234.73"/>
-                <nad:busNode diagramId="35" equipmentId="VL25_0" x="-281.45" y="1289.33"/>
-                <nad:busNode diagramId="40" equipmentId="VL28_0" x="-1213.35" y="929.27"/>
-                <nad:busNode diagramId="45" equipmentId="VL8_0" x="203.29" y="-1160.79"/>
-                <nad:busNode diagramId="48" equipmentId="VL26_0" x="574.78" y="-961.99"/>
-                <nad:busNode diagramId="54" equipmentId="VL29_0" x="-1033.90" y="140.31"/>
-                <nad:busNode diagramId="58" equipmentId="VL35_0" x="988.11" y="322.96"/>
-                <nad:busNode diagramId="61" equipmentId="VL33_0" x="1425.97" y="280.88"/>
-                <nad:busNode diagramId="64" equipmentId="VL34_0" x="770.45" y="-110.26"/>
-                <nad:busNode diagramId="67" equipmentId="VL39_0" x="1321.52" y="-523.30"/>
-                <nad:busNode diagramId="70" equipmentId="VL40_0" x="1591.73" y="-138.04"/>
-                <nad:busNode diagramId="75" equipmentId="VL64_0" x="-350.07" y="-1381.18"/>
-                <nad:busNode diagramId="78" equipmentId="VL68_0" x="-766.93" y="-1158.44"/>
-                <nad:busNode diagramId="81" equipmentId="VL66_0" x="-706.77" y="-708.71"/>
+                <nad:busNode diagramId="1" equipmentId="VL113_0"/>
+                <nad:busNode diagramId="3" equipmentId="VL114_0"/>
+                <nad:busNode diagramId="5" equipmentId="VL23_0"/>
+                <nad:busNode diagramId="7" equipmentId="VL27_0"/>
+                <nad:busNode diagramId="9" equipmentId="VL30_0"/>
+                <nad:busNode diagramId="11" equipmentId="VL31_0"/>
+                <nad:busNode diagramId="13" equipmentId="VL32_0"/>
+                <nad:busNode diagramId="15" equipmentId="VL37_0"/>
+                <nad:busNode diagramId="17" equipmentId="VL38_0"/>
+                <nad:busNode diagramId="19" equipmentId="VL65_0"/>
+                <nad:busNode diagramId="21" equipmentId="VL17_0"/>
+                <nad:busNode diagramId="26" equipmentId="VL115_0"/>
+                <nad:busNode diagramId="29" equipmentId="VL22_0"/>
+                <nad:busNode diagramId="32" equipmentId="VL24_0"/>
+                <nad:busNode diagramId="35" equipmentId="VL25_0"/>
+                <nad:busNode diagramId="40" equipmentId="VL28_0"/>
+                <nad:busNode diagramId="45" equipmentId="VL8_0"/>
+                <nad:busNode diagramId="48" equipmentId="VL26_0"/>
+                <nad:busNode diagramId="54" equipmentId="VL29_0"/>
+                <nad:busNode diagramId="58" equipmentId="VL35_0"/>
+                <nad:busNode diagramId="61" equipmentId="VL33_0"/>
+                <nad:busNode diagramId="64" equipmentId="VL34_0"/>
+                <nad:busNode diagramId="67" equipmentId="VL39_0"/>
+                <nad:busNode diagramId="70" equipmentId="VL40_0"/>
+                <nad:busNode diagramId="75" equipmentId="VL64_0"/>
+                <nad:busNode diagramId="78" equipmentId="VL68_0"/>
+                <nad:busNode diagramId="81" equipmentId="VL66_0"/>
             </nad:busNodes>
             <nad:nodes>
                 <nad:node diagramId="0" equipmentId="VL113" x="-178.77" y="407.56"/>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus.svg
@@ -49,58 +49,58 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="VL1_0"/>
-                <nad:busNode diagramId="3" equipmentId="VL10_0"/>
-                <nad:busNode diagramId="5" equipmentId="VL11_0"/>
-                <nad:busNode diagramId="7" equipmentId="VL12_0"/>
-                <nad:busNode diagramId="9" equipmentId="VL13_0"/>
-                <nad:busNode diagramId="11" equipmentId="VL14_0"/>
-                <nad:busNode diagramId="13" equipmentId="VL2_0"/>
-                <nad:busNode diagramId="15" equipmentId="VL3_0"/>
-                <nad:busNode diagramId="17" equipmentId="VL4_0"/>
-                <nad:busNode diagramId="19" equipmentId="VL5_0"/>
-                <nad:busNode diagramId="21" equipmentId="VL6_0"/>
-                <nad:busNode diagramId="23" equipmentId="VL7_0"/>
-                <nad:busNode diagramId="25" equipmentId="VL8_0"/>
-                <nad:busNode diagramId="27" equipmentId="VL9_0"/>
+                <nad:busNode svgId="1" equipmentId="VL1_0"/>
+                <nad:busNode svgId="3" equipmentId="VL10_0"/>
+                <nad:busNode svgId="5" equipmentId="VL11_0"/>
+                <nad:busNode svgId="7" equipmentId="VL12_0"/>
+                <nad:busNode svgId="9" equipmentId="VL13_0"/>
+                <nad:busNode svgId="11" equipmentId="VL14_0"/>
+                <nad:busNode svgId="13" equipmentId="VL2_0"/>
+                <nad:busNode svgId="15" equipmentId="VL3_0"/>
+                <nad:busNode svgId="17" equipmentId="VL4_0"/>
+                <nad:busNode svgId="19" equipmentId="VL5_0"/>
+                <nad:busNode svgId="21" equipmentId="VL6_0"/>
+                <nad:busNode svgId="23" equipmentId="VL7_0"/>
+                <nad:busNode svgId="25" equipmentId="VL8_0"/>
+                <nad:busNode svgId="27" equipmentId="VL9_0"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node diagramId="0" equipmentId="VL1" x="517.01" y="-642.50"/>
-                <nad:node diagramId="2" equipmentId="VL10" x="-518.51" y="516.42"/>
-                <nad:node diagramId="4" equipmentId="VL11" x="-720.95" y="118.61"/>
-                <nad:node diagramId="6" equipmentId="VL12" x="-635.66" y="-662.83"/>
-                <nad:node diagramId="8" equipmentId="VL13" x="-630.18" y="-297.82"/>
-                <nad:node diagramId="10" equipmentId="VL14" x="-308.48" y="92.20"/>
-                <nad:node diagramId="12" equipmentId="VL2" x="596.05" y="-263.35"/>
-                <nad:node diagramId="14" equipmentId="VL3" x="827.88" y="25.42"/>
-                <nad:node diagramId="16" equipmentId="VL4" x="405.95" y="123.38"/>
-                <nad:node diagramId="18" equipmentId="VL5" x="225.14" y="-349.97"/>
-                <nad:node diagramId="20" equipmentId="VL6" x="-336.09" y="-378.75"/>
-                <nad:node diagramId="22" equipmentId="VL7" x="369.06" y="599.72"/>
-                <nad:node diagramId="24" equipmentId="VL8" x="568.63" y="975.46"/>
-                <nad:node diagramId="26" equipmentId="VL9" x="-23.76" y="416.70"/>
+                <nad:node svgId="0" equipmentId="VL1" x="517.01" y="-642.50"/>
+                <nad:node svgId="2" equipmentId="VL10" x="-518.51" y="516.42"/>
+                <nad:node svgId="4" equipmentId="VL11" x="-720.95" y="118.61"/>
+                <nad:node svgId="6" equipmentId="VL12" x="-635.66" y="-662.83"/>
+                <nad:node svgId="8" equipmentId="VL13" x="-630.18" y="-297.82"/>
+                <nad:node svgId="10" equipmentId="VL14" x="-308.48" y="92.20"/>
+                <nad:node svgId="12" equipmentId="VL2" x="596.05" y="-263.35"/>
+                <nad:node svgId="14" equipmentId="VL3" x="827.88" y="25.42"/>
+                <nad:node svgId="16" equipmentId="VL4" x="405.95" y="123.38"/>
+                <nad:node svgId="18" equipmentId="VL5" x="225.14" y="-349.97"/>
+                <nad:node svgId="20" equipmentId="VL6" x="-336.09" y="-378.75"/>
+                <nad:node svgId="22" equipmentId="VL7" x="369.06" y="599.72"/>
+                <nad:node svgId="24" equipmentId="VL8" x="568.63" y="975.46"/>
+                <nad:node svgId="26" equipmentId="VL9" x="-23.76" y="416.70"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge diagramId="28" equipmentId="L1-2-1"/>
-                <nad:edge diagramId="29" equipmentId="L1-5-1"/>
-                <nad:edge diagramId="30" equipmentId="L9-10-1"/>
-                <nad:edge diagramId="31" equipmentId="L10-11-1"/>
-                <nad:edge diagramId="32" equipmentId="L6-11-1"/>
-                <nad:edge diagramId="33" equipmentId="L6-12-1"/>
-                <nad:edge diagramId="34" equipmentId="L12-13-1"/>
-                <nad:edge diagramId="35" equipmentId="L6-13-1"/>
-                <nad:edge diagramId="36" equipmentId="L13-14-1"/>
-                <nad:edge diagramId="37" equipmentId="L9-14-1"/>
-                <nad:edge diagramId="38" equipmentId="L2-3-1"/>
-                <nad:edge diagramId="39" equipmentId="L2-4-1"/>
-                <nad:edge diagramId="40" equipmentId="L2-5-1"/>
-                <nad:edge diagramId="41" equipmentId="L3-4-1"/>
-                <nad:edge diagramId="42" equipmentId="L4-5-1"/>
-                <nad:edge diagramId="43" equipmentId="T4-7-1"/>
-                <nad:edge diagramId="44" equipmentId="T4-9-1"/>
-                <nad:edge diagramId="45" equipmentId="T5-6-1"/>
-                <nad:edge diagramId="46" equipmentId="L7-8-1"/>
-                <nad:edge diagramId="47" equipmentId="L7-9-1"/>
+                <nad:edge svgId="28" equipmentId="L1-2-1"/>
+                <nad:edge svgId="29" equipmentId="L1-5-1"/>
+                <nad:edge svgId="30" equipmentId="L9-10-1"/>
+                <nad:edge svgId="31" equipmentId="L10-11-1"/>
+                <nad:edge svgId="32" equipmentId="L6-11-1"/>
+                <nad:edge svgId="33" equipmentId="L6-12-1"/>
+                <nad:edge svgId="34" equipmentId="L12-13-1"/>
+                <nad:edge svgId="35" equipmentId="L6-13-1"/>
+                <nad:edge svgId="36" equipmentId="L13-14-1"/>
+                <nad:edge svgId="37" equipmentId="L9-14-1"/>
+                <nad:edge svgId="38" equipmentId="L2-3-1"/>
+                <nad:edge svgId="39" equipmentId="L2-4-1"/>
+                <nad:edge svgId="40" equipmentId="L2-5-1"/>
+                <nad:edge svgId="41" equipmentId="L3-4-1"/>
+                <nad:edge svgId="42" equipmentId="L4-5-1"/>
+                <nad:edge svgId="43" equipmentId="T4-7-1"/>
+                <nad:edge svgId="44" equipmentId="T4-9-1"/>
+                <nad:edge svgId="45" equipmentId="T5-6-1"/>
+                <nad:edge svgId="46" equipmentId="L7-8-1"/>
+                <nad:edge svgId="47" equipmentId="L7-9-1"/>
             </nad:edges>
         </nad:nad>
     </metadata>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus.svg
@@ -49,20 +49,20 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="VL1_0" x="517.01" y="-642.50"/>
-                <nad:busNode diagramId="3" equipmentId="VL10_0" x="-518.51" y="516.42"/>
-                <nad:busNode diagramId="5" equipmentId="VL11_0" x="-720.95" y="118.61"/>
-                <nad:busNode diagramId="7" equipmentId="VL12_0" x="-635.66" y="-662.83"/>
-                <nad:busNode diagramId="9" equipmentId="VL13_0" x="-630.18" y="-297.82"/>
-                <nad:busNode diagramId="11" equipmentId="VL14_0" x="-308.48" y="92.20"/>
-                <nad:busNode diagramId="13" equipmentId="VL2_0" x="596.05" y="-263.35"/>
-                <nad:busNode diagramId="15" equipmentId="VL3_0" x="827.88" y="25.42"/>
-                <nad:busNode diagramId="17" equipmentId="VL4_0" x="405.95" y="123.38"/>
-                <nad:busNode diagramId="19" equipmentId="VL5_0" x="225.14" y="-349.97"/>
-                <nad:busNode diagramId="21" equipmentId="VL6_0" x="-336.09" y="-378.75"/>
-                <nad:busNode diagramId="23" equipmentId="VL7_0" x="369.06" y="599.72"/>
-                <nad:busNode diagramId="25" equipmentId="VL8_0" x="568.63" y="975.46"/>
-                <nad:busNode diagramId="27" equipmentId="VL9_0" x="-23.76" y="416.70"/>
+                <nad:busNode diagramId="1" equipmentId="VL1_0"/>
+                <nad:busNode diagramId="3" equipmentId="VL10_0"/>
+                <nad:busNode diagramId="5" equipmentId="VL11_0"/>
+                <nad:busNode diagramId="7" equipmentId="VL12_0"/>
+                <nad:busNode diagramId="9" equipmentId="VL13_0"/>
+                <nad:busNode diagramId="11" equipmentId="VL14_0"/>
+                <nad:busNode diagramId="13" equipmentId="VL2_0"/>
+                <nad:busNode diagramId="15" equipmentId="VL3_0"/>
+                <nad:busNode diagramId="17" equipmentId="VL4_0"/>
+                <nad:busNode diagramId="19" equipmentId="VL5_0"/>
+                <nad:busNode diagramId="21" equipmentId="VL6_0"/>
+                <nad:busNode diagramId="23" equipmentId="VL7_0"/>
+                <nad:busNode diagramId="25" equipmentId="VL8_0"/>
+                <nad:busNode diagramId="27" equipmentId="VL9_0"/>
             </nad:busNodes>
             <nad:nodes>
                 <nad:node diagramId="0" equipmentId="VL1" x="517.01" y="-642.50"/>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_disconnection.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_disconnection.svg
@@ -49,57 +49,57 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="VL1_0"/>
-                <nad:busNode diagramId="3" equipmentId="VL10_0"/>
-                <nad:busNode diagramId="5" equipmentId="VL11_0"/>
-                <nad:busNode diagramId="7" equipmentId="VL12_0"/>
-                <nad:busNode diagramId="9" equipmentId="VL13_0"/>
-                <nad:busNode diagramId="12" equipmentId="VL2_0"/>
-                <nad:busNode diagramId="14" equipmentId="VL3_0"/>
-                <nad:busNode diagramId="16" equipmentId="VL4_0"/>
-                <nad:busNode diagramId="18" equipmentId="VL5_0"/>
-                <nad:busNode diagramId="20" equipmentId="VL6_0"/>
-                <nad:busNode diagramId="22" equipmentId="VL7_0"/>
-                <nad:busNode diagramId="24" equipmentId="VL8_0"/>
-                <nad:busNode diagramId="26" equipmentId="VL9_0"/>
+                <nad:busNode svgId="1" equipmentId="VL1_0"/>
+                <nad:busNode svgId="3" equipmentId="VL10_0"/>
+                <nad:busNode svgId="5" equipmentId="VL11_0"/>
+                <nad:busNode svgId="7" equipmentId="VL12_0"/>
+                <nad:busNode svgId="9" equipmentId="VL13_0"/>
+                <nad:busNode svgId="12" equipmentId="VL2_0"/>
+                <nad:busNode svgId="14" equipmentId="VL3_0"/>
+                <nad:busNode svgId="16" equipmentId="VL4_0"/>
+                <nad:busNode svgId="18" equipmentId="VL5_0"/>
+                <nad:busNode svgId="20" equipmentId="VL6_0"/>
+                <nad:busNode svgId="22" equipmentId="VL7_0"/>
+                <nad:busNode svgId="24" equipmentId="VL8_0"/>
+                <nad:busNode svgId="26" equipmentId="VL9_0"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node diagramId="0" equipmentId="VL1" x="517.01" y="-642.50"/>
-                <nad:node diagramId="2" equipmentId="VL10" x="-518.51" y="516.42"/>
-                <nad:node diagramId="4" equipmentId="VL11" x="-720.95" y="118.61"/>
-                <nad:node diagramId="6" equipmentId="VL12" x="-635.66" y="-662.83"/>
-                <nad:node diagramId="8" equipmentId="VL13" x="-630.18" y="-297.82"/>
-                <nad:node diagramId="10" equipmentId="VL14" x="-308.48" y="92.20"/>
-                <nad:node diagramId="11" equipmentId="VL2" x="596.05" y="-263.35"/>
-                <nad:node diagramId="13" equipmentId="VL3" x="827.88" y="25.42"/>
-                <nad:node diagramId="15" equipmentId="VL4" x="405.95" y="123.38"/>
-                <nad:node diagramId="17" equipmentId="VL5" x="225.14" y="-349.97"/>
-                <nad:node diagramId="19" equipmentId="VL6" x="-336.09" y="-378.75"/>
-                <nad:node diagramId="21" equipmentId="VL7" x="369.06" y="599.72"/>
-                <nad:node diagramId="23" equipmentId="VL8" x="568.63" y="975.46"/>
-                <nad:node diagramId="25" equipmentId="VL9" x="-23.76" y="416.70"/>
+                <nad:node svgId="0" equipmentId="VL1" x="517.01" y="-642.50"/>
+                <nad:node svgId="2" equipmentId="VL10" x="-518.51" y="516.42"/>
+                <nad:node svgId="4" equipmentId="VL11" x="-720.95" y="118.61"/>
+                <nad:node svgId="6" equipmentId="VL12" x="-635.66" y="-662.83"/>
+                <nad:node svgId="8" equipmentId="VL13" x="-630.18" y="-297.82"/>
+                <nad:node svgId="10" equipmentId="VL14" x="-308.48" y="92.20"/>
+                <nad:node svgId="11" equipmentId="VL2" x="596.05" y="-263.35"/>
+                <nad:node svgId="13" equipmentId="VL3" x="827.88" y="25.42"/>
+                <nad:node svgId="15" equipmentId="VL4" x="405.95" y="123.38"/>
+                <nad:node svgId="17" equipmentId="VL5" x="225.14" y="-349.97"/>
+                <nad:node svgId="19" equipmentId="VL6" x="-336.09" y="-378.75"/>
+                <nad:node svgId="21" equipmentId="VL7" x="369.06" y="599.72"/>
+                <nad:node svgId="23" equipmentId="VL8" x="568.63" y="975.46"/>
+                <nad:node svgId="25" equipmentId="VL9" x="-23.76" y="416.70"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge diagramId="27" equipmentId="L1-2-1"/>
-                <nad:edge diagramId="28" equipmentId="L1-5-1"/>
-                <nad:edge diagramId="29" equipmentId="L9-10-1"/>
-                <nad:edge diagramId="30" equipmentId="L10-11-1"/>
-                <nad:edge diagramId="31" equipmentId="L6-11-1"/>
-                <nad:edge diagramId="32" equipmentId="L6-12-1"/>
-                <nad:edge diagramId="33" equipmentId="L12-13-1"/>
-                <nad:edge diagramId="34" equipmentId="L6-13-1"/>
-                <nad:edge diagramId="35" equipmentId="L13-14-1"/>
-                <nad:edge diagramId="36" equipmentId="L9-14-1"/>
-                <nad:edge diagramId="37" equipmentId="L2-3-1"/>
-                <nad:edge diagramId="38" equipmentId="L2-4-1"/>
-                <nad:edge diagramId="39" equipmentId="L2-5-1"/>
-                <nad:edge diagramId="40" equipmentId="L3-4-1"/>
-                <nad:edge diagramId="41" equipmentId="L4-5-1"/>
-                <nad:edge diagramId="42" equipmentId="T4-7-1"/>
-                <nad:edge diagramId="43" equipmentId="T4-9-1"/>
-                <nad:edge diagramId="44" equipmentId="T5-6-1"/>
-                <nad:edge diagramId="45" equipmentId="L7-8-1"/>
-                <nad:edge diagramId="46" equipmentId="L7-9-1"/>
+                <nad:edge svgId="27" equipmentId="L1-2-1"/>
+                <nad:edge svgId="28" equipmentId="L1-5-1"/>
+                <nad:edge svgId="29" equipmentId="L9-10-1"/>
+                <nad:edge svgId="30" equipmentId="L10-11-1"/>
+                <nad:edge svgId="31" equipmentId="L6-11-1"/>
+                <nad:edge svgId="32" equipmentId="L6-12-1"/>
+                <nad:edge svgId="33" equipmentId="L12-13-1"/>
+                <nad:edge svgId="34" equipmentId="L6-13-1"/>
+                <nad:edge svgId="35" equipmentId="L13-14-1"/>
+                <nad:edge svgId="36" equipmentId="L9-14-1"/>
+                <nad:edge svgId="37" equipmentId="L2-3-1"/>
+                <nad:edge svgId="38" equipmentId="L2-4-1"/>
+                <nad:edge svgId="39" equipmentId="L2-5-1"/>
+                <nad:edge svgId="40" equipmentId="L3-4-1"/>
+                <nad:edge svgId="41" equipmentId="L4-5-1"/>
+                <nad:edge svgId="42" equipmentId="T4-7-1"/>
+                <nad:edge svgId="43" equipmentId="T4-9-1"/>
+                <nad:edge svgId="44" equipmentId="T5-6-1"/>
+                <nad:edge svgId="45" equipmentId="L7-8-1"/>
+                <nad:edge svgId="46" equipmentId="L7-9-1"/>
             </nad:edges>
         </nad:nad>
     </metadata>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_disconnection.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_disconnection.svg
@@ -49,19 +49,19 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="VL1_0" x="517.01" y="-642.50"/>
-                <nad:busNode diagramId="3" equipmentId="VL10_0" x="-518.51" y="516.42"/>
-                <nad:busNode diagramId="5" equipmentId="VL11_0" x="-720.95" y="118.61"/>
-                <nad:busNode diagramId="7" equipmentId="VL12_0" x="-635.66" y="-662.83"/>
-                <nad:busNode diagramId="9" equipmentId="VL13_0" x="-630.18" y="-297.82"/>
-                <nad:busNode diagramId="12" equipmentId="VL2_0" x="596.05" y="-263.35"/>
-                <nad:busNode diagramId="14" equipmentId="VL3_0" x="827.88" y="25.42"/>
-                <nad:busNode diagramId="16" equipmentId="VL4_0" x="405.95" y="123.38"/>
-                <nad:busNode diagramId="18" equipmentId="VL5_0" x="225.14" y="-349.97"/>
-                <nad:busNode diagramId="20" equipmentId="VL6_0" x="-336.09" y="-378.75"/>
-                <nad:busNode diagramId="22" equipmentId="VL7_0" x="369.06" y="599.72"/>
-                <nad:busNode diagramId="24" equipmentId="VL8_0" x="568.63" y="975.46"/>
-                <nad:busNode diagramId="26" equipmentId="VL9_0" x="-23.76" y="416.70"/>
+                <nad:busNode diagramId="1" equipmentId="VL1_0"/>
+                <nad:busNode diagramId="3" equipmentId="VL10_0"/>
+                <nad:busNode diagramId="5" equipmentId="VL11_0"/>
+                <nad:busNode diagramId="7" equipmentId="VL12_0"/>
+                <nad:busNode diagramId="9" equipmentId="VL13_0"/>
+                <nad:busNode diagramId="12" equipmentId="VL2_0"/>
+                <nad:busNode diagramId="14" equipmentId="VL3_0"/>
+                <nad:busNode diagramId="16" equipmentId="VL4_0"/>
+                <nad:busNode diagramId="18" equipmentId="VL5_0"/>
+                <nad:busNode diagramId="20" equipmentId="VL6_0"/>
+                <nad:busNode diagramId="22" equipmentId="VL7_0"/>
+                <nad:busNode diagramId="24" equipmentId="VL8_0"/>
+                <nad:busNode diagramId="26" equipmentId="VL9_0"/>
             </nad:busNodes>
             <nad:nodes>
                 <nad:node diagramId="0" equipmentId="VL1" x="517.01" y="-642.50"/>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_fictitious.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_fictitious.svg
@@ -49,58 +49,58 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="VL1_0"/>
-                <nad:busNode diagramId="3" equipmentId="VL10_0"/>
-                <nad:busNode diagramId="5" equipmentId="VL11_0"/>
-                <nad:busNode diagramId="7" equipmentId="VL12_0"/>
-                <nad:busNode diagramId="9" equipmentId="VL13_0"/>
-                <nad:busNode diagramId="11" equipmentId="VL14_0"/>
-                <nad:busNode diagramId="13" equipmentId="VL2_0"/>
-                <nad:busNode diagramId="15" equipmentId="VL3_0"/>
-                <nad:busNode diagramId="17" equipmentId="VL4_0"/>
-                <nad:busNode diagramId="19" equipmentId="VL5_0"/>
-                <nad:busNode diagramId="21" equipmentId="VL6_0"/>
-                <nad:busNode diagramId="23" equipmentId="VL7_0"/>
-                <nad:busNode diagramId="25" equipmentId="VL8_0"/>
-                <nad:busNode diagramId="27" equipmentId="VL9_0"/>
+                <nad:busNode svgId="1" equipmentId="VL1_0"/>
+                <nad:busNode svgId="3" equipmentId="VL10_0"/>
+                <nad:busNode svgId="5" equipmentId="VL11_0"/>
+                <nad:busNode svgId="7" equipmentId="VL12_0"/>
+                <nad:busNode svgId="9" equipmentId="VL13_0"/>
+                <nad:busNode svgId="11" equipmentId="VL14_0"/>
+                <nad:busNode svgId="13" equipmentId="VL2_0"/>
+                <nad:busNode svgId="15" equipmentId="VL3_0"/>
+                <nad:busNode svgId="17" equipmentId="VL4_0"/>
+                <nad:busNode svgId="19" equipmentId="VL5_0"/>
+                <nad:busNode svgId="21" equipmentId="VL6_0"/>
+                <nad:busNode svgId="23" equipmentId="VL7_0"/>
+                <nad:busNode svgId="25" equipmentId="VL8_0"/>
+                <nad:busNode svgId="27" equipmentId="VL9_0"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node diagramId="0" equipmentId="VL1" x="517.01" y="-642.50"/>
-                <nad:node diagramId="2" equipmentId="VL10" x="-518.51" y="516.42"/>
-                <nad:node diagramId="4" equipmentId="VL11" x="-720.95" y="118.61"/>
-                <nad:node diagramId="6" equipmentId="VL12" x="-635.66" y="-662.83"/>
-                <nad:node diagramId="8" equipmentId="VL13" x="-630.18" y="-297.82"/>
-                <nad:node diagramId="10" equipmentId="VL14" x="-308.48" y="92.20"/>
-                <nad:node diagramId="12" equipmentId="VL2" x="596.05" y="-263.35"/>
-                <nad:node diagramId="14" equipmentId="VL3" x="827.88" y="25.42"/>
-                <nad:node diagramId="16" equipmentId="VL4" x="405.95" y="123.38"/>
-                <nad:node diagramId="18" equipmentId="VL5" x="225.14" y="-349.97"/>
-                <nad:node diagramId="20" equipmentId="VL6" x="-336.09" y="-378.75"/>
-                <nad:node diagramId="22" equipmentId="VL7" x="369.06" y="599.72"/>
-                <nad:node diagramId="24" equipmentId="VL8" x="568.63" y="975.46"/>
-                <nad:node diagramId="26" equipmentId="VL9" x="-23.76" y="416.70"/>
+                <nad:node svgId="0" equipmentId="VL1" x="517.01" y="-642.50"/>
+                <nad:node svgId="2" equipmentId="VL10" x="-518.51" y="516.42"/>
+                <nad:node svgId="4" equipmentId="VL11" x="-720.95" y="118.61"/>
+                <nad:node svgId="6" equipmentId="VL12" x="-635.66" y="-662.83"/>
+                <nad:node svgId="8" equipmentId="VL13" x="-630.18" y="-297.82"/>
+                <nad:node svgId="10" equipmentId="VL14" x="-308.48" y="92.20"/>
+                <nad:node svgId="12" equipmentId="VL2" x="596.05" y="-263.35"/>
+                <nad:node svgId="14" equipmentId="VL3" x="827.88" y="25.42"/>
+                <nad:node svgId="16" equipmentId="VL4" x="405.95" y="123.38"/>
+                <nad:node svgId="18" equipmentId="VL5" x="225.14" y="-349.97"/>
+                <nad:node svgId="20" equipmentId="VL6" x="-336.09" y="-378.75"/>
+                <nad:node svgId="22" equipmentId="VL7" x="369.06" y="599.72"/>
+                <nad:node svgId="24" equipmentId="VL8" x="568.63" y="975.46"/>
+                <nad:node svgId="26" equipmentId="VL9" x="-23.76" y="416.70"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge diagramId="28" equipmentId="L1-2-1"/>
-                <nad:edge diagramId="29" equipmentId="L1-5-1"/>
-                <nad:edge diagramId="30" equipmentId="L9-10-1"/>
-                <nad:edge diagramId="31" equipmentId="L10-11-1"/>
-                <nad:edge diagramId="32" equipmentId="L6-11-1"/>
-                <nad:edge diagramId="33" equipmentId="L6-12-1"/>
-                <nad:edge diagramId="34" equipmentId="L12-13-1"/>
-                <nad:edge diagramId="35" equipmentId="L6-13-1"/>
-                <nad:edge diagramId="36" equipmentId="L13-14-1"/>
-                <nad:edge diagramId="37" equipmentId="L9-14-1"/>
-                <nad:edge diagramId="38" equipmentId="L2-3-1"/>
-                <nad:edge diagramId="39" equipmentId="L2-4-1"/>
-                <nad:edge diagramId="40" equipmentId="L2-5-1"/>
-                <nad:edge diagramId="41" equipmentId="L3-4-1"/>
-                <nad:edge diagramId="42" equipmentId="L4-5-1"/>
-                <nad:edge diagramId="43" equipmentId="T4-7-1"/>
-                <nad:edge diagramId="44" equipmentId="T4-9-1"/>
-                <nad:edge diagramId="45" equipmentId="T5-6-1"/>
-                <nad:edge diagramId="46" equipmentId="L7-8-1"/>
-                <nad:edge diagramId="47" equipmentId="L7-9-1"/>
+                <nad:edge svgId="28" equipmentId="L1-2-1"/>
+                <nad:edge svgId="29" equipmentId="L1-5-1"/>
+                <nad:edge svgId="30" equipmentId="L9-10-1"/>
+                <nad:edge svgId="31" equipmentId="L10-11-1"/>
+                <nad:edge svgId="32" equipmentId="L6-11-1"/>
+                <nad:edge svgId="33" equipmentId="L6-12-1"/>
+                <nad:edge svgId="34" equipmentId="L12-13-1"/>
+                <nad:edge svgId="35" equipmentId="L6-13-1"/>
+                <nad:edge svgId="36" equipmentId="L13-14-1"/>
+                <nad:edge svgId="37" equipmentId="L9-14-1"/>
+                <nad:edge svgId="38" equipmentId="L2-3-1"/>
+                <nad:edge svgId="39" equipmentId="L2-4-1"/>
+                <nad:edge svgId="40" equipmentId="L2-5-1"/>
+                <nad:edge svgId="41" equipmentId="L3-4-1"/>
+                <nad:edge svgId="42" equipmentId="L4-5-1"/>
+                <nad:edge svgId="43" equipmentId="T4-7-1"/>
+                <nad:edge svgId="44" equipmentId="T4-9-1"/>
+                <nad:edge svgId="45" equipmentId="T5-6-1"/>
+                <nad:edge svgId="46" equipmentId="L7-8-1"/>
+                <nad:edge svgId="47" equipmentId="L7-9-1"/>
             </nad:edges>
         </nad:nad>
     </metadata>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_fictitious.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_fictitious.svg
@@ -49,20 +49,20 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="VL1_0" x="517.01" y="-642.50"/>
-                <nad:busNode diagramId="3" equipmentId="VL10_0" x="-518.51" y="516.42"/>
-                <nad:busNode diagramId="5" equipmentId="VL11_0" x="-720.95" y="118.61"/>
-                <nad:busNode diagramId="7" equipmentId="VL12_0" x="-635.66" y="-662.83"/>
-                <nad:busNode diagramId="9" equipmentId="VL13_0" x="-630.18" y="-297.82"/>
-                <nad:busNode diagramId="11" equipmentId="VL14_0" x="-308.48" y="92.20"/>
-                <nad:busNode diagramId="13" equipmentId="VL2_0" x="596.05" y="-263.35"/>
-                <nad:busNode diagramId="15" equipmentId="VL3_0" x="827.88" y="25.42"/>
-                <nad:busNode diagramId="17" equipmentId="VL4_0" x="405.95" y="123.38"/>
-                <nad:busNode diagramId="19" equipmentId="VL5_0" x="225.14" y="-349.97"/>
-                <nad:busNode diagramId="21" equipmentId="VL6_0" x="-336.09" y="-378.75"/>
-                <nad:busNode diagramId="23" equipmentId="VL7_0" x="369.06" y="599.72"/>
-                <nad:busNode diagramId="25" equipmentId="VL8_0" x="568.63" y="975.46"/>
-                <nad:busNode diagramId="27" equipmentId="VL9_0" x="-23.76" y="416.70"/>
+                <nad:busNode diagramId="1" equipmentId="VL1_0"/>
+                <nad:busNode diagramId="3" equipmentId="VL10_0"/>
+                <nad:busNode diagramId="5" equipmentId="VL11_0"/>
+                <nad:busNode diagramId="7" equipmentId="VL12_0"/>
+                <nad:busNode diagramId="9" equipmentId="VL13_0"/>
+                <nad:busNode diagramId="11" equipmentId="VL14_0"/>
+                <nad:busNode diagramId="13" equipmentId="VL2_0"/>
+                <nad:busNode diagramId="15" equipmentId="VL3_0"/>
+                <nad:busNode diagramId="17" equipmentId="VL4_0"/>
+                <nad:busNode diagramId="19" equipmentId="VL5_0"/>
+                <nad:busNode diagramId="21" equipmentId="VL6_0"/>
+                <nad:busNode diagramId="23" equipmentId="VL7_0"/>
+                <nad:busNode diagramId="25" equipmentId="VL8_0"/>
+                <nad:busNode diagramId="27" equipmentId="VL9_0"/>
             </nad:busNodes>
             <nad:nodes>
                 <nad:node diagramId="0" equipmentId="VL1" x="517.01" y="-642.50"/>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_text_nodes.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_text_nodes.svg
@@ -49,20 +49,20 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="VL1_0" x="979.43" y="495.57"/>
-                <nad:busNode diagramId="3" equipmentId="VL10_0" x="-1039.27" y="14.91"/>
-                <nad:busNode diagramId="5" equipmentId="VL11_0" x="-879.21" y="-478.53"/>
-                <nad:busNode diagramId="7" equipmentId="VL12_0" x="-111.97" y="-704.76"/>
-                <nad:busNode diagramId="9" equipmentId="VL13_0" x="-399.66" y="-132.95"/>
-                <nad:busNode diagramId="11" equipmentId="VL14_0" x="-711.89" y="460.94"/>
-                <nad:busNode diagramId="13" equipmentId="VL2_0" x="889.61" y="18.81"/>
-                <nad:busNode diagramId="15" equipmentId="VL3_0" x="536.13" y="-344.90"/>
-                <nad:busNode diagramId="17" equipmentId="VL4_0" x="358.14" y="151.61"/>
-                <nad:busNode diagramId="19" equipmentId="VL5_0" x="642.46" y="167.97"/>
-                <nad:busNode diagramId="21" equipmentId="VL6_0" x="-200.18" y="-394.87"/>
-                <nad:busNode diagramId="23" equipmentId="VL7_0" x="157.47" y="788.76"/>
-                <nad:busNode diagramId="25" equipmentId="VL8_0" x="468.63" y="1266.46"/>
-                <nad:busNode diagramId="27" equipmentId="VL9_0" x="-308.54" y="477.21"/>
+                <nad:busNode diagramId="1" equipmentId="VL1_0"/>
+                <nad:busNode diagramId="3" equipmentId="VL10_0"/>
+                <nad:busNode diagramId="5" equipmentId="VL11_0"/>
+                <nad:busNode diagramId="7" equipmentId="VL12_0"/>
+                <nad:busNode diagramId="9" equipmentId="VL13_0"/>
+                <nad:busNode diagramId="11" equipmentId="VL14_0"/>
+                <nad:busNode diagramId="13" equipmentId="VL2_0"/>
+                <nad:busNode diagramId="15" equipmentId="VL3_0"/>
+                <nad:busNode diagramId="17" equipmentId="VL4_0"/>
+                <nad:busNode diagramId="19" equipmentId="VL5_0"/>
+                <nad:busNode diagramId="21" equipmentId="VL6_0"/>
+                <nad:busNode diagramId="23" equipmentId="VL7_0"/>
+                <nad:busNode diagramId="25" equipmentId="VL8_0"/>
+                <nad:busNode diagramId="27" equipmentId="VL9_0"/>
             </nad:busNodes>
             <nad:nodes>
                 <nad:node diagramId="0" equipmentId="VL1" x="979.43" y="495.57"/>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_text_nodes.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_text_nodes.svg
@@ -49,58 +49,58 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="VL1_0"/>
-                <nad:busNode diagramId="3" equipmentId="VL10_0"/>
-                <nad:busNode diagramId="5" equipmentId="VL11_0"/>
-                <nad:busNode diagramId="7" equipmentId="VL12_0"/>
-                <nad:busNode diagramId="9" equipmentId="VL13_0"/>
-                <nad:busNode diagramId="11" equipmentId="VL14_0"/>
-                <nad:busNode diagramId="13" equipmentId="VL2_0"/>
-                <nad:busNode diagramId="15" equipmentId="VL3_0"/>
-                <nad:busNode diagramId="17" equipmentId="VL4_0"/>
-                <nad:busNode diagramId="19" equipmentId="VL5_0"/>
-                <nad:busNode diagramId="21" equipmentId="VL6_0"/>
-                <nad:busNode diagramId="23" equipmentId="VL7_0"/>
-                <nad:busNode diagramId="25" equipmentId="VL8_0"/>
-                <nad:busNode diagramId="27" equipmentId="VL9_0"/>
+                <nad:busNode svgId="1" equipmentId="VL1_0"/>
+                <nad:busNode svgId="3" equipmentId="VL10_0"/>
+                <nad:busNode svgId="5" equipmentId="VL11_0"/>
+                <nad:busNode svgId="7" equipmentId="VL12_0"/>
+                <nad:busNode svgId="9" equipmentId="VL13_0"/>
+                <nad:busNode svgId="11" equipmentId="VL14_0"/>
+                <nad:busNode svgId="13" equipmentId="VL2_0"/>
+                <nad:busNode svgId="15" equipmentId="VL3_0"/>
+                <nad:busNode svgId="17" equipmentId="VL4_0"/>
+                <nad:busNode svgId="19" equipmentId="VL5_0"/>
+                <nad:busNode svgId="21" equipmentId="VL6_0"/>
+                <nad:busNode svgId="23" equipmentId="VL7_0"/>
+                <nad:busNode svgId="25" equipmentId="VL8_0"/>
+                <nad:busNode svgId="27" equipmentId="VL9_0"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node diagramId="0" equipmentId="VL1" x="979.43" y="495.57"/>
-                <nad:node diagramId="2" equipmentId="VL10" x="-1039.27" y="14.91"/>
-                <nad:node diagramId="4" equipmentId="VL11" x="-879.21" y="-478.53"/>
-                <nad:node diagramId="6" equipmentId="VL12" x="-111.97" y="-704.76"/>
-                <nad:node diagramId="8" equipmentId="VL13" x="-399.66" y="-132.95"/>
-                <nad:node diagramId="10" equipmentId="VL14" x="-711.89" y="460.94"/>
-                <nad:node diagramId="12" equipmentId="VL2" x="889.61" y="18.81"/>
-                <nad:node diagramId="14" equipmentId="VL3" x="536.13" y="-344.90"/>
-                <nad:node diagramId="16" equipmentId="VL4" x="358.14" y="151.61"/>
-                <nad:node diagramId="18" equipmentId="VL5" x="642.46" y="167.97"/>
-                <nad:node diagramId="20" equipmentId="VL6" x="-200.18" y="-394.87"/>
-                <nad:node diagramId="22" equipmentId="VL7" x="157.47" y="788.76"/>
-                <nad:node diagramId="24" equipmentId="VL8" x="468.63" y="1266.46"/>
-                <nad:node diagramId="26" equipmentId="VL9" x="-308.54" y="477.21"/>
+                <nad:node svgId="0" equipmentId="VL1" x="979.43" y="495.57"/>
+                <nad:node svgId="2" equipmentId="VL10" x="-1039.27" y="14.91"/>
+                <nad:node svgId="4" equipmentId="VL11" x="-879.21" y="-478.53"/>
+                <nad:node svgId="6" equipmentId="VL12" x="-111.97" y="-704.76"/>
+                <nad:node svgId="8" equipmentId="VL13" x="-399.66" y="-132.95"/>
+                <nad:node svgId="10" equipmentId="VL14" x="-711.89" y="460.94"/>
+                <nad:node svgId="12" equipmentId="VL2" x="889.61" y="18.81"/>
+                <nad:node svgId="14" equipmentId="VL3" x="536.13" y="-344.90"/>
+                <nad:node svgId="16" equipmentId="VL4" x="358.14" y="151.61"/>
+                <nad:node svgId="18" equipmentId="VL5" x="642.46" y="167.97"/>
+                <nad:node svgId="20" equipmentId="VL6" x="-200.18" y="-394.87"/>
+                <nad:node svgId="22" equipmentId="VL7" x="157.47" y="788.76"/>
+                <nad:node svgId="24" equipmentId="VL8" x="468.63" y="1266.46"/>
+                <nad:node svgId="26" equipmentId="VL9" x="-308.54" y="477.21"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge diagramId="28" equipmentId="L1-2-1"/>
-                <nad:edge diagramId="29" equipmentId="L1-5-1"/>
-                <nad:edge diagramId="30" equipmentId="L9-10-1"/>
-                <nad:edge diagramId="31" equipmentId="L10-11-1"/>
-                <nad:edge diagramId="32" equipmentId="L6-11-1"/>
-                <nad:edge diagramId="33" equipmentId="L6-12-1"/>
-                <nad:edge diagramId="34" equipmentId="L12-13-1"/>
-                <nad:edge diagramId="35" equipmentId="L6-13-1"/>
-                <nad:edge diagramId="36" equipmentId="L13-14-1"/>
-                <nad:edge diagramId="37" equipmentId="L9-14-1"/>
-                <nad:edge diagramId="38" equipmentId="L2-3-1"/>
-                <nad:edge diagramId="39" equipmentId="L2-4-1"/>
-                <nad:edge diagramId="40" equipmentId="L2-5-1"/>
-                <nad:edge diagramId="41" equipmentId="L3-4-1"/>
-                <nad:edge diagramId="42" equipmentId="L4-5-1"/>
-                <nad:edge diagramId="43" equipmentId="T4-7-1"/>
-                <nad:edge diagramId="44" equipmentId="T4-9-1"/>
-                <nad:edge diagramId="45" equipmentId="T5-6-1"/>
-                <nad:edge diagramId="46" equipmentId="L7-8-1"/>
-                <nad:edge diagramId="47" equipmentId="L7-9-1"/>
+                <nad:edge svgId="28" equipmentId="L1-2-1"/>
+                <nad:edge svgId="29" equipmentId="L1-5-1"/>
+                <nad:edge svgId="30" equipmentId="L9-10-1"/>
+                <nad:edge svgId="31" equipmentId="L10-11-1"/>
+                <nad:edge svgId="32" equipmentId="L6-11-1"/>
+                <nad:edge svgId="33" equipmentId="L6-12-1"/>
+                <nad:edge svgId="34" equipmentId="L12-13-1"/>
+                <nad:edge svgId="35" equipmentId="L6-13-1"/>
+                <nad:edge svgId="36" equipmentId="L13-14-1"/>
+                <nad:edge svgId="37" equipmentId="L9-14-1"/>
+                <nad:edge svgId="38" equipmentId="L2-3-1"/>
+                <nad:edge svgId="39" equipmentId="L2-4-1"/>
+                <nad:edge svgId="40" equipmentId="L2-5-1"/>
+                <nad:edge svgId="41" equipmentId="L3-4-1"/>
+                <nad:edge svgId="42" equipmentId="L4-5-1"/>
+                <nad:edge svgId="43" equipmentId="T4-7-1"/>
+                <nad:edge svgId="44" equipmentId="T4-9-1"/>
+                <nad:edge svgId="45" equipmentId="T5-6-1"/>
+                <nad:edge svgId="46" equipmentId="L7-8-1"/>
+                <nad:edge svgId="47" equipmentId="L7-9-1"/>
             </nad:edges>
         </nad:nad>
     </metadata>

--- a/network-area-diagram/src/test/resources/IEEE_14_id_prefixed.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_id_prefixed.svg
@@ -49,58 +49,58 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="test_1" equipmentId="VL1_0"/>
-                <nad:busNode diagramId="test_3" equipmentId="VL10_0"/>
-                <nad:busNode diagramId="test_5" equipmentId="VL11_0"/>
-                <nad:busNode diagramId="test_7" equipmentId="VL12_0"/>
-                <nad:busNode diagramId="test_9" equipmentId="VL13_0"/>
-                <nad:busNode diagramId="test_11" equipmentId="VL14_0"/>
-                <nad:busNode diagramId="test_13" equipmentId="VL2_0"/>
-                <nad:busNode diagramId="test_15" equipmentId="VL3_0"/>
-                <nad:busNode diagramId="test_17" equipmentId="VL4_0"/>
-                <nad:busNode diagramId="test_19" equipmentId="VL5_0"/>
-                <nad:busNode diagramId="test_21" equipmentId="VL6_0"/>
-                <nad:busNode diagramId="test_23" equipmentId="VL7_0"/>
-                <nad:busNode diagramId="test_25" equipmentId="VL8_0"/>
-                <nad:busNode diagramId="test_27" equipmentId="VL9_0"/>
+                <nad:busNode svgId="test_1" equipmentId="VL1_0"/>
+                <nad:busNode svgId="test_3" equipmentId="VL10_0"/>
+                <nad:busNode svgId="test_5" equipmentId="VL11_0"/>
+                <nad:busNode svgId="test_7" equipmentId="VL12_0"/>
+                <nad:busNode svgId="test_9" equipmentId="VL13_0"/>
+                <nad:busNode svgId="test_11" equipmentId="VL14_0"/>
+                <nad:busNode svgId="test_13" equipmentId="VL2_0"/>
+                <nad:busNode svgId="test_15" equipmentId="VL3_0"/>
+                <nad:busNode svgId="test_17" equipmentId="VL4_0"/>
+                <nad:busNode svgId="test_19" equipmentId="VL5_0"/>
+                <nad:busNode svgId="test_21" equipmentId="VL6_0"/>
+                <nad:busNode svgId="test_23" equipmentId="VL7_0"/>
+                <nad:busNode svgId="test_25" equipmentId="VL8_0"/>
+                <nad:busNode svgId="test_27" equipmentId="VL9_0"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node diagramId="test_0" equipmentId="VL1" x="517.01" y="-642.50"/>
-                <nad:node diagramId="test_2" equipmentId="VL10" x="-518.51" y="516.42"/>
-                <nad:node diagramId="test_4" equipmentId="VL11" x="-720.95" y="118.61"/>
-                <nad:node diagramId="test_6" equipmentId="VL12" x="-635.66" y="-662.83"/>
-                <nad:node diagramId="test_8" equipmentId="VL13" x="-630.18" y="-297.82"/>
-                <nad:node diagramId="test_10" equipmentId="VL14" x="-308.48" y="92.20"/>
-                <nad:node diagramId="test_12" equipmentId="VL2" x="596.05" y="-263.35"/>
-                <nad:node diagramId="test_14" equipmentId="VL3" x="827.88" y="25.42"/>
-                <nad:node diagramId="test_16" equipmentId="VL4" x="405.95" y="123.38"/>
-                <nad:node diagramId="test_18" equipmentId="VL5" x="225.14" y="-349.97"/>
-                <nad:node diagramId="test_20" equipmentId="VL6" x="-336.09" y="-378.75"/>
-                <nad:node diagramId="test_22" equipmentId="VL7" x="369.06" y="599.72"/>
-                <nad:node diagramId="test_24" equipmentId="VL8" x="568.63" y="975.46"/>
-                <nad:node diagramId="test_26" equipmentId="VL9" x="-23.76" y="416.70"/>
+                <nad:node svgId="test_0" equipmentId="VL1" x="517.01" y="-642.50"/>
+                <nad:node svgId="test_2" equipmentId="VL10" x="-518.51" y="516.42"/>
+                <nad:node svgId="test_4" equipmentId="VL11" x="-720.95" y="118.61"/>
+                <nad:node svgId="test_6" equipmentId="VL12" x="-635.66" y="-662.83"/>
+                <nad:node svgId="test_8" equipmentId="VL13" x="-630.18" y="-297.82"/>
+                <nad:node svgId="test_10" equipmentId="VL14" x="-308.48" y="92.20"/>
+                <nad:node svgId="test_12" equipmentId="VL2" x="596.05" y="-263.35"/>
+                <nad:node svgId="test_14" equipmentId="VL3" x="827.88" y="25.42"/>
+                <nad:node svgId="test_16" equipmentId="VL4" x="405.95" y="123.38"/>
+                <nad:node svgId="test_18" equipmentId="VL5" x="225.14" y="-349.97"/>
+                <nad:node svgId="test_20" equipmentId="VL6" x="-336.09" y="-378.75"/>
+                <nad:node svgId="test_22" equipmentId="VL7" x="369.06" y="599.72"/>
+                <nad:node svgId="test_24" equipmentId="VL8" x="568.63" y="975.46"/>
+                <nad:node svgId="test_26" equipmentId="VL9" x="-23.76" y="416.70"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge diagramId="test_28" equipmentId="L1-2-1"/>
-                <nad:edge diagramId="test_29" equipmentId="L1-5-1"/>
-                <nad:edge diagramId="test_30" equipmentId="L9-10-1"/>
-                <nad:edge diagramId="test_31" equipmentId="L10-11-1"/>
-                <nad:edge diagramId="test_32" equipmentId="L6-11-1"/>
-                <nad:edge diagramId="test_33" equipmentId="L6-12-1"/>
-                <nad:edge diagramId="test_34" equipmentId="L12-13-1"/>
-                <nad:edge diagramId="test_35" equipmentId="L6-13-1"/>
-                <nad:edge diagramId="test_36" equipmentId="L13-14-1"/>
-                <nad:edge diagramId="test_37" equipmentId="L9-14-1"/>
-                <nad:edge diagramId="test_38" equipmentId="L2-3-1"/>
-                <nad:edge diagramId="test_39" equipmentId="L2-4-1"/>
-                <nad:edge diagramId="test_40" equipmentId="L2-5-1"/>
-                <nad:edge diagramId="test_41" equipmentId="L3-4-1"/>
-                <nad:edge diagramId="test_42" equipmentId="L4-5-1"/>
-                <nad:edge diagramId="test_43" equipmentId="T4-7-1"/>
-                <nad:edge diagramId="test_44" equipmentId="T4-9-1"/>
-                <nad:edge diagramId="test_45" equipmentId="T5-6-1"/>
-                <nad:edge diagramId="test_46" equipmentId="L7-8-1"/>
-                <nad:edge diagramId="test_47" equipmentId="L7-9-1"/>
+                <nad:edge svgId="test_28" equipmentId="L1-2-1"/>
+                <nad:edge svgId="test_29" equipmentId="L1-5-1"/>
+                <nad:edge svgId="test_30" equipmentId="L9-10-1"/>
+                <nad:edge svgId="test_31" equipmentId="L10-11-1"/>
+                <nad:edge svgId="test_32" equipmentId="L6-11-1"/>
+                <nad:edge svgId="test_33" equipmentId="L6-12-1"/>
+                <nad:edge svgId="test_34" equipmentId="L12-13-1"/>
+                <nad:edge svgId="test_35" equipmentId="L6-13-1"/>
+                <nad:edge svgId="test_36" equipmentId="L13-14-1"/>
+                <nad:edge svgId="test_37" equipmentId="L9-14-1"/>
+                <nad:edge svgId="test_38" equipmentId="L2-3-1"/>
+                <nad:edge svgId="test_39" equipmentId="L2-4-1"/>
+                <nad:edge svgId="test_40" equipmentId="L2-5-1"/>
+                <nad:edge svgId="test_41" equipmentId="L3-4-1"/>
+                <nad:edge svgId="test_42" equipmentId="L4-5-1"/>
+                <nad:edge svgId="test_43" equipmentId="T4-7-1"/>
+                <nad:edge svgId="test_44" equipmentId="T4-9-1"/>
+                <nad:edge svgId="test_45" equipmentId="T5-6-1"/>
+                <nad:edge svgId="test_46" equipmentId="L7-8-1"/>
+                <nad:edge svgId="test_47" equipmentId="L7-9-1"/>
             </nad:edges>
         </nad:nad>
     </metadata>

--- a/network-area-diagram/src/test/resources/IEEE_14_id_prefixed.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_id_prefixed.svg
@@ -49,20 +49,20 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="test_1" equipmentId="VL1_0" x="517.01" y="-642.50"/>
-                <nad:busNode diagramId="test_3" equipmentId="VL10_0" x="-518.51" y="516.42"/>
-                <nad:busNode diagramId="test_5" equipmentId="VL11_0" x="-720.95" y="118.61"/>
-                <nad:busNode diagramId="test_7" equipmentId="VL12_0" x="-635.66" y="-662.83"/>
-                <nad:busNode diagramId="test_9" equipmentId="VL13_0" x="-630.18" y="-297.82"/>
-                <nad:busNode diagramId="test_11" equipmentId="VL14_0" x="-308.48" y="92.20"/>
-                <nad:busNode diagramId="test_13" equipmentId="VL2_0" x="596.05" y="-263.35"/>
-                <nad:busNode diagramId="test_15" equipmentId="VL3_0" x="827.88" y="25.42"/>
-                <nad:busNode diagramId="test_17" equipmentId="VL4_0" x="405.95" y="123.38"/>
-                <nad:busNode diagramId="test_19" equipmentId="VL5_0" x="225.14" y="-349.97"/>
-                <nad:busNode diagramId="test_21" equipmentId="VL6_0" x="-336.09" y="-378.75"/>
-                <nad:busNode diagramId="test_23" equipmentId="VL7_0" x="369.06" y="599.72"/>
-                <nad:busNode diagramId="test_25" equipmentId="VL8_0" x="568.63" y="975.46"/>
-                <nad:busNode diagramId="test_27" equipmentId="VL9_0" x="-23.76" y="416.70"/>
+                <nad:busNode diagramId="test_1" equipmentId="VL1_0"/>
+                <nad:busNode diagramId="test_3" equipmentId="VL10_0"/>
+                <nad:busNode diagramId="test_5" equipmentId="VL11_0"/>
+                <nad:busNode diagramId="test_7" equipmentId="VL12_0"/>
+                <nad:busNode diagramId="test_9" equipmentId="VL13_0"/>
+                <nad:busNode diagramId="test_11" equipmentId="VL14_0"/>
+                <nad:busNode diagramId="test_13" equipmentId="VL2_0"/>
+                <nad:busNode diagramId="test_15" equipmentId="VL3_0"/>
+                <nad:busNode diagramId="test_17" equipmentId="VL4_0"/>
+                <nad:busNode diagramId="test_19" equipmentId="VL5_0"/>
+                <nad:busNode diagramId="test_21" equipmentId="VL6_0"/>
+                <nad:busNode diagramId="test_23" equipmentId="VL7_0"/>
+                <nad:busNode diagramId="test_25" equipmentId="VL8_0"/>
+                <nad:busNode diagramId="test_27" equipmentId="VL9_0"/>
             </nad:busNodes>
             <nad:nodes>
                 <nad:node diagramId="test_0" equipmentId="VL1" x="517.01" y="-642.50"/>

--- a/network-area-diagram/src/test/resources/IEEE_24_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_24_bus.svg
@@ -49,30 +49,30 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="VL1_0" x="-962.13" y="480.68"/>
-                <nad:busNode diagramId="3" equipmentId="VL10_0" x="-493.64" y="692.74"/>
-                <nad:busNode diagramId="5" equipmentId="VL11_0" x="46.99" y="652.79"/>
-                <nad:busNode diagramId="7" equipmentId="VL12_0" x="-160.17" y="328.18"/>
-                <nad:busNode diagramId="9" equipmentId="VL13_0" x="180.28" y="320.01"/>
-                <nad:busNode diagramId="11" equipmentId="VL14_0" x="644.30" y="427.15"/>
-                <nad:busNode diagramId="13" equipmentId="VL15_0" x="879.89" y="-504.78"/>
-                <nad:busNode diagramId="15" equipmentId="VL16_0" x="871.96" y="-122.70"/>
-                <nad:busNode diagramId="17" equipmentId="VL17_0" x="1398.65" y="-57.76"/>
-                <nad:busNode diagramId="19" equipmentId="VL18_0" x="1425.03" y="-379.69"/>
-                <nad:busNode diagramId="21" equipmentId="VL19_0" x="505.57" y="-664.44"/>
-                <nad:busNode diagramId="23" equipmentId="VL2_0" x="-977.53" y="1089.24"/>
-                <nad:busNode diagramId="25" equipmentId="VL20_0" x="64.25" y="-650.28"/>
-                <nad:busNode diagramId="27" equipmentId="VL21_0" x="1379.40" y="-680.93"/>
-                <nad:busNode diagramId="29" equipmentId="VL22_0" x="1754.07" y="-359.50"/>
-                <nad:busNode diagramId="31" equipmentId="VL23_0" x="13.35" y="-87.40"/>
-                <nad:busNode diagramId="33" equipmentId="VL24_0" x="284.26" y="-318.91"/>
-                <nad:busNode diagramId="35" equipmentId="VL3_0" x="-439.43" y="-35.17"/>
-                <nad:busNode diagramId="37" equipmentId="VL4_0" x="-752.55" y="865.30"/>
-                <nad:busNode diagramId="39" equipmentId="VL5_0" x="-1169.10" y="698.07"/>
-                <nad:busNode diagramId="41" equipmentId="VL6_0" x="-591.99" y="1240.96"/>
-                <nad:busNode diagramId="43" equipmentId="VL7_0" x="-1177.69" y="-238.11"/>
-                <nad:busNode diagramId="45" equipmentId="VL8_0" x="-846.14" y="126.31"/>
-                <nad:busNode diagramId="47" equipmentId="VL9_0" x="-477.52" y="372.89"/>
+                <nad:busNode diagramId="1" equipmentId="VL1_0"/>
+                <nad:busNode diagramId="3" equipmentId="VL10_0"/>
+                <nad:busNode diagramId="5" equipmentId="VL11_0"/>
+                <nad:busNode diagramId="7" equipmentId="VL12_0"/>
+                <nad:busNode diagramId="9" equipmentId="VL13_0"/>
+                <nad:busNode diagramId="11" equipmentId="VL14_0"/>
+                <nad:busNode diagramId="13" equipmentId="VL15_0"/>
+                <nad:busNode diagramId="15" equipmentId="VL16_0"/>
+                <nad:busNode diagramId="17" equipmentId="VL17_0"/>
+                <nad:busNode diagramId="19" equipmentId="VL18_0"/>
+                <nad:busNode diagramId="21" equipmentId="VL19_0"/>
+                <nad:busNode diagramId="23" equipmentId="VL2_0"/>
+                <nad:busNode diagramId="25" equipmentId="VL20_0"/>
+                <nad:busNode diagramId="27" equipmentId="VL21_0"/>
+                <nad:busNode diagramId="29" equipmentId="VL22_0"/>
+                <nad:busNode diagramId="31" equipmentId="VL23_0"/>
+                <nad:busNode diagramId="33" equipmentId="VL24_0"/>
+                <nad:busNode diagramId="35" equipmentId="VL3_0"/>
+                <nad:busNode diagramId="37" equipmentId="VL4_0"/>
+                <nad:busNode diagramId="39" equipmentId="VL5_0"/>
+                <nad:busNode diagramId="41" equipmentId="VL6_0"/>
+                <nad:busNode diagramId="43" equipmentId="VL7_0"/>
+                <nad:busNode diagramId="45" equipmentId="VL8_0"/>
+                <nad:busNode diagramId="47" equipmentId="VL9_0"/>
             </nad:busNodes>
             <nad:nodes>
                 <nad:node diagramId="0" equipmentId="VL1" x="-962.13" y="480.68"/>

--- a/network-area-diagram/src/test/resources/IEEE_24_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_24_bus.svg
@@ -49,96 +49,96 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="VL1_0"/>
-                <nad:busNode diagramId="3" equipmentId="VL10_0"/>
-                <nad:busNode diagramId="5" equipmentId="VL11_0"/>
-                <nad:busNode diagramId="7" equipmentId="VL12_0"/>
-                <nad:busNode diagramId="9" equipmentId="VL13_0"/>
-                <nad:busNode diagramId="11" equipmentId="VL14_0"/>
-                <nad:busNode diagramId="13" equipmentId="VL15_0"/>
-                <nad:busNode diagramId="15" equipmentId="VL16_0"/>
-                <nad:busNode diagramId="17" equipmentId="VL17_0"/>
-                <nad:busNode diagramId="19" equipmentId="VL18_0"/>
-                <nad:busNode diagramId="21" equipmentId="VL19_0"/>
-                <nad:busNode diagramId="23" equipmentId="VL2_0"/>
-                <nad:busNode diagramId="25" equipmentId="VL20_0"/>
-                <nad:busNode diagramId="27" equipmentId="VL21_0"/>
-                <nad:busNode diagramId="29" equipmentId="VL22_0"/>
-                <nad:busNode diagramId="31" equipmentId="VL23_0"/>
-                <nad:busNode diagramId="33" equipmentId="VL24_0"/>
-                <nad:busNode diagramId="35" equipmentId="VL3_0"/>
-                <nad:busNode diagramId="37" equipmentId="VL4_0"/>
-                <nad:busNode diagramId="39" equipmentId="VL5_0"/>
-                <nad:busNode diagramId="41" equipmentId="VL6_0"/>
-                <nad:busNode diagramId="43" equipmentId="VL7_0"/>
-                <nad:busNode diagramId="45" equipmentId="VL8_0"/>
-                <nad:busNode diagramId="47" equipmentId="VL9_0"/>
+                <nad:busNode svgId="1" equipmentId="VL1_0"/>
+                <nad:busNode svgId="3" equipmentId="VL10_0"/>
+                <nad:busNode svgId="5" equipmentId="VL11_0"/>
+                <nad:busNode svgId="7" equipmentId="VL12_0"/>
+                <nad:busNode svgId="9" equipmentId="VL13_0"/>
+                <nad:busNode svgId="11" equipmentId="VL14_0"/>
+                <nad:busNode svgId="13" equipmentId="VL15_0"/>
+                <nad:busNode svgId="15" equipmentId="VL16_0"/>
+                <nad:busNode svgId="17" equipmentId="VL17_0"/>
+                <nad:busNode svgId="19" equipmentId="VL18_0"/>
+                <nad:busNode svgId="21" equipmentId="VL19_0"/>
+                <nad:busNode svgId="23" equipmentId="VL2_0"/>
+                <nad:busNode svgId="25" equipmentId="VL20_0"/>
+                <nad:busNode svgId="27" equipmentId="VL21_0"/>
+                <nad:busNode svgId="29" equipmentId="VL22_0"/>
+                <nad:busNode svgId="31" equipmentId="VL23_0"/>
+                <nad:busNode svgId="33" equipmentId="VL24_0"/>
+                <nad:busNode svgId="35" equipmentId="VL3_0"/>
+                <nad:busNode svgId="37" equipmentId="VL4_0"/>
+                <nad:busNode svgId="39" equipmentId="VL5_0"/>
+                <nad:busNode svgId="41" equipmentId="VL6_0"/>
+                <nad:busNode svgId="43" equipmentId="VL7_0"/>
+                <nad:busNode svgId="45" equipmentId="VL8_0"/>
+                <nad:busNode svgId="47" equipmentId="VL9_0"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node diagramId="0" equipmentId="VL1" x="-962.13" y="480.68"/>
-                <nad:node diagramId="2" equipmentId="VL10" x="-493.64" y="692.74"/>
-                <nad:node diagramId="4" equipmentId="VL11" x="46.99" y="652.79"/>
-                <nad:node diagramId="6" equipmentId="VL12" x="-160.17" y="328.18"/>
-                <nad:node diagramId="8" equipmentId="VL13" x="180.28" y="320.01"/>
-                <nad:node diagramId="10" equipmentId="VL14" x="644.30" y="427.15"/>
-                <nad:node diagramId="12" equipmentId="VL15" x="879.89" y="-504.78"/>
-                <nad:node diagramId="14" equipmentId="VL16" x="871.96" y="-122.70"/>
-                <nad:node diagramId="16" equipmentId="VL17" x="1398.65" y="-57.76"/>
-                <nad:node diagramId="18" equipmentId="VL18" x="1425.03" y="-379.69"/>
-                <nad:node diagramId="20" equipmentId="VL19" x="505.57" y="-664.44"/>
-                <nad:node diagramId="22" equipmentId="VL2" x="-977.53" y="1089.24"/>
-                <nad:node diagramId="24" equipmentId="VL20" x="64.25" y="-650.28"/>
-                <nad:node diagramId="26" equipmentId="VL21" x="1379.40" y="-680.93"/>
-                <nad:node diagramId="28" equipmentId="VL22" x="1754.07" y="-359.50"/>
-                <nad:node diagramId="30" equipmentId="VL23" x="13.35" y="-87.40"/>
-                <nad:node diagramId="32" equipmentId="VL24" x="284.26" y="-318.91"/>
-                <nad:node diagramId="34" equipmentId="VL3" x="-439.43" y="-35.17"/>
-                <nad:node diagramId="36" equipmentId="VL4" x="-752.55" y="865.30"/>
-                <nad:node diagramId="38" equipmentId="VL5" x="-1169.10" y="698.07"/>
-                <nad:node diagramId="40" equipmentId="VL6" x="-591.99" y="1240.96"/>
-                <nad:node diagramId="42" equipmentId="VL7" x="-1177.69" y="-238.11"/>
-                <nad:node diagramId="44" equipmentId="VL8" x="-846.14" y="126.31"/>
-                <nad:node diagramId="46" equipmentId="VL9" x="-477.52" y="372.89"/>
+                <nad:node svgId="0" equipmentId="VL1" x="-962.13" y="480.68"/>
+                <nad:node svgId="2" equipmentId="VL10" x="-493.64" y="692.74"/>
+                <nad:node svgId="4" equipmentId="VL11" x="46.99" y="652.79"/>
+                <nad:node svgId="6" equipmentId="VL12" x="-160.17" y="328.18"/>
+                <nad:node svgId="8" equipmentId="VL13" x="180.28" y="320.01"/>
+                <nad:node svgId="10" equipmentId="VL14" x="644.30" y="427.15"/>
+                <nad:node svgId="12" equipmentId="VL15" x="879.89" y="-504.78"/>
+                <nad:node svgId="14" equipmentId="VL16" x="871.96" y="-122.70"/>
+                <nad:node svgId="16" equipmentId="VL17" x="1398.65" y="-57.76"/>
+                <nad:node svgId="18" equipmentId="VL18" x="1425.03" y="-379.69"/>
+                <nad:node svgId="20" equipmentId="VL19" x="505.57" y="-664.44"/>
+                <nad:node svgId="22" equipmentId="VL2" x="-977.53" y="1089.24"/>
+                <nad:node svgId="24" equipmentId="VL20" x="64.25" y="-650.28"/>
+                <nad:node svgId="26" equipmentId="VL21" x="1379.40" y="-680.93"/>
+                <nad:node svgId="28" equipmentId="VL22" x="1754.07" y="-359.50"/>
+                <nad:node svgId="30" equipmentId="VL23" x="13.35" y="-87.40"/>
+                <nad:node svgId="32" equipmentId="VL24" x="284.26" y="-318.91"/>
+                <nad:node svgId="34" equipmentId="VL3" x="-439.43" y="-35.17"/>
+                <nad:node svgId="36" equipmentId="VL4" x="-752.55" y="865.30"/>
+                <nad:node svgId="38" equipmentId="VL5" x="-1169.10" y="698.07"/>
+                <nad:node svgId="40" equipmentId="VL6" x="-591.99" y="1240.96"/>
+                <nad:node svgId="42" equipmentId="VL7" x="-1177.69" y="-238.11"/>
+                <nad:node svgId="44" equipmentId="VL8" x="-846.14" y="126.31"/>
+                <nad:node svgId="46" equipmentId="VL9" x="-477.52" y="372.89"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge diagramId="48" equipmentId="L-1-2-1 "/>
-                <nad:edge diagramId="49" equipmentId="L-3-1-1 "/>
-                <nad:edge diagramId="50" equipmentId="L-1-5-1 "/>
-                <nad:edge diagramId="51" equipmentId="L-10-6-1 "/>
-                <nad:edge diagramId="52" equipmentId="L-8-10-1 "/>
-                <nad:edge diagramId="53" equipmentId="T-5-10-1 "/>
-                <nad:edge diagramId="54" equipmentId="T-11-10-1 "/>
-                <nad:edge diagramId="55" equipmentId="T-12-10-1 "/>
-                <nad:edge diagramId="56" equipmentId="L-11-13-1 "/>
-                <nad:edge diagramId="57" equipmentId="L-11-14-1 "/>
-                <nad:edge diagramId="58" equipmentId="T-11-9-1 "/>
-                <nad:edge diagramId="59" equipmentId="L-12-13-1 "/>
-                <nad:edge diagramId="60" equipmentId="L-12-23-1 "/>
-                <nad:edge diagramId="61" equipmentId="T-9-12-1 "/>
-                <nad:edge diagramId="62" equipmentId="L-23-13-1 "/>
-                <nad:edge diagramId="63" equipmentId="L-14-16-1 "/>
-                <nad:edge diagramId="64" equipmentId="L-16-15-1 "/>
-                <nad:edge diagramId="65" equipmentId="L-15-21-1 "/>
-                <nad:edge diagramId="66" equipmentId="L-21-15-2 "/>
-                <nad:edge diagramId="67" equipmentId="L-15-24-1 "/>
-                <nad:edge diagramId="68" equipmentId="L-16-17-1 "/>
-                <nad:edge diagramId="69" equipmentId="L-16-19-1 "/>
-                <nad:edge diagramId="70" equipmentId="L-17-18-1 "/>
-                <nad:edge diagramId="71" equipmentId="L-17-22-1 "/>
-                <nad:edge diagramId="72" equipmentId="L-18-21-1 "/>
-                <nad:edge diagramId="73" equipmentId="L-18-21-2 "/>
-                <nad:edge diagramId="74" equipmentId="L-19-20-1 "/>
-                <nad:edge diagramId="75" equipmentId="L-19-20-2 "/>
-                <nad:edge diagramId="76" equipmentId="L-2-4-1 "/>
-                <nad:edge diagramId="77" equipmentId="L-2-6-1 "/>
-                <nad:edge diagramId="78" equipmentId="L-20-23-1 "/>
-                <nad:edge diagramId="79" equipmentId="L-20-23-2 "/>
-                <nad:edge diagramId="80" equipmentId="L-21-22-1 "/>
-                <nad:edge diagramId="81" equipmentId="T-24-3-1 "/>
-                <nad:edge diagramId="82" equipmentId="L-3-9-1 "/>
-                <nad:edge diagramId="83" equipmentId="L-4-9-1 "/>
-                <nad:edge diagramId="84" equipmentId="L-7-8-1 "/>
-                <nad:edge diagramId="85" equipmentId="L-8-9-1 "/>
+                <nad:edge svgId="48" equipmentId="L-1-2-1 "/>
+                <nad:edge svgId="49" equipmentId="L-3-1-1 "/>
+                <nad:edge svgId="50" equipmentId="L-1-5-1 "/>
+                <nad:edge svgId="51" equipmentId="L-10-6-1 "/>
+                <nad:edge svgId="52" equipmentId="L-8-10-1 "/>
+                <nad:edge svgId="53" equipmentId="T-5-10-1 "/>
+                <nad:edge svgId="54" equipmentId="T-11-10-1 "/>
+                <nad:edge svgId="55" equipmentId="T-12-10-1 "/>
+                <nad:edge svgId="56" equipmentId="L-11-13-1 "/>
+                <nad:edge svgId="57" equipmentId="L-11-14-1 "/>
+                <nad:edge svgId="58" equipmentId="T-11-9-1 "/>
+                <nad:edge svgId="59" equipmentId="L-12-13-1 "/>
+                <nad:edge svgId="60" equipmentId="L-12-23-1 "/>
+                <nad:edge svgId="61" equipmentId="T-9-12-1 "/>
+                <nad:edge svgId="62" equipmentId="L-23-13-1 "/>
+                <nad:edge svgId="63" equipmentId="L-14-16-1 "/>
+                <nad:edge svgId="64" equipmentId="L-16-15-1 "/>
+                <nad:edge svgId="65" equipmentId="L-15-21-1 "/>
+                <nad:edge svgId="66" equipmentId="L-21-15-2 "/>
+                <nad:edge svgId="67" equipmentId="L-15-24-1 "/>
+                <nad:edge svgId="68" equipmentId="L-16-17-1 "/>
+                <nad:edge svgId="69" equipmentId="L-16-19-1 "/>
+                <nad:edge svgId="70" equipmentId="L-17-18-1 "/>
+                <nad:edge svgId="71" equipmentId="L-17-22-1 "/>
+                <nad:edge svgId="72" equipmentId="L-18-21-1 "/>
+                <nad:edge svgId="73" equipmentId="L-18-21-2 "/>
+                <nad:edge svgId="74" equipmentId="L-19-20-1 "/>
+                <nad:edge svgId="75" equipmentId="L-19-20-2 "/>
+                <nad:edge svgId="76" equipmentId="L-2-4-1 "/>
+                <nad:edge svgId="77" equipmentId="L-2-6-1 "/>
+                <nad:edge svgId="78" equipmentId="L-20-23-1 "/>
+                <nad:edge svgId="79" equipmentId="L-20-23-2 "/>
+                <nad:edge svgId="80" equipmentId="L-21-22-1 "/>
+                <nad:edge svgId="81" equipmentId="T-24-3-1 "/>
+                <nad:edge svgId="82" equipmentId="L-3-9-1 "/>
+                <nad:edge svgId="83" equipmentId="L-4-9-1 "/>
+                <nad:edge svgId="84" equipmentId="L-7-8-1 "/>
+                <nad:edge svgId="85" equipmentId="L-8-9-1 "/>
             </nad:edges>
         </nad:nad>
     </metadata>

--- a/network-area-diagram/src/test/resources/IEEE_30_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_30_bus.svg
@@ -49,36 +49,36 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="VL1_0" x="565.06" y="-817.84"/>
-                <nad:busNode diagramId="3" equipmentId="VL10_0" x="210.04" y="69.85"/>
-                <nad:busNode diagramId="5" equipmentId="VL11_0" x="-610.23" y="747.39"/>
-                <nad:busNode diagramId="7" equipmentId="VL12_0" x="1145.30" y="-81.29"/>
-                <nad:busNode diagramId="9" equipmentId="VL13_0" x="1588.70" y="194.19"/>
-                <nad:busNode diagramId="11" equipmentId="VL14_0" x="913.52" y="122.69"/>
-                <nad:busNode diagramId="13" equipmentId="VL15_0" x="487.32" y="-474.91"/>
-                <nad:busNode diagramId="15" equipmentId="VL16_0" x="1396.87" y="-367.51"/>
-                <nad:busNode diagramId="17" equipmentId="VL17_0" x="921.96" y="-302.15"/>
-                <nad:busNode diagramId="19" equipmentId="VL18_0" x="290.45" y="-1130.66"/>
-                <nad:busNode diagramId="21" equipmentId="VL19_0" x="-82.84" y="-1218.43"/>
-                <nad:busNode diagramId="23" equipmentId="VL2_0" x="180.70" y="-263.40"/>
-                <nad:busNode diagramId="25" equipmentId="VL20_0" x="-34.48" y="-735.42"/>
-                <nad:busNode diagramId="27" equipmentId="VL21_0" x="387.95" y="405.49"/>
-                <nad:busNode diagramId="29" equipmentId="VL22_0" x="-140.57" y="127.31"/>
-                <nad:busNode diagramId="31" equipmentId="VL23_0" x="-407.83" y="-535.70"/>
-                <nad:busNode diagramId="33" equipmentId="VL24_0" x="-785.89" y="-44.13"/>
-                <nad:busNode diagramId="35" equipmentId="VL25_0" x="-1136.46" y="521.59"/>
-                <nad:busNode diagramId="37" equipmentId="VL26_0" x="-1561.04" y="399.29"/>
-                <nad:busNode diagramId="39" equipmentId="VL27_0" x="-831.63" y="1168.73"/>
-                <nad:busNode diagramId="41" equipmentId="VL28_0" x="-213.94" y="1050.08"/>
-                <nad:busNode diagramId="43" equipmentId="VL29_0" x="-759.33" y="1607.48"/>
-                <nad:busNode diagramId="45" equipmentId="VL3_0" x="901.51" y="-716.33"/>
-                <nad:busNode diagramId="47" equipmentId="VL30_0" x="-1075.65" y="1516.77"/>
-                <nad:busNode diagramId="49" equipmentId="VL4_0" x="605.40" y="-102.54"/>
-                <nad:busNode diagramId="51" equipmentId="VL5_0" x="-325.24" y="-198.83"/>
-                <nad:busNode diagramId="53" equipmentId="VL6_0" x="71.61" y="428.90"/>
-                <nad:busNode diagramId="55" equipmentId="VL7_0" x="-458.72" y="201.69"/>
-                <nad:busNode diagramId="57" equipmentId="VL8_0" x="173.93" y="995.43"/>
-                <nad:busNode diagramId="59" equipmentId="VL9_0" x="-207.43" y="574.68"/>
+                <nad:busNode diagramId="1" equipmentId="VL1_0"/>
+                <nad:busNode diagramId="3" equipmentId="VL10_0"/>
+                <nad:busNode diagramId="5" equipmentId="VL11_0"/>
+                <nad:busNode diagramId="7" equipmentId="VL12_0"/>
+                <nad:busNode diagramId="9" equipmentId="VL13_0"/>
+                <nad:busNode diagramId="11" equipmentId="VL14_0"/>
+                <nad:busNode diagramId="13" equipmentId="VL15_0"/>
+                <nad:busNode diagramId="15" equipmentId="VL16_0"/>
+                <nad:busNode diagramId="17" equipmentId="VL17_0"/>
+                <nad:busNode diagramId="19" equipmentId="VL18_0"/>
+                <nad:busNode diagramId="21" equipmentId="VL19_0"/>
+                <nad:busNode diagramId="23" equipmentId="VL2_0"/>
+                <nad:busNode diagramId="25" equipmentId="VL20_0"/>
+                <nad:busNode diagramId="27" equipmentId="VL21_0"/>
+                <nad:busNode diagramId="29" equipmentId="VL22_0"/>
+                <nad:busNode diagramId="31" equipmentId="VL23_0"/>
+                <nad:busNode diagramId="33" equipmentId="VL24_0"/>
+                <nad:busNode diagramId="35" equipmentId="VL25_0"/>
+                <nad:busNode diagramId="37" equipmentId="VL26_0"/>
+                <nad:busNode diagramId="39" equipmentId="VL27_0"/>
+                <nad:busNode diagramId="41" equipmentId="VL28_0"/>
+                <nad:busNode diagramId="43" equipmentId="VL29_0"/>
+                <nad:busNode diagramId="45" equipmentId="VL3_0"/>
+                <nad:busNode diagramId="47" equipmentId="VL30_0"/>
+                <nad:busNode diagramId="49" equipmentId="VL4_0"/>
+                <nad:busNode diagramId="51" equipmentId="VL5_0"/>
+                <nad:busNode diagramId="53" equipmentId="VL6_0"/>
+                <nad:busNode diagramId="55" equipmentId="VL7_0"/>
+                <nad:busNode diagramId="57" equipmentId="VL8_0"/>
+                <nad:busNode diagramId="59" equipmentId="VL9_0"/>
             </nad:busNodes>
             <nad:nodes>
                 <nad:node diagramId="0" equipmentId="VL1" x="565.06" y="-817.84"/>

--- a/network-area-diagram/src/test/resources/IEEE_30_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_30_bus.svg
@@ -49,111 +49,111 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="VL1_0"/>
-                <nad:busNode diagramId="3" equipmentId="VL10_0"/>
-                <nad:busNode diagramId="5" equipmentId="VL11_0"/>
-                <nad:busNode diagramId="7" equipmentId="VL12_0"/>
-                <nad:busNode diagramId="9" equipmentId="VL13_0"/>
-                <nad:busNode diagramId="11" equipmentId="VL14_0"/>
-                <nad:busNode diagramId="13" equipmentId="VL15_0"/>
-                <nad:busNode diagramId="15" equipmentId="VL16_0"/>
-                <nad:busNode diagramId="17" equipmentId="VL17_0"/>
-                <nad:busNode diagramId="19" equipmentId="VL18_0"/>
-                <nad:busNode diagramId="21" equipmentId="VL19_0"/>
-                <nad:busNode diagramId="23" equipmentId="VL2_0"/>
-                <nad:busNode diagramId="25" equipmentId="VL20_0"/>
-                <nad:busNode diagramId="27" equipmentId="VL21_0"/>
-                <nad:busNode diagramId="29" equipmentId="VL22_0"/>
-                <nad:busNode diagramId="31" equipmentId="VL23_0"/>
-                <nad:busNode diagramId="33" equipmentId="VL24_0"/>
-                <nad:busNode diagramId="35" equipmentId="VL25_0"/>
-                <nad:busNode diagramId="37" equipmentId="VL26_0"/>
-                <nad:busNode diagramId="39" equipmentId="VL27_0"/>
-                <nad:busNode diagramId="41" equipmentId="VL28_0"/>
-                <nad:busNode diagramId="43" equipmentId="VL29_0"/>
-                <nad:busNode diagramId="45" equipmentId="VL3_0"/>
-                <nad:busNode diagramId="47" equipmentId="VL30_0"/>
-                <nad:busNode diagramId="49" equipmentId="VL4_0"/>
-                <nad:busNode diagramId="51" equipmentId="VL5_0"/>
-                <nad:busNode diagramId="53" equipmentId="VL6_0"/>
-                <nad:busNode diagramId="55" equipmentId="VL7_0"/>
-                <nad:busNode diagramId="57" equipmentId="VL8_0"/>
-                <nad:busNode diagramId="59" equipmentId="VL9_0"/>
+                <nad:busNode svgId="1" equipmentId="VL1_0"/>
+                <nad:busNode svgId="3" equipmentId="VL10_0"/>
+                <nad:busNode svgId="5" equipmentId="VL11_0"/>
+                <nad:busNode svgId="7" equipmentId="VL12_0"/>
+                <nad:busNode svgId="9" equipmentId="VL13_0"/>
+                <nad:busNode svgId="11" equipmentId="VL14_0"/>
+                <nad:busNode svgId="13" equipmentId="VL15_0"/>
+                <nad:busNode svgId="15" equipmentId="VL16_0"/>
+                <nad:busNode svgId="17" equipmentId="VL17_0"/>
+                <nad:busNode svgId="19" equipmentId="VL18_0"/>
+                <nad:busNode svgId="21" equipmentId="VL19_0"/>
+                <nad:busNode svgId="23" equipmentId="VL2_0"/>
+                <nad:busNode svgId="25" equipmentId="VL20_0"/>
+                <nad:busNode svgId="27" equipmentId="VL21_0"/>
+                <nad:busNode svgId="29" equipmentId="VL22_0"/>
+                <nad:busNode svgId="31" equipmentId="VL23_0"/>
+                <nad:busNode svgId="33" equipmentId="VL24_0"/>
+                <nad:busNode svgId="35" equipmentId="VL25_0"/>
+                <nad:busNode svgId="37" equipmentId="VL26_0"/>
+                <nad:busNode svgId="39" equipmentId="VL27_0"/>
+                <nad:busNode svgId="41" equipmentId="VL28_0"/>
+                <nad:busNode svgId="43" equipmentId="VL29_0"/>
+                <nad:busNode svgId="45" equipmentId="VL3_0"/>
+                <nad:busNode svgId="47" equipmentId="VL30_0"/>
+                <nad:busNode svgId="49" equipmentId="VL4_0"/>
+                <nad:busNode svgId="51" equipmentId="VL5_0"/>
+                <nad:busNode svgId="53" equipmentId="VL6_0"/>
+                <nad:busNode svgId="55" equipmentId="VL7_0"/>
+                <nad:busNode svgId="57" equipmentId="VL8_0"/>
+                <nad:busNode svgId="59" equipmentId="VL9_0"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node diagramId="0" equipmentId="VL1" x="565.06" y="-817.84"/>
-                <nad:node diagramId="2" equipmentId="VL10" x="210.04" y="69.85"/>
-                <nad:node diagramId="4" equipmentId="VL11" x="-610.23" y="747.39"/>
-                <nad:node diagramId="6" equipmentId="VL12" x="1145.30" y="-81.29"/>
-                <nad:node diagramId="8" equipmentId="VL13" x="1588.70" y="194.19"/>
-                <nad:node diagramId="10" equipmentId="VL14" x="913.52" y="122.69"/>
-                <nad:node diagramId="12" equipmentId="VL15" x="487.32" y="-474.91"/>
-                <nad:node diagramId="14" equipmentId="VL16" x="1396.87" y="-367.51"/>
-                <nad:node diagramId="16" equipmentId="VL17" x="921.96" y="-302.15"/>
-                <nad:node diagramId="18" equipmentId="VL18" x="290.45" y="-1130.66"/>
-                <nad:node diagramId="20" equipmentId="VL19" x="-82.84" y="-1218.43"/>
-                <nad:node diagramId="22" equipmentId="VL2" x="180.70" y="-263.40"/>
-                <nad:node diagramId="24" equipmentId="VL20" x="-34.48" y="-735.42"/>
-                <nad:node diagramId="26" equipmentId="VL21" x="387.95" y="405.49"/>
-                <nad:node diagramId="28" equipmentId="VL22" x="-140.57" y="127.31"/>
-                <nad:node diagramId="30" equipmentId="VL23" x="-407.83" y="-535.70"/>
-                <nad:node diagramId="32" equipmentId="VL24" x="-785.89" y="-44.13"/>
-                <nad:node diagramId="34" equipmentId="VL25" x="-1136.46" y="521.59"/>
-                <nad:node diagramId="36" equipmentId="VL26" x="-1561.04" y="399.29"/>
-                <nad:node diagramId="38" equipmentId="VL27" x="-831.63" y="1168.73"/>
-                <nad:node diagramId="40" equipmentId="VL28" x="-213.94" y="1050.08"/>
-                <nad:node diagramId="42" equipmentId="VL29" x="-759.33" y="1607.48"/>
-                <nad:node diagramId="44" equipmentId="VL3" x="901.51" y="-716.33"/>
-                <nad:node diagramId="46" equipmentId="VL30" x="-1075.65" y="1516.77"/>
-                <nad:node diagramId="48" equipmentId="VL4" x="605.40" y="-102.54"/>
-                <nad:node diagramId="50" equipmentId="VL5" x="-325.24" y="-198.83"/>
-                <nad:node diagramId="52" equipmentId="VL6" x="71.61" y="428.90"/>
-                <nad:node diagramId="54" equipmentId="VL7" x="-458.72" y="201.69"/>
-                <nad:node diagramId="56" equipmentId="VL8" x="173.93" y="995.43"/>
-                <nad:node diagramId="58" equipmentId="VL9" x="-207.43" y="574.68"/>
+                <nad:node svgId="0" equipmentId="VL1" x="565.06" y="-817.84"/>
+                <nad:node svgId="2" equipmentId="VL10" x="210.04" y="69.85"/>
+                <nad:node svgId="4" equipmentId="VL11" x="-610.23" y="747.39"/>
+                <nad:node svgId="6" equipmentId="VL12" x="1145.30" y="-81.29"/>
+                <nad:node svgId="8" equipmentId="VL13" x="1588.70" y="194.19"/>
+                <nad:node svgId="10" equipmentId="VL14" x="913.52" y="122.69"/>
+                <nad:node svgId="12" equipmentId="VL15" x="487.32" y="-474.91"/>
+                <nad:node svgId="14" equipmentId="VL16" x="1396.87" y="-367.51"/>
+                <nad:node svgId="16" equipmentId="VL17" x="921.96" y="-302.15"/>
+                <nad:node svgId="18" equipmentId="VL18" x="290.45" y="-1130.66"/>
+                <nad:node svgId="20" equipmentId="VL19" x="-82.84" y="-1218.43"/>
+                <nad:node svgId="22" equipmentId="VL2" x="180.70" y="-263.40"/>
+                <nad:node svgId="24" equipmentId="VL20" x="-34.48" y="-735.42"/>
+                <nad:node svgId="26" equipmentId="VL21" x="387.95" y="405.49"/>
+                <nad:node svgId="28" equipmentId="VL22" x="-140.57" y="127.31"/>
+                <nad:node svgId="30" equipmentId="VL23" x="-407.83" y="-535.70"/>
+                <nad:node svgId="32" equipmentId="VL24" x="-785.89" y="-44.13"/>
+                <nad:node svgId="34" equipmentId="VL25" x="-1136.46" y="521.59"/>
+                <nad:node svgId="36" equipmentId="VL26" x="-1561.04" y="399.29"/>
+                <nad:node svgId="38" equipmentId="VL27" x="-831.63" y="1168.73"/>
+                <nad:node svgId="40" equipmentId="VL28" x="-213.94" y="1050.08"/>
+                <nad:node svgId="42" equipmentId="VL29" x="-759.33" y="1607.48"/>
+                <nad:node svgId="44" equipmentId="VL3" x="901.51" y="-716.33"/>
+                <nad:node svgId="46" equipmentId="VL30" x="-1075.65" y="1516.77"/>
+                <nad:node svgId="48" equipmentId="VL4" x="605.40" y="-102.54"/>
+                <nad:node svgId="50" equipmentId="VL5" x="-325.24" y="-198.83"/>
+                <nad:node svgId="52" equipmentId="VL6" x="71.61" y="428.90"/>
+                <nad:node svgId="54" equipmentId="VL7" x="-458.72" y="201.69"/>
+                <nad:node svgId="56" equipmentId="VL8" x="173.93" y="995.43"/>
+                <nad:node svgId="58" equipmentId="VL9" x="-207.43" y="574.68"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge diagramId="60" equipmentId="L1-2-1"/>
-                <nad:edge diagramId="61" equipmentId="L1-3-1"/>
-                <nad:edge diagramId="62" equipmentId="L9-10-1"/>
-                <nad:edge diagramId="63" equipmentId="L10-20-1"/>
-                <nad:edge diagramId="64" equipmentId="L10-17-1"/>
-                <nad:edge diagramId="65" equipmentId="L10-21-1"/>
-                <nad:edge diagramId="66" equipmentId="L10-22-1"/>
-                <nad:edge diagramId="67" equipmentId="T6-10-1"/>
-                <nad:edge diagramId="68" equipmentId="L9-11-1"/>
-                <nad:edge diagramId="69" equipmentId="L12-13-1"/>
-                <nad:edge diagramId="70" equipmentId="L12-14-1"/>
-                <nad:edge diagramId="71" equipmentId="L12-15-1"/>
-                <nad:edge diagramId="72" equipmentId="L12-16-1"/>
-                <nad:edge diagramId="73" equipmentId="T4-12-1"/>
-                <nad:edge diagramId="74" equipmentId="L14-15-1"/>
-                <nad:edge diagramId="75" equipmentId="L15-18-1"/>
-                <nad:edge diagramId="76" equipmentId="L15-23-1"/>
-                <nad:edge diagramId="77" equipmentId="L16-17-1"/>
-                <nad:edge diagramId="78" equipmentId="L18-19-1"/>
-                <nad:edge diagramId="79" equipmentId="L19-20-1"/>
-                <nad:edge diagramId="80" equipmentId="L2-4-1"/>
-                <nad:edge diagramId="81" equipmentId="L2-5-1"/>
-                <nad:edge diagramId="82" equipmentId="L2-6-1"/>
-                <nad:edge diagramId="83" equipmentId="L21-22-1"/>
-                <nad:edge diagramId="84" equipmentId="L22-24-1"/>
-                <nad:edge diagramId="85" equipmentId="L23-24-1"/>
-                <nad:edge diagramId="86" equipmentId="L24-25-1"/>
-                <nad:edge diagramId="87" equipmentId="L25-26-1"/>
-                <nad:edge diagramId="88" equipmentId="L25-27-1"/>
-                <nad:edge diagramId="89" equipmentId="L27-29-1"/>
-                <nad:edge diagramId="90" equipmentId="L27-30-1"/>
-                <nad:edge diagramId="91" equipmentId="T28-27-1"/>
-                <nad:edge diagramId="92" equipmentId="L8-28-1"/>
-                <nad:edge diagramId="93" equipmentId="L6-28-1"/>
-                <nad:edge diagramId="94" equipmentId="L29-30-1"/>
-                <nad:edge diagramId="95" equipmentId="L3-4-1"/>
-                <nad:edge diagramId="96" equipmentId="L4-6-1"/>
-                <nad:edge diagramId="97" equipmentId="L5-7-1"/>
-                <nad:edge diagramId="98" equipmentId="L6-7-1"/>
-                <nad:edge diagramId="99" equipmentId="L6-8-1"/>
-                <nad:edge diagramId="100" equipmentId="T6-9-1"/>
+                <nad:edge svgId="60" equipmentId="L1-2-1"/>
+                <nad:edge svgId="61" equipmentId="L1-3-1"/>
+                <nad:edge svgId="62" equipmentId="L9-10-1"/>
+                <nad:edge svgId="63" equipmentId="L10-20-1"/>
+                <nad:edge svgId="64" equipmentId="L10-17-1"/>
+                <nad:edge svgId="65" equipmentId="L10-21-1"/>
+                <nad:edge svgId="66" equipmentId="L10-22-1"/>
+                <nad:edge svgId="67" equipmentId="T6-10-1"/>
+                <nad:edge svgId="68" equipmentId="L9-11-1"/>
+                <nad:edge svgId="69" equipmentId="L12-13-1"/>
+                <nad:edge svgId="70" equipmentId="L12-14-1"/>
+                <nad:edge svgId="71" equipmentId="L12-15-1"/>
+                <nad:edge svgId="72" equipmentId="L12-16-1"/>
+                <nad:edge svgId="73" equipmentId="T4-12-1"/>
+                <nad:edge svgId="74" equipmentId="L14-15-1"/>
+                <nad:edge svgId="75" equipmentId="L15-18-1"/>
+                <nad:edge svgId="76" equipmentId="L15-23-1"/>
+                <nad:edge svgId="77" equipmentId="L16-17-1"/>
+                <nad:edge svgId="78" equipmentId="L18-19-1"/>
+                <nad:edge svgId="79" equipmentId="L19-20-1"/>
+                <nad:edge svgId="80" equipmentId="L2-4-1"/>
+                <nad:edge svgId="81" equipmentId="L2-5-1"/>
+                <nad:edge svgId="82" equipmentId="L2-6-1"/>
+                <nad:edge svgId="83" equipmentId="L21-22-1"/>
+                <nad:edge svgId="84" equipmentId="L22-24-1"/>
+                <nad:edge svgId="85" equipmentId="L23-24-1"/>
+                <nad:edge svgId="86" equipmentId="L24-25-1"/>
+                <nad:edge svgId="87" equipmentId="L25-26-1"/>
+                <nad:edge svgId="88" equipmentId="L25-27-1"/>
+                <nad:edge svgId="89" equipmentId="L27-29-1"/>
+                <nad:edge svgId="90" equipmentId="L27-30-1"/>
+                <nad:edge svgId="91" equipmentId="T28-27-1"/>
+                <nad:edge svgId="92" equipmentId="L8-28-1"/>
+                <nad:edge svgId="93" equipmentId="L6-28-1"/>
+                <nad:edge svgId="94" equipmentId="L29-30-1"/>
+                <nad:edge svgId="95" equipmentId="L3-4-1"/>
+                <nad:edge svgId="96" equipmentId="L4-6-1"/>
+                <nad:edge svgId="97" equipmentId="L5-7-1"/>
+                <nad:edge svgId="98" equipmentId="L6-7-1"/>
+                <nad:edge svgId="99" equipmentId="L6-8-1"/>
+                <nad:edge svgId="100" equipmentId="T6-9-1"/>
             </nad:edges>
         </nad:nad>
     </metadata>

--- a/network-area-diagram/src/test/resources/IEEE_57_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_57_bus.svg
@@ -114,189 +114,189 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="VL1_0"/>
-                <nad:busNode diagramId="3" equipmentId="VL10_0"/>
-                <nad:busNode diagramId="4" equipmentId="VL10_1"/>
-                <nad:busNode diagramId="6" equipmentId="VL11_0"/>
-                <nad:busNode diagramId="7" equipmentId="VL11_1"/>
-                <nad:busNode diagramId="8" equipmentId="VL11_2"/>
-                <nad:busNode diagramId="10" equipmentId="VL12_0"/>
-                <nad:busNode diagramId="12" equipmentId="VL13_0"/>
-                <nad:busNode diagramId="13" equipmentId="VL13_1"/>
-                <nad:busNode diagramId="15" equipmentId="VL14_0"/>
-                <nad:busNode diagramId="16" equipmentId="VL14_1"/>
-                <nad:busNode diagramId="18" equipmentId="VL15_0"/>
-                <nad:busNode diagramId="19" equipmentId="VL15_1"/>
-                <nad:busNode diagramId="21" equipmentId="VL16_0"/>
-                <nad:busNode diagramId="23" equipmentId="VL17_0"/>
-                <nad:busNode diagramId="25" equipmentId="VL19_0"/>
-                <nad:busNode diagramId="27" equipmentId="VL2_0"/>
-                <nad:busNode diagramId="29" equipmentId="VL20_0"/>
-                <nad:busNode diagramId="30" equipmentId="VL20_1"/>
-                <nad:busNode diagramId="32" equipmentId="VL22_0"/>
-                <nad:busNode diagramId="34" equipmentId="VL23_0"/>
-                <nad:busNode diagramId="36" equipmentId="VL24_0"/>
-                <nad:busNode diagramId="37" equipmentId="VL24_1"/>
-                <nad:busNode diagramId="38" equipmentId="VL24_2"/>
-                <nad:busNode diagramId="40" equipmentId="VL27_0"/>
-                <nad:busNode diagramId="42" equipmentId="VL28_0"/>
-                <nad:busNode diagramId="44" equipmentId="VL3_0"/>
-                <nad:busNode diagramId="46" equipmentId="VL30_0"/>
-                <nad:busNode diagramId="48" equipmentId="VL31_0"/>
-                <nad:busNode diagramId="50" equipmentId="VL32_0"/>
-                <nad:busNode diagramId="51" equipmentId="VL32_1"/>
-                <nad:busNode diagramId="53" equipmentId="VL33_0"/>
-                <nad:busNode diagramId="55" equipmentId="VL35_0"/>
-                <nad:busNode diagramId="57" equipmentId="VL36_0"/>
-                <nad:busNode diagramId="59" equipmentId="VL37_0"/>
-                <nad:busNode diagramId="61" equipmentId="VL38_0"/>
-                <nad:busNode diagramId="63" equipmentId="VL39_0"/>
-                <nad:busNode diagramId="64" equipmentId="VL39_1"/>
-                <nad:busNode diagramId="66" equipmentId="VL4_0"/>
-                <nad:busNode diagramId="67" equipmentId="VL4_1"/>
-                <nad:busNode diagramId="69" equipmentId="VL40_0"/>
-                <nad:busNode diagramId="70" equipmentId="VL40_1"/>
-                <nad:busNode diagramId="72" equipmentId="VL42_0"/>
-                <nad:busNode diagramId="74" equipmentId="VL44_0"/>
-                <nad:busNode diagramId="76" equipmentId="VL47_0"/>
-                <nad:busNode diagramId="78" equipmentId="VL48_0"/>
-                <nad:busNode diagramId="80" equipmentId="VL5_0"/>
-                <nad:busNode diagramId="82" equipmentId="VL50_0"/>
-                <nad:busNode diagramId="84" equipmentId="VL52_0"/>
-                <nad:busNode diagramId="86" equipmentId="VL53_0"/>
-                <nad:busNode diagramId="88" equipmentId="VL54_0"/>
-                <nad:busNode diagramId="90" equipmentId="VL6_0"/>
-                <nad:busNode diagramId="92" equipmentId="VL7_0"/>
-                <nad:busNode diagramId="93" equipmentId="VL7_1"/>
-                <nad:busNode diagramId="95" equipmentId="VL8_0"/>
-                <nad:busNode diagramId="97" equipmentId="VL9_0"/>
-                <nad:busNode diagramId="98" equipmentId="VL9_1"/>
+                <nad:busNode svgId="1" equipmentId="VL1_0"/>
+                <nad:busNode svgId="3" equipmentId="VL10_0"/>
+                <nad:busNode svgId="4" equipmentId="VL10_1"/>
+                <nad:busNode svgId="6" equipmentId="VL11_0"/>
+                <nad:busNode svgId="7" equipmentId="VL11_1"/>
+                <nad:busNode svgId="8" equipmentId="VL11_2"/>
+                <nad:busNode svgId="10" equipmentId="VL12_0"/>
+                <nad:busNode svgId="12" equipmentId="VL13_0"/>
+                <nad:busNode svgId="13" equipmentId="VL13_1"/>
+                <nad:busNode svgId="15" equipmentId="VL14_0"/>
+                <nad:busNode svgId="16" equipmentId="VL14_1"/>
+                <nad:busNode svgId="18" equipmentId="VL15_0"/>
+                <nad:busNode svgId="19" equipmentId="VL15_1"/>
+                <nad:busNode svgId="21" equipmentId="VL16_0"/>
+                <nad:busNode svgId="23" equipmentId="VL17_0"/>
+                <nad:busNode svgId="25" equipmentId="VL19_0"/>
+                <nad:busNode svgId="27" equipmentId="VL2_0"/>
+                <nad:busNode svgId="29" equipmentId="VL20_0"/>
+                <nad:busNode svgId="30" equipmentId="VL20_1"/>
+                <nad:busNode svgId="32" equipmentId="VL22_0"/>
+                <nad:busNode svgId="34" equipmentId="VL23_0"/>
+                <nad:busNode svgId="36" equipmentId="VL24_0"/>
+                <nad:busNode svgId="37" equipmentId="VL24_1"/>
+                <nad:busNode svgId="38" equipmentId="VL24_2"/>
+                <nad:busNode svgId="40" equipmentId="VL27_0"/>
+                <nad:busNode svgId="42" equipmentId="VL28_0"/>
+                <nad:busNode svgId="44" equipmentId="VL3_0"/>
+                <nad:busNode svgId="46" equipmentId="VL30_0"/>
+                <nad:busNode svgId="48" equipmentId="VL31_0"/>
+                <nad:busNode svgId="50" equipmentId="VL32_0"/>
+                <nad:busNode svgId="51" equipmentId="VL32_1"/>
+                <nad:busNode svgId="53" equipmentId="VL33_0"/>
+                <nad:busNode svgId="55" equipmentId="VL35_0"/>
+                <nad:busNode svgId="57" equipmentId="VL36_0"/>
+                <nad:busNode svgId="59" equipmentId="VL37_0"/>
+                <nad:busNode svgId="61" equipmentId="VL38_0"/>
+                <nad:busNode svgId="63" equipmentId="VL39_0"/>
+                <nad:busNode svgId="64" equipmentId="VL39_1"/>
+                <nad:busNode svgId="66" equipmentId="VL4_0"/>
+                <nad:busNode svgId="67" equipmentId="VL4_1"/>
+                <nad:busNode svgId="69" equipmentId="VL40_0"/>
+                <nad:busNode svgId="70" equipmentId="VL40_1"/>
+                <nad:busNode svgId="72" equipmentId="VL42_0"/>
+                <nad:busNode svgId="74" equipmentId="VL44_0"/>
+                <nad:busNode svgId="76" equipmentId="VL47_0"/>
+                <nad:busNode svgId="78" equipmentId="VL48_0"/>
+                <nad:busNode svgId="80" equipmentId="VL5_0"/>
+                <nad:busNode svgId="82" equipmentId="VL50_0"/>
+                <nad:busNode svgId="84" equipmentId="VL52_0"/>
+                <nad:busNode svgId="86" equipmentId="VL53_0"/>
+                <nad:busNode svgId="88" equipmentId="VL54_0"/>
+                <nad:busNode svgId="90" equipmentId="VL6_0"/>
+                <nad:busNode svgId="92" equipmentId="VL7_0"/>
+                <nad:busNode svgId="93" equipmentId="VL7_1"/>
+                <nad:busNode svgId="95" equipmentId="VL8_0"/>
+                <nad:busNode svgId="97" equipmentId="VL9_0"/>
+                <nad:busNode svgId="98" equipmentId="VL9_1"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node diagramId="0" equipmentId="VL1" x="-269.69" y="-93.47"/>
-                <nad:node diagramId="2" equipmentId="VL10" x="846.23" y="833.49"/>
-                <nad:node diagramId="5" equipmentId="VL11" x="1241.95" y="134.97"/>
-                <nad:node diagramId="9" equipmentId="VL12" x="408.55" y="427.89"/>
-                <nad:node diagramId="11" equipmentId="VL13" x="740.31" y="235.48"/>
-                <nad:node diagramId="14" equipmentId="VL14" x="605.92" y="-65.16"/>
-                <nad:node diagramId="17" equipmentId="VL15" x="143.15" y="20.88"/>
-                <nad:node diagramId="20" equipmentId="VL16" x="-0.01" y="374.43"/>
-                <nad:node diagramId="22" equipmentId="VL17" x="5.89" y="-216.42"/>
-                <nad:node diagramId="24" equipmentId="VL19" x="-944.26" y="1444.53"/>
-                <nad:node diagramId="26" equipmentId="VL2" x="-736.48" y="-15.02"/>
-                <nad:node diagramId="28" equipmentId="VL20" x="-588.77" y="1088.92"/>
-                <nad:node diagramId="31" equipmentId="VL22" x="-395.93" y="177.02"/>
-                <nad:node diagramId="33" equipmentId="VL23" x="-910.76" y="-412.51"/>
-                <nad:node diagramId="35" equipmentId="VL24" x="-1281.09" y="-717.24"/>
-                <nad:node diagramId="39" equipmentId="VL27" x="-1535.07" y="-244.76"/>
-                <nad:node diagramId="41" equipmentId="VL28" x="-1348.15" y="290.37"/>
-                <nad:node diagramId="43" equipmentId="VL3" x="-693.77" y="399.71"/>
-                <nad:node diagramId="45" equipmentId="VL30" x="-1062.06" y="-1227.28"/>
-                <nad:node diagramId="47" equipmentId="VL31" x="-640.82" y="-1554.26"/>
-                <nad:node diagramId="49" equipmentId="VL32" x="-103.26" y="-1734.24"/>
-                <nad:node diagramId="52" equipmentId="VL33" x="-160.71" y="-2128.26"/>
-                <nad:node diagramId="54" equipmentId="VL35" x="472.67" y="-1584.04"/>
-                <nad:node diagramId="56" equipmentId="VL36" x="990.15" y="-1220.07"/>
-                <nad:node diagramId="58" equipmentId="VL37" x="923.97" y="-881.50"/>
-                <nad:node diagramId="60" equipmentId="VL38" x="472.29" y="-345.80"/>
-                <nad:node diagramId="62" equipmentId="VL39" x="1418.63" y="-953.01"/>
-                <nad:node diagramId="65" equipmentId="VL4" x="-1160.19" y="1084.54"/>
-                <nad:node diagramId="68" equipmentId="VL40" x="1440.50" y="-562.18"/>
-                <nad:node diagramId="71" equipmentId="VL42" x="1654.22" y="-148.09"/>
-                <nad:node diagramId="73" equipmentId="VL44" x="188.38" y="-578.05"/>
-                <nad:node diagramId="75" equipmentId="VL47" x="973.47" y="-408.27"/>
-                <nad:node diagramId="77" equipmentId="VL48" x="916.67" y="-128.87"/>
-                <nad:node diagramId="79" equipmentId="VL5" x="-1505.20" y="1031.73"/>
-                <nad:node diagramId="81" equipmentId="VL50" x="1152.75" y="663.93"/>
-                <nad:node diagramId="83" equipmentId="VL52" x="-302.76" y="1464.80"/>
-                <nad:node diagramId="85" equipmentId="VL53" x="140.43" y="1652.22"/>
-                <nad:node diagramId="87" equipmentId="VL54" x="476.73" y="1343.65"/>
-                <nad:node diagramId="89" equipmentId="VL6" x="-1040.78" y="847.06"/>
-                <nad:node diagramId="91" equipmentId="VL7" x="-743.08" y="832.53"/>
-                <nad:node diagramId="94" equipmentId="VL8" x="-287.14" y="859.63"/>
-                <nad:node diagramId="96" equipmentId="VL9" x="550.55" y="731.35"/>
+                <nad:node svgId="0" equipmentId="VL1" x="-269.69" y="-93.47"/>
+                <nad:node svgId="2" equipmentId="VL10" x="846.23" y="833.49"/>
+                <nad:node svgId="5" equipmentId="VL11" x="1241.95" y="134.97"/>
+                <nad:node svgId="9" equipmentId="VL12" x="408.55" y="427.89"/>
+                <nad:node svgId="11" equipmentId="VL13" x="740.31" y="235.48"/>
+                <nad:node svgId="14" equipmentId="VL14" x="605.92" y="-65.16"/>
+                <nad:node svgId="17" equipmentId="VL15" x="143.15" y="20.88"/>
+                <nad:node svgId="20" equipmentId="VL16" x="-0.01" y="374.43"/>
+                <nad:node svgId="22" equipmentId="VL17" x="5.89" y="-216.42"/>
+                <nad:node svgId="24" equipmentId="VL19" x="-944.26" y="1444.53"/>
+                <nad:node svgId="26" equipmentId="VL2" x="-736.48" y="-15.02"/>
+                <nad:node svgId="28" equipmentId="VL20" x="-588.77" y="1088.92"/>
+                <nad:node svgId="31" equipmentId="VL22" x="-395.93" y="177.02"/>
+                <nad:node svgId="33" equipmentId="VL23" x="-910.76" y="-412.51"/>
+                <nad:node svgId="35" equipmentId="VL24" x="-1281.09" y="-717.24"/>
+                <nad:node svgId="39" equipmentId="VL27" x="-1535.07" y="-244.76"/>
+                <nad:node svgId="41" equipmentId="VL28" x="-1348.15" y="290.37"/>
+                <nad:node svgId="43" equipmentId="VL3" x="-693.77" y="399.71"/>
+                <nad:node svgId="45" equipmentId="VL30" x="-1062.06" y="-1227.28"/>
+                <nad:node svgId="47" equipmentId="VL31" x="-640.82" y="-1554.26"/>
+                <nad:node svgId="49" equipmentId="VL32" x="-103.26" y="-1734.24"/>
+                <nad:node svgId="52" equipmentId="VL33" x="-160.71" y="-2128.26"/>
+                <nad:node svgId="54" equipmentId="VL35" x="472.67" y="-1584.04"/>
+                <nad:node svgId="56" equipmentId="VL36" x="990.15" y="-1220.07"/>
+                <nad:node svgId="58" equipmentId="VL37" x="923.97" y="-881.50"/>
+                <nad:node svgId="60" equipmentId="VL38" x="472.29" y="-345.80"/>
+                <nad:node svgId="62" equipmentId="VL39" x="1418.63" y="-953.01"/>
+                <nad:node svgId="65" equipmentId="VL4" x="-1160.19" y="1084.54"/>
+                <nad:node svgId="68" equipmentId="VL40" x="1440.50" y="-562.18"/>
+                <nad:node svgId="71" equipmentId="VL42" x="1654.22" y="-148.09"/>
+                <nad:node svgId="73" equipmentId="VL44" x="188.38" y="-578.05"/>
+                <nad:node svgId="75" equipmentId="VL47" x="973.47" y="-408.27"/>
+                <nad:node svgId="77" equipmentId="VL48" x="916.67" y="-128.87"/>
+                <nad:node svgId="79" equipmentId="VL5" x="-1505.20" y="1031.73"/>
+                <nad:node svgId="81" equipmentId="VL50" x="1152.75" y="663.93"/>
+                <nad:node svgId="83" equipmentId="VL52" x="-302.76" y="1464.80"/>
+                <nad:node svgId="85" equipmentId="VL53" x="140.43" y="1652.22"/>
+                <nad:node svgId="87" equipmentId="VL54" x="476.73" y="1343.65"/>
+                <nad:node svgId="89" equipmentId="VL6" x="-1040.78" y="847.06"/>
+                <nad:node svgId="91" equipmentId="VL7" x="-743.08" y="832.53"/>
+                <nad:node svgId="94" equipmentId="VL8" x="-287.14" y="859.63"/>
+                <nad:node svgId="96" equipmentId="VL9" x="550.55" y="731.35"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge diagramId="99" equipmentId="L1-2-1"/>
-                <nad:edge diagramId="100" equipmentId="L1-15-1"/>
-                <nad:edge diagramId="101" equipmentId="L1-16-1"/>
-                <nad:edge diagramId="102" equipmentId="L1-17-1"/>
-                <nad:edge diagramId="103" equipmentId="L9-10-1"/>
-                <nad:edge diagramId="104" equipmentId="L10-12-1"/>
-                <nad:edge diagramId="105" equipmentId="L50-51-1"/>
-                <nad:edge diagramId="106" equipmentId="T10-51-1"/>
-                <nad:edge diagramId="107" equipmentId="L9-11-1"/>
-                <nad:edge diagramId="108" equipmentId="L11-13-1"/>
-                <nad:edge diagramId="109" equipmentId="L41-42-1"/>
-                <nad:edge diagramId="110" equipmentId="L41-43-1"/>
-                <nad:edge diagramId="111" equipmentId="L56-41-1"/>
-                <nad:edge diagramId="112" equipmentId="T11-41-1"/>
-                <nad:edge diagramId="113" equipmentId="T11-43-1"/>
-                <nad:edge diagramId="114" equipmentId="L9-12-1"/>
-                <nad:edge diagramId="115" equipmentId="L12-13-1"/>
-                <nad:edge diagramId="116" equipmentId="L12-16-1"/>
-                <nad:edge diagramId="117" equipmentId="L12-17-1"/>
-                <nad:edge diagramId="118" equipmentId="L9-13-1"/>
-                <nad:edge diagramId="119" equipmentId="L13-14-1"/>
-                <nad:edge diagramId="120" equipmentId="L13-15-1"/>
-                <nad:edge diagramId="121" equipmentId="L48-49-1"/>
-                <nad:edge diagramId="122" equipmentId="L49-50-1"/>
-                <nad:edge diagramId="123" equipmentId="L38-49-1"/>
-                <nad:edge diagramId="124" equipmentId="T13-49-1"/>
-                <nad:edge diagramId="125" equipmentId="L14-15-1"/>
-                <nad:edge diagramId="126" equipmentId="L46-47-1"/>
-                <nad:edge diagramId="127" equipmentId="T14-46-1"/>
-                <nad:edge diagramId="128" equipmentId="L3-15-1"/>
-                <nad:edge diagramId="129" equipmentId="L44-45-1"/>
-                <nad:edge diagramId="130" equipmentId="T15-45-1"/>
-                <nad:edge diagramId="131" equipmentId="L18-19-1"/>
-                <nad:edge diagramId="132" equipmentId="L19-20-1"/>
-                <nad:edge diagramId="133" equipmentId="L2-3-1"/>
-                <nad:edge diagramId="134" equipmentId="L21-22-1"/>
-                <nad:edge diagramId="135" equipmentId="T21-20-1"/>
-                <nad:edge diagramId="136" equipmentId="L22-23-1"/>
-                <nad:edge diagramId="137" equipmentId="L22-38-1"/>
-                <nad:edge diagramId="138" equipmentId="L23-24-1"/>
-                <nad:edge diagramId="139" equipmentId="L25-30-1"/>
-                <nad:edge diagramId="140" equipmentId="L26-27-1"/>
-                <nad:edge diagramId="141" equipmentId="T24-25-1"/>
-                <nad:edge diagramId="142" equipmentId="T24-25-2"/>
-                <nad:edge diagramId="143" equipmentId="T24-26-1"/>
-                <nad:edge diagramId="144" equipmentId="L27-28-1"/>
-                <nad:edge diagramId="145" equipmentId="L28-29-1"/>
-                <nad:edge diagramId="146" equipmentId="L3-4-1"/>
-                <nad:edge diagramId="147" equipmentId="L30-31-1"/>
-                <nad:edge diagramId="148" equipmentId="L31-32-1"/>
-                <nad:edge diagramId="149" equipmentId="L32-33-1"/>
-                <nad:edge diagramId="150" equipmentId="L34-35-1"/>
-                <nad:edge diagramId="151" equipmentId="T34-32-1"/>
-                <nad:edge diagramId="152" equipmentId="L35-36-1"/>
-                <nad:edge diagramId="153" equipmentId="L36-37-1"/>
-                <nad:edge diagramId="154" equipmentId="L36-40-1"/>
-                <nad:edge diagramId="155" equipmentId="L37-38-1"/>
-                <nad:edge diagramId="156" equipmentId="L37-39-1"/>
-                <nad:edge diagramId="157" equipmentId="L38-44-1"/>
-                <nad:edge diagramId="158" equipmentId="L38-48-1"/>
-                <nad:edge diagramId="159" equipmentId="L57-56-1"/>
-                <nad:edge diagramId="160" equipmentId="T39-57-1"/>
-                <nad:edge diagramId="161" equipmentId="L4-5-1"/>
-                <nad:edge diagramId="162" equipmentId="L4-6-1"/>
-                <nad:edge diagramId="163" equipmentId="T4-18-1"/>
-                <nad:edge diagramId="164" equipmentId="T4-18-2"/>
-                <nad:edge diagramId="165" equipmentId="L56-42-1"/>
-                <nad:edge diagramId="166" equipmentId="T40-56-1"/>
-                <nad:edge diagramId="167" equipmentId="L47-48-1"/>
-                <nad:edge diagramId="168" equipmentId="L5-6-1"/>
-                <nad:edge diagramId="169" equipmentId="L29-52-1"/>
-                <nad:edge diagramId="170" equipmentId="L52-53-1"/>
-                <nad:edge diagramId="171" equipmentId="L53-54-1"/>
-                <nad:edge diagramId="172" equipmentId="L54-55-1"/>
-                <nad:edge diagramId="173" equipmentId="L6-7-1"/>
-                <nad:edge diagramId="174" equipmentId="L6-8-1"/>
-                <nad:edge diagramId="175" equipmentId="L7-8-1"/>
-                <nad:edge diagramId="176" equipmentId="T7-29-1"/>
-                <nad:edge diagramId="177" equipmentId="L8-9-1"/>
-                <nad:edge diagramId="178" equipmentId="T9-55-1"/>
+                <nad:edge svgId="99" equipmentId="L1-2-1"/>
+                <nad:edge svgId="100" equipmentId="L1-15-1"/>
+                <nad:edge svgId="101" equipmentId="L1-16-1"/>
+                <nad:edge svgId="102" equipmentId="L1-17-1"/>
+                <nad:edge svgId="103" equipmentId="L9-10-1"/>
+                <nad:edge svgId="104" equipmentId="L10-12-1"/>
+                <nad:edge svgId="105" equipmentId="L50-51-1"/>
+                <nad:edge svgId="106" equipmentId="T10-51-1"/>
+                <nad:edge svgId="107" equipmentId="L9-11-1"/>
+                <nad:edge svgId="108" equipmentId="L11-13-1"/>
+                <nad:edge svgId="109" equipmentId="L41-42-1"/>
+                <nad:edge svgId="110" equipmentId="L41-43-1"/>
+                <nad:edge svgId="111" equipmentId="L56-41-1"/>
+                <nad:edge svgId="112" equipmentId="T11-41-1"/>
+                <nad:edge svgId="113" equipmentId="T11-43-1"/>
+                <nad:edge svgId="114" equipmentId="L9-12-1"/>
+                <nad:edge svgId="115" equipmentId="L12-13-1"/>
+                <nad:edge svgId="116" equipmentId="L12-16-1"/>
+                <nad:edge svgId="117" equipmentId="L12-17-1"/>
+                <nad:edge svgId="118" equipmentId="L9-13-1"/>
+                <nad:edge svgId="119" equipmentId="L13-14-1"/>
+                <nad:edge svgId="120" equipmentId="L13-15-1"/>
+                <nad:edge svgId="121" equipmentId="L48-49-1"/>
+                <nad:edge svgId="122" equipmentId="L49-50-1"/>
+                <nad:edge svgId="123" equipmentId="L38-49-1"/>
+                <nad:edge svgId="124" equipmentId="T13-49-1"/>
+                <nad:edge svgId="125" equipmentId="L14-15-1"/>
+                <nad:edge svgId="126" equipmentId="L46-47-1"/>
+                <nad:edge svgId="127" equipmentId="T14-46-1"/>
+                <nad:edge svgId="128" equipmentId="L3-15-1"/>
+                <nad:edge svgId="129" equipmentId="L44-45-1"/>
+                <nad:edge svgId="130" equipmentId="T15-45-1"/>
+                <nad:edge svgId="131" equipmentId="L18-19-1"/>
+                <nad:edge svgId="132" equipmentId="L19-20-1"/>
+                <nad:edge svgId="133" equipmentId="L2-3-1"/>
+                <nad:edge svgId="134" equipmentId="L21-22-1"/>
+                <nad:edge svgId="135" equipmentId="T21-20-1"/>
+                <nad:edge svgId="136" equipmentId="L22-23-1"/>
+                <nad:edge svgId="137" equipmentId="L22-38-1"/>
+                <nad:edge svgId="138" equipmentId="L23-24-1"/>
+                <nad:edge svgId="139" equipmentId="L25-30-1"/>
+                <nad:edge svgId="140" equipmentId="L26-27-1"/>
+                <nad:edge svgId="141" equipmentId="T24-25-1"/>
+                <nad:edge svgId="142" equipmentId="T24-25-2"/>
+                <nad:edge svgId="143" equipmentId="T24-26-1"/>
+                <nad:edge svgId="144" equipmentId="L27-28-1"/>
+                <nad:edge svgId="145" equipmentId="L28-29-1"/>
+                <nad:edge svgId="146" equipmentId="L3-4-1"/>
+                <nad:edge svgId="147" equipmentId="L30-31-1"/>
+                <nad:edge svgId="148" equipmentId="L31-32-1"/>
+                <nad:edge svgId="149" equipmentId="L32-33-1"/>
+                <nad:edge svgId="150" equipmentId="L34-35-1"/>
+                <nad:edge svgId="151" equipmentId="T34-32-1"/>
+                <nad:edge svgId="152" equipmentId="L35-36-1"/>
+                <nad:edge svgId="153" equipmentId="L36-37-1"/>
+                <nad:edge svgId="154" equipmentId="L36-40-1"/>
+                <nad:edge svgId="155" equipmentId="L37-38-1"/>
+                <nad:edge svgId="156" equipmentId="L37-39-1"/>
+                <nad:edge svgId="157" equipmentId="L38-44-1"/>
+                <nad:edge svgId="158" equipmentId="L38-48-1"/>
+                <nad:edge svgId="159" equipmentId="L57-56-1"/>
+                <nad:edge svgId="160" equipmentId="T39-57-1"/>
+                <nad:edge svgId="161" equipmentId="L4-5-1"/>
+                <nad:edge svgId="162" equipmentId="L4-6-1"/>
+                <nad:edge svgId="163" equipmentId="T4-18-1"/>
+                <nad:edge svgId="164" equipmentId="T4-18-2"/>
+                <nad:edge svgId="165" equipmentId="L56-42-1"/>
+                <nad:edge svgId="166" equipmentId="T40-56-1"/>
+                <nad:edge svgId="167" equipmentId="L47-48-1"/>
+                <nad:edge svgId="168" equipmentId="L5-6-1"/>
+                <nad:edge svgId="169" equipmentId="L29-52-1"/>
+                <nad:edge svgId="170" equipmentId="L52-53-1"/>
+                <nad:edge svgId="171" equipmentId="L53-54-1"/>
+                <nad:edge svgId="172" equipmentId="L54-55-1"/>
+                <nad:edge svgId="173" equipmentId="L6-7-1"/>
+                <nad:edge svgId="174" equipmentId="L6-8-1"/>
+                <nad:edge svgId="175" equipmentId="L7-8-1"/>
+                <nad:edge svgId="176" equipmentId="T7-29-1"/>
+                <nad:edge svgId="177" equipmentId="L8-9-1"/>
+                <nad:edge svgId="178" equipmentId="T9-55-1"/>
             </nad:edges>
         </nad:nad>
     </metadata>

--- a/network-area-diagram/src/test/resources/IEEE_57_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_57_bus.svg
@@ -114,63 +114,63 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="VL1_0" x="-269.69" y="-93.47"/>
-                <nad:busNode diagramId="3" equipmentId="VL10_0" x="846.23" y="833.49"/>
-                <nad:busNode diagramId="4" equipmentId="VL10_1" x="846.23" y="833.49"/>
-                <nad:busNode diagramId="6" equipmentId="VL11_0" x="1241.95" y="134.97"/>
-                <nad:busNode diagramId="7" equipmentId="VL11_1" x="1241.95" y="134.97"/>
-                <nad:busNode diagramId="8" equipmentId="VL11_2" x="1241.95" y="134.97"/>
-                <nad:busNode diagramId="10" equipmentId="VL12_0" x="408.55" y="427.89"/>
-                <nad:busNode diagramId="12" equipmentId="VL13_0" x="740.31" y="235.48"/>
-                <nad:busNode diagramId="13" equipmentId="VL13_1" x="740.31" y="235.48"/>
-                <nad:busNode diagramId="15" equipmentId="VL14_0" x="605.92" y="-65.16"/>
-                <nad:busNode diagramId="16" equipmentId="VL14_1" x="605.92" y="-65.16"/>
-                <nad:busNode diagramId="18" equipmentId="VL15_0" x="143.15" y="20.88"/>
-                <nad:busNode diagramId="19" equipmentId="VL15_1" x="143.15" y="20.88"/>
-                <nad:busNode diagramId="21" equipmentId="VL16_0" x="-0.01" y="374.43"/>
-                <nad:busNode diagramId="23" equipmentId="VL17_0" x="5.89" y="-216.42"/>
-                <nad:busNode diagramId="25" equipmentId="VL19_0" x="-944.26" y="1444.53"/>
-                <nad:busNode diagramId="27" equipmentId="VL2_0" x="-736.48" y="-15.02"/>
-                <nad:busNode diagramId="29" equipmentId="VL20_0" x="-588.77" y="1088.92"/>
-                <nad:busNode diagramId="30" equipmentId="VL20_1" x="-588.77" y="1088.92"/>
-                <nad:busNode diagramId="32" equipmentId="VL22_0" x="-395.93" y="177.02"/>
-                <nad:busNode diagramId="34" equipmentId="VL23_0" x="-910.76" y="-412.51"/>
-                <nad:busNode diagramId="36" equipmentId="VL24_0" x="-1281.09" y="-717.24"/>
-                <nad:busNode diagramId="37" equipmentId="VL24_1" x="-1281.09" y="-717.24"/>
-                <nad:busNode diagramId="38" equipmentId="VL24_2" x="-1281.09" y="-717.24"/>
-                <nad:busNode diagramId="40" equipmentId="VL27_0" x="-1535.07" y="-244.76"/>
-                <nad:busNode diagramId="42" equipmentId="VL28_0" x="-1348.15" y="290.37"/>
-                <nad:busNode diagramId="44" equipmentId="VL3_0" x="-693.77" y="399.71"/>
-                <nad:busNode diagramId="46" equipmentId="VL30_0" x="-1062.06" y="-1227.28"/>
-                <nad:busNode diagramId="48" equipmentId="VL31_0" x="-640.82" y="-1554.26"/>
-                <nad:busNode diagramId="50" equipmentId="VL32_0" x="-103.26" y="-1734.24"/>
-                <nad:busNode diagramId="51" equipmentId="VL32_1" x="-103.26" y="-1734.24"/>
-                <nad:busNode diagramId="53" equipmentId="VL33_0" x="-160.71" y="-2128.26"/>
-                <nad:busNode diagramId="55" equipmentId="VL35_0" x="472.67" y="-1584.04"/>
-                <nad:busNode diagramId="57" equipmentId="VL36_0" x="990.15" y="-1220.07"/>
-                <nad:busNode diagramId="59" equipmentId="VL37_0" x="923.97" y="-881.50"/>
-                <nad:busNode diagramId="61" equipmentId="VL38_0" x="472.29" y="-345.80"/>
-                <nad:busNode diagramId="63" equipmentId="VL39_0" x="1418.63" y="-953.01"/>
-                <nad:busNode diagramId="64" equipmentId="VL39_1" x="1418.63" y="-953.01"/>
-                <nad:busNode diagramId="66" equipmentId="VL4_0" x="-1160.19" y="1084.54"/>
-                <nad:busNode diagramId="67" equipmentId="VL4_1" x="-1160.19" y="1084.54"/>
-                <nad:busNode diagramId="69" equipmentId="VL40_0" x="1440.50" y="-562.18"/>
-                <nad:busNode diagramId="70" equipmentId="VL40_1" x="1440.50" y="-562.18"/>
-                <nad:busNode diagramId="72" equipmentId="VL42_0" x="1654.22" y="-148.09"/>
-                <nad:busNode diagramId="74" equipmentId="VL44_0" x="188.38" y="-578.05"/>
-                <nad:busNode diagramId="76" equipmentId="VL47_0" x="973.47" y="-408.27"/>
-                <nad:busNode diagramId="78" equipmentId="VL48_0" x="916.67" y="-128.87"/>
-                <nad:busNode diagramId="80" equipmentId="VL5_0" x="-1505.20" y="1031.73"/>
-                <nad:busNode diagramId="82" equipmentId="VL50_0" x="1152.75" y="663.93"/>
-                <nad:busNode diagramId="84" equipmentId="VL52_0" x="-302.76" y="1464.80"/>
-                <nad:busNode diagramId="86" equipmentId="VL53_0" x="140.43" y="1652.22"/>
-                <nad:busNode diagramId="88" equipmentId="VL54_0" x="476.73" y="1343.65"/>
-                <nad:busNode diagramId="90" equipmentId="VL6_0" x="-1040.78" y="847.06"/>
-                <nad:busNode diagramId="92" equipmentId="VL7_0" x="-743.08" y="832.53"/>
-                <nad:busNode diagramId="93" equipmentId="VL7_1" x="-743.08" y="832.53"/>
-                <nad:busNode diagramId="95" equipmentId="VL8_0" x="-287.14" y="859.63"/>
-                <nad:busNode diagramId="97" equipmentId="VL9_0" x="550.55" y="731.35"/>
-                <nad:busNode diagramId="98" equipmentId="VL9_1" x="550.55" y="731.35"/>
+                <nad:busNode diagramId="1" equipmentId="VL1_0"/>
+                <nad:busNode diagramId="3" equipmentId="VL10_0"/>
+                <nad:busNode diagramId="4" equipmentId="VL10_1"/>
+                <nad:busNode diagramId="6" equipmentId="VL11_0"/>
+                <nad:busNode diagramId="7" equipmentId="VL11_1"/>
+                <nad:busNode diagramId="8" equipmentId="VL11_2"/>
+                <nad:busNode diagramId="10" equipmentId="VL12_0"/>
+                <nad:busNode diagramId="12" equipmentId="VL13_0"/>
+                <nad:busNode diagramId="13" equipmentId="VL13_1"/>
+                <nad:busNode diagramId="15" equipmentId="VL14_0"/>
+                <nad:busNode diagramId="16" equipmentId="VL14_1"/>
+                <nad:busNode diagramId="18" equipmentId="VL15_0"/>
+                <nad:busNode diagramId="19" equipmentId="VL15_1"/>
+                <nad:busNode diagramId="21" equipmentId="VL16_0"/>
+                <nad:busNode diagramId="23" equipmentId="VL17_0"/>
+                <nad:busNode diagramId="25" equipmentId="VL19_0"/>
+                <nad:busNode diagramId="27" equipmentId="VL2_0"/>
+                <nad:busNode diagramId="29" equipmentId="VL20_0"/>
+                <nad:busNode diagramId="30" equipmentId="VL20_1"/>
+                <nad:busNode diagramId="32" equipmentId="VL22_0"/>
+                <nad:busNode diagramId="34" equipmentId="VL23_0"/>
+                <nad:busNode diagramId="36" equipmentId="VL24_0"/>
+                <nad:busNode diagramId="37" equipmentId="VL24_1"/>
+                <nad:busNode diagramId="38" equipmentId="VL24_2"/>
+                <nad:busNode diagramId="40" equipmentId="VL27_0"/>
+                <nad:busNode diagramId="42" equipmentId="VL28_0"/>
+                <nad:busNode diagramId="44" equipmentId="VL3_0"/>
+                <nad:busNode diagramId="46" equipmentId="VL30_0"/>
+                <nad:busNode diagramId="48" equipmentId="VL31_0"/>
+                <nad:busNode diagramId="50" equipmentId="VL32_0"/>
+                <nad:busNode diagramId="51" equipmentId="VL32_1"/>
+                <nad:busNode diagramId="53" equipmentId="VL33_0"/>
+                <nad:busNode diagramId="55" equipmentId="VL35_0"/>
+                <nad:busNode diagramId="57" equipmentId="VL36_0"/>
+                <nad:busNode diagramId="59" equipmentId="VL37_0"/>
+                <nad:busNode diagramId="61" equipmentId="VL38_0"/>
+                <nad:busNode diagramId="63" equipmentId="VL39_0"/>
+                <nad:busNode diagramId="64" equipmentId="VL39_1"/>
+                <nad:busNode diagramId="66" equipmentId="VL4_0"/>
+                <nad:busNode diagramId="67" equipmentId="VL4_1"/>
+                <nad:busNode diagramId="69" equipmentId="VL40_0"/>
+                <nad:busNode diagramId="70" equipmentId="VL40_1"/>
+                <nad:busNode diagramId="72" equipmentId="VL42_0"/>
+                <nad:busNode diagramId="74" equipmentId="VL44_0"/>
+                <nad:busNode diagramId="76" equipmentId="VL47_0"/>
+                <nad:busNode diagramId="78" equipmentId="VL48_0"/>
+                <nad:busNode diagramId="80" equipmentId="VL5_0"/>
+                <nad:busNode diagramId="82" equipmentId="VL50_0"/>
+                <nad:busNode diagramId="84" equipmentId="VL52_0"/>
+                <nad:busNode diagramId="86" equipmentId="VL53_0"/>
+                <nad:busNode diagramId="88" equipmentId="VL54_0"/>
+                <nad:busNode diagramId="90" equipmentId="VL6_0"/>
+                <nad:busNode diagramId="92" equipmentId="VL7_0"/>
+                <nad:busNode diagramId="93" equipmentId="VL7_1"/>
+                <nad:busNode diagramId="95" equipmentId="VL8_0"/>
+                <nad:busNode diagramId="97" equipmentId="VL9_0"/>
+                <nad:busNode diagramId="98" equipmentId="VL9_1"/>
             </nad:busNodes>
             <nad:nodes>
                 <nad:node diagramId="0" equipmentId="VL1" x="-269.69" y="-93.47"/>

--- a/network-area-diagram/src/test/resources/current_limits.svg
+++ b/network-area-diagram/src/test/resources/current_limits.svg
@@ -49,15 +49,15 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="vl1_0"/>
-                <nad:busNode diagramId="3" equipmentId="vl2_0"/>
+                <nad:busNode svgId="1" equipmentId="vl1_0"/>
+                <nad:busNode svgId="3" equipmentId="vl2_0"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node diagramId="0" equipmentId="vl1" x="159.59" y="-88.93"/>
-                <nad:node diagramId="2" equipmentId="vl2" x="-84.74" y="167.62"/>
+                <nad:node svgId="0" equipmentId="vl1" x="159.59" y="-88.93"/>
+                <nad:node svgId="2" equipmentId="vl2" x="-84.74" y="167.62"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge diagramId="4" equipmentId="l1"/>
+                <nad:edge svgId="4" equipmentId="l1"/>
             </nad:edges>
         </nad:nad>
     </metadata>

--- a/network-area-diagram/src/test/resources/current_limits.svg
+++ b/network-area-diagram/src/test/resources/current_limits.svg
@@ -49,8 +49,8 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="vl1_0" x="159.59" y="-88.93"/>
-                <nad:busNode diagramId="3" equipmentId="vl2_0" x="-84.74" y="167.62"/>
+                <nad:busNode diagramId="1" equipmentId="vl1_0"/>
+                <nad:busNode diagramId="3" equipmentId="vl2_0"/>
             </nad:busNodes>
             <nad:nodes>
                 <nad:node diagramId="0" equipmentId="vl1" x="159.59" y="-88.93"/>

--- a/network-area-diagram/src/test/resources/detailed_text_node.svg
+++ b/network-area-diagram/src/test/resources/detailed_text_node.svg
@@ -114,15 +114,15 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="vl1_0"/>
-                <nad:busNode diagramId="3" equipmentId="vl2_0"/>
+                <nad:busNode svgId="1" equipmentId="vl1_0"/>
+                <nad:busNode svgId="3" equipmentId="vl2_0"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node diagramId="0" equipmentId="vl1" x="159.59" y="-88.93"/>
-                <nad:node diagramId="2" equipmentId="vl2" x="-84.74" y="167.62"/>
+                <nad:node svgId="0" equipmentId="vl1" x="159.59" y="-88.93"/>
+                <nad:node svgId="2" equipmentId="vl2" x="-84.74" y="167.62"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge diagramId="4" equipmentId="l1"/>
+                <nad:edge svgId="4" equipmentId="l1"/>
             </nad:edges>
         </nad:nad>
     </metadata>

--- a/network-area-diagram/src/test/resources/detailed_text_node.svg
+++ b/network-area-diagram/src/test/resources/detailed_text_node.svg
@@ -114,8 +114,8 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="vl1_0" x="159.59" y="-88.93"/>
-                <nad:busNode diagramId="3" equipmentId="vl2_0" x="-84.74" y="167.62"/>
+                <nad:busNode diagramId="1" equipmentId="vl1_0"/>
+                <nad:busNode diagramId="3" equipmentId="vl2_0"/>
             </nad:busNodes>
             <nad:nodes>
                 <nad:node diagramId="0" equipmentId="vl1" x="159.59" y="-88.93"/>

--- a/network-area-diagram/src/test/resources/detailed_text_node_no_legend.svg
+++ b/network-area-diagram/src/test/resources/detailed_text_node_no_legend.svg
@@ -114,15 +114,15 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="vl1_0"/>
-                <nad:busNode diagramId="3" equipmentId="vl2_0"/>
+                <nad:busNode svgId="1" equipmentId="vl1_0"/>
+                <nad:busNode svgId="3" equipmentId="vl2_0"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node diagramId="0" equipmentId="vl1" x="159.59" y="-88.93"/>
-                <nad:node diagramId="2" equipmentId="vl2" x="-84.74" y="167.62"/>
+                <nad:node svgId="0" equipmentId="vl1" x="159.59" y="-88.93"/>
+                <nad:node svgId="2" equipmentId="vl2" x="-84.74" y="167.62"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge diagramId="4" equipmentId="l1"/>
+                <nad:edge svgId="4" equipmentId="l1"/>
             </nad:edges>
         </nad:nad>
     </metadata>

--- a/network-area-diagram/src/test/resources/detailed_text_node_no_legend.svg
+++ b/network-area-diagram/src/test/resources/detailed_text_node_no_legend.svg
@@ -114,8 +114,8 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="vl1_0" x="159.59" y="-88.93"/>
-                <nad:busNode diagramId="3" equipmentId="vl2_0" x="-84.74" y="167.62"/>
+                <nad:busNode diagramId="1" equipmentId="vl1_0"/>
+                <nad:busNode diagramId="3" equipmentId="vl2_0"/>
             </nad:busNodes>
             <nad:nodes>
                 <nad:node diagramId="0" equipmentId="vl1" x="159.59" y="-88.93"/>

--- a/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.0.svg
+++ b/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.0.svg
@@ -49,21 +49,21 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="A 230_0" x="-1079.96" y="333.71"/>
-                <nad:busNode diagramId="3" equipmentId="A 400_0" x="-1400.60" y="110.15"/>
-                <nad:busNode diagramId="5" equipmentId="B 230_0" x="-652.84" y="449.89"/>
-                <nad:busNode diagramId="7" equipmentId="C 20_0" x="1071.49" y="-357.56"/>
-                <nad:busNode diagramId="9" equipmentId="C 230_0" x="-133.04" y="361.83"/>
-                <nad:busNode diagramId="11" equipmentId="C 66_0" x="696.57" y="-44.99"/>
-                <nad:busNode diagramId="13" equipmentId="D 10_0" x="394.71" y="18.56"/>
-                <nad:busNode diagramId="15" equipmentId="D 66_0" x="890.04" y="196.72"/>
-                <nad:busNode diagramId="17" equipmentId="E 10_0" x="388.39" y="-480.46"/>
-                <nad:busNode diagramId="19" equipmentId="F 10_0" x="27.07" y="-527.58"/>
-                <nad:busNode diagramId="21" equipmentId="G 10_0" x="-353.26" y="-627.67"/>
-                <nad:busNode diagramId="23" equipmentId="H 10_0" x="-201.99" y="-255.59"/>
-                <nad:busNode diagramId="25" equipmentId="I 10_0" x="36.97" y="46.15"/>
-                <nad:busNode diagramId="27" equipmentId="J 10_0" x="197.15" y="589.04"/>
-                <nad:busNode diagramId="29" equipmentId="K 10_0" x="531.12" y="540.93"/>
+                <nad:busNode diagramId="1" equipmentId="A 230_0"/>
+                <nad:busNode diagramId="3" equipmentId="A 400_0"/>
+                <nad:busNode diagramId="5" equipmentId="B 230_0"/>
+                <nad:busNode diagramId="7" equipmentId="C 20_0"/>
+                <nad:busNode diagramId="9" equipmentId="C 230_0"/>
+                <nad:busNode diagramId="11" equipmentId="C 66_0"/>
+                <nad:busNode diagramId="13" equipmentId="D 10_0"/>
+                <nad:busNode diagramId="15" equipmentId="D 66_0"/>
+                <nad:busNode diagramId="17" equipmentId="E 10_0"/>
+                <nad:busNode diagramId="19" equipmentId="F 10_0"/>
+                <nad:busNode diagramId="21" equipmentId="G 10_0"/>
+                <nad:busNode diagramId="23" equipmentId="H 10_0"/>
+                <nad:busNode diagramId="25" equipmentId="I 10_0"/>
+                <nad:busNode diagramId="27" equipmentId="J 10_0"/>
+                <nad:busNode diagramId="29" equipmentId="K 10_0"/>
             </nad:busNodes>
             <nad:nodes>
                 <nad:node diagramId="0" equipmentId="A 230" x="-1079.96" y="333.71"/>

--- a/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.0.svg
+++ b/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.0.svg
@@ -49,56 +49,56 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="A 230_0"/>
-                <nad:busNode diagramId="3" equipmentId="A 400_0"/>
-                <nad:busNode diagramId="5" equipmentId="B 230_0"/>
-                <nad:busNode diagramId="7" equipmentId="C 20_0"/>
-                <nad:busNode diagramId="9" equipmentId="C 230_0"/>
-                <nad:busNode diagramId="11" equipmentId="C 66_0"/>
-                <nad:busNode diagramId="13" equipmentId="D 10_0"/>
-                <nad:busNode diagramId="15" equipmentId="D 66_0"/>
-                <nad:busNode diagramId="17" equipmentId="E 10_0"/>
-                <nad:busNode diagramId="19" equipmentId="F 10_0"/>
-                <nad:busNode diagramId="21" equipmentId="G 10_0"/>
-                <nad:busNode diagramId="23" equipmentId="H 10_0"/>
-                <nad:busNode diagramId="25" equipmentId="I 10_0"/>
-                <nad:busNode diagramId="27" equipmentId="J 10_0"/>
-                <nad:busNode diagramId="29" equipmentId="K 10_0"/>
+                <nad:busNode svgId="1" equipmentId="A 230_0"/>
+                <nad:busNode svgId="3" equipmentId="A 400_0"/>
+                <nad:busNode svgId="5" equipmentId="B 230_0"/>
+                <nad:busNode svgId="7" equipmentId="C 20_0"/>
+                <nad:busNode svgId="9" equipmentId="C 230_0"/>
+                <nad:busNode svgId="11" equipmentId="C 66_0"/>
+                <nad:busNode svgId="13" equipmentId="D 10_0"/>
+                <nad:busNode svgId="15" equipmentId="D 66_0"/>
+                <nad:busNode svgId="17" equipmentId="E 10_0"/>
+                <nad:busNode svgId="19" equipmentId="F 10_0"/>
+                <nad:busNode svgId="21" equipmentId="G 10_0"/>
+                <nad:busNode svgId="23" equipmentId="H 10_0"/>
+                <nad:busNode svgId="25" equipmentId="I 10_0"/>
+                <nad:busNode svgId="27" equipmentId="J 10_0"/>
+                <nad:busNode svgId="29" equipmentId="K 10_0"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node diagramId="0" equipmentId="A 230" x="-1079.96" y="333.71"/>
-                <nad:node diagramId="2" equipmentId="A 400" x="-1400.60" y="110.15"/>
-                <nad:node diagramId="4" equipmentId="B 230" x="-652.84" y="449.89"/>
-                <nad:node diagramId="6" equipmentId="C 20" x="1071.49" y="-357.56"/>
-                <nad:node diagramId="8" equipmentId="C 230" x="-133.04" y="361.83"/>
-                <nad:node diagramId="10" equipmentId="C 66" x="696.57" y="-44.99"/>
-                <nad:node diagramId="12" equipmentId="D 10" x="394.71" y="18.56"/>
-                <nad:node diagramId="14" equipmentId="D 66" x="890.04" y="196.72"/>
-                <nad:node diagramId="16" equipmentId="E 10" x="388.39" y="-480.46"/>
-                <nad:node diagramId="18" equipmentId="F 10" x="27.07" y="-527.58"/>
-                <nad:node diagramId="20" equipmentId="G 10" x="-353.26" y="-627.67"/>
-                <nad:node diagramId="22" equipmentId="H 10" x="-201.99" y="-255.59"/>
-                <nad:node diagramId="24" equipmentId="I 10" x="36.97" y="46.15"/>
-                <nad:node diagramId="26" equipmentId="J 10" x="197.15" y="589.04"/>
-                <nad:node diagramId="28" equipmentId="K 10" x="531.12" y="540.93"/>
+                <nad:node svgId="0" equipmentId="A 230" x="-1079.96" y="333.71"/>
+                <nad:node svgId="2" equipmentId="A 400" x="-1400.60" y="110.15"/>
+                <nad:node svgId="4" equipmentId="B 230" x="-652.84" y="449.89"/>
+                <nad:node svgId="6" equipmentId="C 20" x="1071.49" y="-357.56"/>
+                <nad:node svgId="8" equipmentId="C 230" x="-133.04" y="361.83"/>
+                <nad:node svgId="10" equipmentId="C 66" x="696.57" y="-44.99"/>
+                <nad:node svgId="12" equipmentId="D 10" x="394.71" y="18.56"/>
+                <nad:node svgId="14" equipmentId="D 66" x="890.04" y="196.72"/>
+                <nad:node svgId="16" equipmentId="E 10" x="388.39" y="-480.46"/>
+                <nad:node svgId="18" equipmentId="F 10" x="27.07" y="-527.58"/>
+                <nad:node svgId="20" equipmentId="G 10" x="-353.26" y="-627.67"/>
+                <nad:node svgId="22" equipmentId="H 10" x="-201.99" y="-255.59"/>
+                <nad:node svgId="24" equipmentId="I 10" x="36.97" y="46.15"/>
+                <nad:node svgId="26" equipmentId="J 10" x="197.15" y="589.04"/>
+                <nad:node svgId="28" equipmentId="K 10" x="531.12" y="540.93"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge diagramId="30" equipmentId="A - B"/>
-                <nad:edge diagramId="31" equipmentId="A 400 230"/>
-                <nad:edge diagramId="32" equipmentId="B - C"/>
-                <nad:edge diagramId="33" equipmentId="C 66 20"/>
-                <nad:edge diagramId="34" equipmentId="C 230 66"/>
-                <nad:edge diagramId="35" equipmentId="C - D"/>
-                <nad:edge diagramId="36" equipmentId="D - E"/>
-                <nad:edge diagramId="37" equipmentId="H - D"/>
-                <nad:edge diagramId="38" equipmentId="K - D"/>
-                <nad:edge diagramId="39" equipmentId="D 66 10"/>
-                <nad:edge diagramId="40" equipmentId="E - F"/>
-                <nad:edge diagramId="41" equipmentId="F - G"/>
-                <nad:edge diagramId="42" equipmentId="F - I"/>
-                <nad:edge diagramId="43" equipmentId="G - H"/>
-                <nad:edge diagramId="44" equipmentId="I - J"/>
-                <nad:edge diagramId="45" equipmentId="J - K"/>
+                <nad:edge svgId="30" equipmentId="A - B"/>
+                <nad:edge svgId="31" equipmentId="A 400 230"/>
+                <nad:edge svgId="32" equipmentId="B - C"/>
+                <nad:edge svgId="33" equipmentId="C 66 20"/>
+                <nad:edge svgId="34" equipmentId="C 230 66"/>
+                <nad:edge svgId="35" equipmentId="C - D"/>
+                <nad:edge svgId="36" equipmentId="D - E"/>
+                <nad:edge svgId="37" equipmentId="H - D"/>
+                <nad:edge svgId="38" equipmentId="K - D"/>
+                <nad:edge svgId="39" equipmentId="D 66 10"/>
+                <nad:edge svgId="40" equipmentId="E - F"/>
+                <nad:edge svgId="41" equipmentId="F - G"/>
+                <nad:edge svgId="42" equipmentId="F - I"/>
+                <nad:edge svgId="43" equipmentId="G - H"/>
+                <nad:edge svgId="44" equipmentId="I - J"/>
+                <nad:edge svgId="45" equipmentId="J - K"/>
             </nad:edges>
         </nad:nad>
     </metadata>

--- a/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.2.svg
+++ b/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.2.svg
@@ -49,21 +49,21 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="A 230_0" x="-1786.74" y="291.69"/>
-                <nad:busNode diagramId="3" equipmentId="A 400_0" x="-2026.74" y="-33.30"/>
-                <nad:busNode diagramId="5" equipmentId="B 230_0" x="-1451.50" y="634.69"/>
-                <nad:busNode diagramId="7" equipmentId="C 20_0" x="-556.38" y="362.32"/>
-                <nad:busNode diagramId="9" equipmentId="C 230_0" x="-1004.67" y="862.59"/>
-                <nad:busNode diagramId="11" equipmentId="C 66_0" x="-454.23" y="759.76"/>
-                <nad:busNode diagramId="13" equipmentId="D 10_0" x="505.49" y="118.48"/>
-                <nad:busNode diagramId="15" equipmentId="D 66_0" x="112.38" y="611.74"/>
-                <nad:busNode diagramId="17" equipmentId="E 10_0" x="717.25" y="-362.96"/>
-                <nad:busNode diagramId="19" equipmentId="F 10_0" x="819.43" y="-857.64"/>
-                <nad:busNode diagramId="21" equipmentId="G 10_0" x="268.32" y="-888.64"/>
-                <nad:busNode diagramId="23" equipmentId="H 10_0" x="110.95" y="-398.21"/>
-                <nad:busNode diagramId="25" equipmentId="I 10_0" x="1359.11" y="-706.74"/>
-                <nad:busNode diagramId="27" equipmentId="J 10_0" x="1491.86" y="-198.36"/>
-                <nad:busNode diagramId="29" equipmentId="K 10_0" x="1137.19" y="196.56"/>
+                <nad:busNode diagramId="1" equipmentId="A 230_0"/>
+                <nad:busNode diagramId="3" equipmentId="A 400_0"/>
+                <nad:busNode diagramId="5" equipmentId="B 230_0"/>
+                <nad:busNode diagramId="7" equipmentId="C 20_0"/>
+                <nad:busNode diagramId="9" equipmentId="C 230_0"/>
+                <nad:busNode diagramId="11" equipmentId="C 66_0"/>
+                <nad:busNode diagramId="13" equipmentId="D 10_0"/>
+                <nad:busNode diagramId="15" equipmentId="D 66_0"/>
+                <nad:busNode diagramId="17" equipmentId="E 10_0"/>
+                <nad:busNode diagramId="19" equipmentId="F 10_0"/>
+                <nad:busNode diagramId="21" equipmentId="G 10_0"/>
+                <nad:busNode diagramId="23" equipmentId="H 10_0"/>
+                <nad:busNode diagramId="25" equipmentId="I 10_0"/>
+                <nad:busNode diagramId="27" equipmentId="J 10_0"/>
+                <nad:busNode diagramId="29" equipmentId="K 10_0"/>
             </nad:busNodes>
             <nad:nodes>
                 <nad:node diagramId="0" equipmentId="A 230" x="-1786.74" y="291.69"/>

--- a/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.2.svg
+++ b/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.2.svg
@@ -49,56 +49,56 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="A 230_0"/>
-                <nad:busNode diagramId="3" equipmentId="A 400_0"/>
-                <nad:busNode diagramId="5" equipmentId="B 230_0"/>
-                <nad:busNode diagramId="7" equipmentId="C 20_0"/>
-                <nad:busNode diagramId="9" equipmentId="C 230_0"/>
-                <nad:busNode diagramId="11" equipmentId="C 66_0"/>
-                <nad:busNode diagramId="13" equipmentId="D 10_0"/>
-                <nad:busNode diagramId="15" equipmentId="D 66_0"/>
-                <nad:busNode diagramId="17" equipmentId="E 10_0"/>
-                <nad:busNode diagramId="19" equipmentId="F 10_0"/>
-                <nad:busNode diagramId="21" equipmentId="G 10_0"/>
-                <nad:busNode diagramId="23" equipmentId="H 10_0"/>
-                <nad:busNode diagramId="25" equipmentId="I 10_0"/>
-                <nad:busNode diagramId="27" equipmentId="J 10_0"/>
-                <nad:busNode diagramId="29" equipmentId="K 10_0"/>
+                <nad:busNode svgId="1" equipmentId="A 230_0"/>
+                <nad:busNode svgId="3" equipmentId="A 400_0"/>
+                <nad:busNode svgId="5" equipmentId="B 230_0"/>
+                <nad:busNode svgId="7" equipmentId="C 20_0"/>
+                <nad:busNode svgId="9" equipmentId="C 230_0"/>
+                <nad:busNode svgId="11" equipmentId="C 66_0"/>
+                <nad:busNode svgId="13" equipmentId="D 10_0"/>
+                <nad:busNode svgId="15" equipmentId="D 66_0"/>
+                <nad:busNode svgId="17" equipmentId="E 10_0"/>
+                <nad:busNode svgId="19" equipmentId="F 10_0"/>
+                <nad:busNode svgId="21" equipmentId="G 10_0"/>
+                <nad:busNode svgId="23" equipmentId="H 10_0"/>
+                <nad:busNode svgId="25" equipmentId="I 10_0"/>
+                <nad:busNode svgId="27" equipmentId="J 10_0"/>
+                <nad:busNode svgId="29" equipmentId="K 10_0"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node diagramId="0" equipmentId="A 230" x="-1786.74" y="291.69"/>
-                <nad:node diagramId="2" equipmentId="A 400" x="-2026.74" y="-33.30"/>
-                <nad:node diagramId="4" equipmentId="B 230" x="-1451.50" y="634.69"/>
-                <nad:node diagramId="6" equipmentId="C 20" x="-556.38" y="362.32"/>
-                <nad:node diagramId="8" equipmentId="C 230" x="-1004.67" y="862.59"/>
-                <nad:node diagramId="10" equipmentId="C 66" x="-454.23" y="759.76"/>
-                <nad:node diagramId="12" equipmentId="D 10" x="505.49" y="118.48"/>
-                <nad:node diagramId="14" equipmentId="D 66" x="112.38" y="611.74"/>
-                <nad:node diagramId="16" equipmentId="E 10" x="717.25" y="-362.96"/>
-                <nad:node diagramId="18" equipmentId="F 10" x="819.43" y="-857.64"/>
-                <nad:node diagramId="20" equipmentId="G 10" x="268.32" y="-888.64"/>
-                <nad:node diagramId="22" equipmentId="H 10" x="110.95" y="-398.21"/>
-                <nad:node diagramId="24" equipmentId="I 10" x="1359.11" y="-706.74"/>
-                <nad:node diagramId="26" equipmentId="J 10" x="1491.86" y="-198.36"/>
-                <nad:node diagramId="28" equipmentId="K 10" x="1137.19" y="196.56"/>
+                <nad:node svgId="0" equipmentId="A 230" x="-1786.74" y="291.69"/>
+                <nad:node svgId="2" equipmentId="A 400" x="-2026.74" y="-33.30"/>
+                <nad:node svgId="4" equipmentId="B 230" x="-1451.50" y="634.69"/>
+                <nad:node svgId="6" equipmentId="C 20" x="-556.38" y="362.32"/>
+                <nad:node svgId="8" equipmentId="C 230" x="-1004.67" y="862.59"/>
+                <nad:node svgId="10" equipmentId="C 66" x="-454.23" y="759.76"/>
+                <nad:node svgId="12" equipmentId="D 10" x="505.49" y="118.48"/>
+                <nad:node svgId="14" equipmentId="D 66" x="112.38" y="611.74"/>
+                <nad:node svgId="16" equipmentId="E 10" x="717.25" y="-362.96"/>
+                <nad:node svgId="18" equipmentId="F 10" x="819.43" y="-857.64"/>
+                <nad:node svgId="20" equipmentId="G 10" x="268.32" y="-888.64"/>
+                <nad:node svgId="22" equipmentId="H 10" x="110.95" y="-398.21"/>
+                <nad:node svgId="24" equipmentId="I 10" x="1359.11" y="-706.74"/>
+                <nad:node svgId="26" equipmentId="J 10" x="1491.86" y="-198.36"/>
+                <nad:node svgId="28" equipmentId="K 10" x="1137.19" y="196.56"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge diagramId="30" equipmentId="A - B"/>
-                <nad:edge diagramId="31" equipmentId="A 400 230"/>
-                <nad:edge diagramId="32" equipmentId="B - C"/>
-                <nad:edge diagramId="33" equipmentId="C 66 20"/>
-                <nad:edge diagramId="34" equipmentId="C 230 66"/>
-                <nad:edge diagramId="35" equipmentId="C - D"/>
-                <nad:edge diagramId="36" equipmentId="D - E"/>
-                <nad:edge diagramId="37" equipmentId="H - D"/>
-                <nad:edge diagramId="38" equipmentId="K - D"/>
-                <nad:edge diagramId="39" equipmentId="D 66 10"/>
-                <nad:edge diagramId="40" equipmentId="E - F"/>
-                <nad:edge diagramId="41" equipmentId="F - G"/>
-                <nad:edge diagramId="42" equipmentId="F - I"/>
-                <nad:edge diagramId="43" equipmentId="G - H"/>
-                <nad:edge diagramId="44" equipmentId="I - J"/>
-                <nad:edge diagramId="45" equipmentId="J - K"/>
+                <nad:edge svgId="30" equipmentId="A - B"/>
+                <nad:edge svgId="31" equipmentId="A 400 230"/>
+                <nad:edge svgId="32" equipmentId="B - C"/>
+                <nad:edge svgId="33" equipmentId="C 66 20"/>
+                <nad:edge svgId="34" equipmentId="C 230 66"/>
+                <nad:edge svgId="35" equipmentId="C - D"/>
+                <nad:edge svgId="36" equipmentId="D - E"/>
+                <nad:edge svgId="37" equipmentId="H - D"/>
+                <nad:edge svgId="38" equipmentId="K - D"/>
+                <nad:edge svgId="39" equipmentId="D 66 10"/>
+                <nad:edge svgId="40" equipmentId="E - F"/>
+                <nad:edge svgId="41" equipmentId="F - G"/>
+                <nad:edge svgId="42" equipmentId="F - I"/>
+                <nad:edge svgId="43" equipmentId="G - H"/>
+                <nad:edge svgId="44" equipmentId="I - J"/>
+                <nad:edge svgId="45" equipmentId="J - K"/>
             </nad:edges>
         </nad:nad>
     </metadata>

--- a/network-area-diagram/src/test/resources/edge_info_double_labels.svg
+++ b/network-area-diagram/src/test/resources/edge_info_double_labels.svg
@@ -49,18 +49,18 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="VL_11_0"/>
-                <nad:busNode diagramId="3" equipmentId="VL_132_0"/>
-                <nad:busNode diagramId="5" equipmentId="VL_33_0"/>
+                <nad:busNode svgId="1" equipmentId="VL_11_0"/>
+                <nad:busNode svgId="3" equipmentId="VL_132_0"/>
+                <nad:busNode svgId="5" equipmentId="VL_33_0"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node diagramId="0" equipmentId="VL_11" x="-198.78" y="-222.73"/>
-                <nad:node diagramId="2" equipmentId="VL_132" x="-179.95" y="359.14"/>
-                <nad:node diagramId="4" equipmentId="VL_33" x="454.74" y="-65.39"/>
-                <nad:node diagramId="6" equipmentId="3WT" x="72.67" y="53.08"/>
+                <nad:node svgId="0" equipmentId="VL_11" x="-198.78" y="-222.73"/>
+                <nad:node svgId="2" equipmentId="VL_132" x="-179.95" y="359.14"/>
+                <nad:node svgId="4" equipmentId="VL_33" x="454.74" y="-65.39"/>
+                <nad:node svgId="6" equipmentId="3WT" x="72.67" y="53.08"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge diagramId="9" equipmentId="3WT"/>
+                <nad:edge svgId="9" equipmentId="3WT"/>
             </nad:edges>
         </nad:nad>
     </metadata>

--- a/network-area-diagram/src/test/resources/edge_info_double_labels.svg
+++ b/network-area-diagram/src/test/resources/edge_info_double_labels.svg
@@ -49,9 +49,9 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="VL_11_0" x="-198.78" y="-222.73"/>
-                <nad:busNode diagramId="3" equipmentId="VL_132_0" x="-179.95" y="359.14"/>
-                <nad:busNode diagramId="5" equipmentId="VL_33_0" x="454.74" y="-65.39"/>
+                <nad:busNode diagramId="1" equipmentId="VL_11_0"/>
+                <nad:busNode diagramId="3" equipmentId="VL_132_0"/>
+                <nad:busNode diagramId="5" equipmentId="VL_33_0"/>
             </nad:busNodes>
             <nad:nodes>
                 <nad:node diagramId="0" equipmentId="VL_11" x="-198.78" y="-222.73"/>

--- a/network-area-diagram/src/test/resources/edge_info_missing_label.svg
+++ b/network-area-diagram/src/test/resources/edge_info_missing_label.svg
@@ -49,15 +49,15 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="vl1_0"/>
-                <nad:busNode diagramId="3" equipmentId="vl2_0"/>
+                <nad:busNode svgId="1" equipmentId="vl1_0"/>
+                <nad:busNode svgId="3" equipmentId="vl2_0"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node diagramId="0" equipmentId="vl1" x="159.59" y="-88.93"/>
-                <nad:node diagramId="2" equipmentId="vl2" x="-84.74" y="167.62"/>
+                <nad:node svgId="0" equipmentId="vl1" x="159.59" y="-88.93"/>
+                <nad:node svgId="2" equipmentId="vl2" x="-84.74" y="167.62"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge diagramId="4" equipmentId="l1"/>
+                <nad:edge svgId="4" equipmentId="l1"/>
             </nad:edges>
         </nad:nad>
     </metadata>

--- a/network-area-diagram/src/test/resources/edge_info_missing_label.svg
+++ b/network-area-diagram/src/test/resources/edge_info_missing_label.svg
@@ -49,8 +49,8 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="vl1_0" x="159.59" y="-88.93"/>
-                <nad:busNode diagramId="3" equipmentId="vl2_0" x="-84.74" y="167.62"/>
+                <nad:busNode diagramId="1" equipmentId="vl1_0"/>
+                <nad:busNode diagramId="3" equipmentId="vl2_0"/>
             </nad:busNodes>
             <nad:nodes>
                 <nad:node diagramId="0" equipmentId="vl1" x="159.59" y="-88.93"/>

--- a/network-area-diagram/src/test/resources/edge_info_perpendicular_label.svg
+++ b/network-area-diagram/src/test/resources/edge_info_perpendicular_label.svg
@@ -49,15 +49,15 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="vl1_0"/>
-                <nad:busNode diagramId="3" equipmentId="vl2_0"/>
+                <nad:busNode svgId="1" equipmentId="vl1_0"/>
+                <nad:busNode svgId="3" equipmentId="vl2_0"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node diagramId="0" equipmentId="vl1" x="159.59" y="-88.93"/>
-                <nad:node diagramId="2" equipmentId="vl2" x="-84.74" y="167.62"/>
+                <nad:node svgId="0" equipmentId="vl1" x="159.59" y="-88.93"/>
+                <nad:node svgId="2" equipmentId="vl2" x="-84.74" y="167.62"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge diagramId="4" equipmentId="l1"/>
+                <nad:edge svgId="4" equipmentId="l1"/>
             </nad:edges>
         </nad:nad>
     </metadata>

--- a/network-area-diagram/src/test/resources/edge_info_perpendicular_label.svg
+++ b/network-area-diagram/src/test/resources/edge_info_perpendicular_label.svg
@@ -49,8 +49,8 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="vl1_0" x="159.59" y="-88.93"/>
-                <nad:busNode diagramId="3" equipmentId="vl2_0" x="-84.74" y="167.62"/>
+                <nad:busNode diagramId="1" equipmentId="vl1_0"/>
+                <nad:busNode diagramId="3" equipmentId="vl2_0"/>
             </nad:busNodes>
             <nad:nodes>
                 <nad:node diagramId="0" equipmentId="vl1" x="159.59" y="-88.93"/>

--- a/network-area-diagram/src/test/resources/edge_info_shift.svg
+++ b/network-area-diagram/src/test/resources/edge_info_shift.svg
@@ -49,11 +49,11 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="vl1_0" x="-34.81" y="-139.87"/>
-                <nad:busNode diagramId="2" equipmentId="vl1_1" x="-34.81" y="-139.87"/>
-                <nad:busNode diagramId="4" equipmentId="vl2_0" x="-106.06" y="197.12"/>
-                <nad:busNode diagramId="6" equipmentId="vl3_0" x="232.52" y="76.75"/>
-                <nad:busNode diagramId="7" equipmentId="vl3_1" x="232.52" y="76.75"/>
+                <nad:busNode diagramId="1" equipmentId="vl1_0"/>
+                <nad:busNode diagramId="2" equipmentId="vl1_1"/>
+                <nad:busNode diagramId="4" equipmentId="vl2_0"/>
+                <nad:busNode diagramId="6" equipmentId="vl3_0"/>
+                <nad:busNode diagramId="7" equipmentId="vl3_1"/>
             </nad:busNodes>
             <nad:nodes>
                 <nad:node diagramId="0" equipmentId="vl1" x="-34.81" y="-139.87"/>

--- a/network-area-diagram/src/test/resources/edge_info_shift.svg
+++ b/network-area-diagram/src/test/resources/edge_info_shift.svg
@@ -49,22 +49,22 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="vl1_0"/>
-                <nad:busNode diagramId="2" equipmentId="vl1_1"/>
-                <nad:busNode diagramId="4" equipmentId="vl2_0"/>
-                <nad:busNode diagramId="6" equipmentId="vl3_0"/>
-                <nad:busNode diagramId="7" equipmentId="vl3_1"/>
+                <nad:busNode svgId="1" equipmentId="vl1_0"/>
+                <nad:busNode svgId="2" equipmentId="vl1_1"/>
+                <nad:busNode svgId="4" equipmentId="vl2_0"/>
+                <nad:busNode svgId="6" equipmentId="vl3_0"/>
+                <nad:busNode svgId="7" equipmentId="vl3_1"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node diagramId="0" equipmentId="vl1" x="-34.81" y="-139.87"/>
-                <nad:node diagramId="3" equipmentId="vl2" x="-106.06" y="197.12"/>
-                <nad:node diagramId="5" equipmentId="vl3" x="232.52" y="76.75"/>
+                <nad:node svgId="0" equipmentId="vl1" x="-34.81" y="-139.87"/>
+                <nad:node svgId="3" equipmentId="vl2" x="-106.06" y="197.12"/>
+                <nad:node svgId="5" equipmentId="vl3" x="232.52" y="76.75"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge diagramId="8" equipmentId="l1"/>
-                <nad:edge diagramId="9" equipmentId="l2"/>
-                <nad:edge diagramId="10" equipmentId="tr1"/>
-                <nad:edge diagramId="11" equipmentId="tr2"/>
+                <nad:edge svgId="8" equipmentId="l1"/>
+                <nad:edge svgId="9" equipmentId="l2"/>
+                <nad:edge svgId="10" equipmentId="tr1"/>
+                <nad:edge svgId="11" equipmentId="tr2"/>
             </nad:edges>
         </nad:nad>
     </metadata>

--- a/network-area-diagram/src/test/resources/hvdc-vl-depth-1.svg
+++ b/network-area-diagram/src/test/resources/hvdc-vl-depth-1.svg
@@ -49,15 +49,15 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="VL1_0"/>
-                <nad:busNode diagramId="3" equipmentId="VL2_0"/>
+                <nad:busNode svgId="1" equipmentId="VL1_0"/>
+                <nad:busNode svgId="3" equipmentId="VL2_0"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node diagramId="0" equipmentId="VL1" x="159.59" y="-88.93"/>
-                <nad:node diagramId="2" equipmentId="VL2" x="-84.74" y="167.62"/>
+                <nad:node svgId="0" equipmentId="VL1" x="159.59" y="-88.93"/>
+                <nad:node svgId="2" equipmentId="VL2" x="-84.74" y="167.62"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge diagramId="4" equipmentId="L"/>
+                <nad:edge svgId="4" equipmentId="L"/>
             </nad:edges>
         </nad:nad>
     </metadata>

--- a/network-area-diagram/src/test/resources/hvdc-vl-depth-1.svg
+++ b/network-area-diagram/src/test/resources/hvdc-vl-depth-1.svg
@@ -49,8 +49,8 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="VL1_0" x="159.59" y="-88.93"/>
-                <nad:busNode diagramId="3" equipmentId="VL2_0" x="-84.74" y="167.62"/>
+                <nad:busNode diagramId="1" equipmentId="VL1_0"/>
+                <nad:busNode diagramId="3" equipmentId="VL2_0"/>
             </nad:busNodes>
             <nad:nodes>
                 <nad:node diagramId="0" equipmentId="VL1" x="159.59" y="-88.93"/>

--- a/network-area-diagram/src/test/resources/hvdc.svg
+++ b/network-area-diagram/src/test/resources/hvdc.svg
@@ -49,25 +49,25 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="S1VL1_0"/>
-                <nad:busNode diagramId="3" equipmentId="S1VL2_0"/>
-                <nad:busNode diagramId="5" equipmentId="S2VL1_0"/>
-                <nad:busNode diagramId="7" equipmentId="S3VL1_0"/>
-                <nad:busNode diagramId="9" equipmentId="S4VL1_0"/>
+                <nad:busNode svgId="1" equipmentId="S1VL1_0"/>
+                <nad:busNode svgId="3" equipmentId="S1VL2_0"/>
+                <nad:busNode svgId="5" equipmentId="S2VL1_0"/>
+                <nad:busNode svgId="7" equipmentId="S3VL1_0"/>
+                <nad:busNode svgId="9" equipmentId="S4VL1_0"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node diagramId="0" equipmentId="S1VL1" x="-572.51" y="61.14"/>
-                <nad:node diagramId="2" equipmentId="S1VL2" x="-168.80" y="45.83"/>
-                <nad:node diagramId="4" equipmentId="S2VL1" x="73.32" y="-219.74"/>
-                <nad:node diagramId="6" equipmentId="S3VL1" x="250.50" y="93.81"/>
-                <nad:node diagramId="8" equipmentId="S4VL1" x="633.74" y="221.41"/>
+                <nad:node svgId="0" equipmentId="S1VL1" x="-572.51" y="61.14"/>
+                <nad:node svgId="2" equipmentId="S1VL2" x="-168.80" y="45.83"/>
+                <nad:node svgId="4" equipmentId="S2VL1" x="73.32" y="-219.74"/>
+                <nad:node svgId="6" equipmentId="S3VL1" x="250.50" y="93.81"/>
+                <nad:node svgId="8" equipmentId="S4VL1" x="633.74" y="221.41"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge diagramId="10" equipmentId="TWT"/>
-                <nad:edge diagramId="11" equipmentId="HVDC1"/>
-                <nad:edge diagramId="12" equipmentId="HVDC2"/>
-                <nad:edge diagramId="13" equipmentId="LINE_S2S3"/>
-                <nad:edge diagramId="14" equipmentId="LINE_S3S4"/>
+                <nad:edge svgId="10" equipmentId="TWT"/>
+                <nad:edge svgId="11" equipmentId="HVDC1"/>
+                <nad:edge svgId="12" equipmentId="HVDC2"/>
+                <nad:edge svgId="13" equipmentId="LINE_S2S3"/>
+                <nad:edge svgId="14" equipmentId="LINE_S3S4"/>
             </nad:edges>
         </nad:nad>
     </metadata>

--- a/network-area-diagram/src/test/resources/hvdc.svg
+++ b/network-area-diagram/src/test/resources/hvdc.svg
@@ -49,11 +49,11 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="S1VL1_0" x="-572.51" y="61.14"/>
-                <nad:busNode diagramId="3" equipmentId="S1VL2_0" x="-168.80" y="45.83"/>
-                <nad:busNode diagramId="5" equipmentId="S2VL1_0" x="73.32" y="-219.74"/>
-                <nad:busNode diagramId="7" equipmentId="S3VL1_0" x="250.50" y="93.81"/>
-                <nad:busNode diagramId="9" equipmentId="S4VL1_0" x="633.74" y="221.41"/>
+                <nad:busNode diagramId="1" equipmentId="S1VL1_0"/>
+                <nad:busNode diagramId="3" equipmentId="S1VL2_0"/>
+                <nad:busNode diagramId="5" equipmentId="S2VL1_0"/>
+                <nad:busNode diagramId="7" equipmentId="S3VL1_0"/>
+                <nad:busNode diagramId="9" equipmentId="S4VL1_0"/>
             </nad:busNodes>
             <nad:nodes>
                 <nad:node diagramId="0" equipmentId="S1VL1" x="-572.51" y="61.14"/>

--- a/network-area-diagram/src/test/resources/parallel_transformers.svg
+++ b/network-area-diagram/src/test/resources/parallel_transformers.svg
@@ -49,9 +49,9 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="vl1_0" x="159.59" y="-88.93"/>
-                <nad:busNode diagramId="2" equipmentId="vl1_1" x="159.59" y="-88.93"/>
-                <nad:busNode diagramId="4" equipmentId="vl2_0" x="-84.74" y="167.62"/>
+                <nad:busNode diagramId="1" equipmentId="vl1_0"/>
+                <nad:busNode diagramId="2" equipmentId="vl1_1"/>
+                <nad:busNode diagramId="4" equipmentId="vl2_0"/>
             </nad:busNodes>
             <nad:nodes>
                 <nad:node diagramId="0" equipmentId="vl1" x="159.59" y="-88.93"/>

--- a/network-area-diagram/src/test/resources/parallel_transformers.svg
+++ b/network-area-diagram/src/test/resources/parallel_transformers.svg
@@ -49,17 +49,17 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="vl1_0"/>
-                <nad:busNode diagramId="2" equipmentId="vl1_1"/>
-                <nad:busNode diagramId="4" equipmentId="vl2_0"/>
+                <nad:busNode svgId="1" equipmentId="vl1_0"/>
+                <nad:busNode svgId="2" equipmentId="vl1_1"/>
+                <nad:busNode svgId="4" equipmentId="vl2_0"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node diagramId="0" equipmentId="vl1" x="159.59" y="-88.93"/>
-                <nad:node diagramId="3" equipmentId="vl2" x="-84.74" y="167.62"/>
+                <nad:node svgId="0" equipmentId="vl1" x="159.59" y="-88.93"/>
+                <nad:node svgId="3" equipmentId="vl2" x="-84.74" y="167.62"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge diagramId="5" equipmentId="tr1"/>
-                <nad:edge diagramId="6" equipmentId="tr2"/>
+                <nad:edge svgId="5" equipmentId="tr1"/>
+                <nad:edge svgId="6" equipmentId="tr2"/>
             </nad:edges>
         </nad:nad>
     </metadata>

--- a/network-area-diagram/src/test/resources/simple-eu-loop100.svg
+++ b/network-area-diagram/src/test/resources/simple-eu-loop100.svg
@@ -114,18 +114,18 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="BBE1AA1_0" x="-474.24" y="-207.95"/>
-                <nad:busNode diagramId="2" equipmentId="BBE1AA1_1" x="-474.24" y="-207.95"/>
-                <nad:busNode diagramId="4" equipmentId="BBE2AA1_0" x="-554.05" y="231.25"/>
-                <nad:busNode diagramId="6" equipmentId="DDE1AA1_0" x="705.62" y="274.16"/>
-                <nad:busNode diagramId="8" equipmentId="DDE2AA1_0" x="450.15" y="0.62"/>
-                <nad:busNode diagramId="10" equipmentId="DDE3AA1_0" x="374.91" y="436.80"/>
-                <nad:busNode diagramId="12" equipmentId="FFR1AA1_0" x="36.39" y="731.65"/>
-                <nad:busNode diagramId="13" equipmentId="FFR1AA1_1" x="36.39" y="731.65"/>
-                <nad:busNode diagramId="15" equipmentId="FFR3AA1_0" x="-372.12" y="626.05"/>
-                <nad:busNode diagramId="17" equipmentId="NNL1AA1_0" x="123.07" y="-803.45"/>
-                <nad:busNode diagramId="19" equipmentId="NNL2AA1_0" x="-149.64" y="-534.70"/>
-                <nad:busNode diagramId="21" equipmentId="NNL3AA1_0" x="251.99" y="-442.28"/>
+                <nad:busNode diagramId="1" equipmentId="BBE1AA1_0"/>
+                <nad:busNode diagramId="2" equipmentId="BBE1AA1_1"/>
+                <nad:busNode diagramId="4" equipmentId="BBE2AA1_0"/>
+                <nad:busNode diagramId="6" equipmentId="DDE1AA1_0"/>
+                <nad:busNode diagramId="8" equipmentId="DDE2AA1_0"/>
+                <nad:busNode diagramId="10" equipmentId="DDE3AA1_0"/>
+                <nad:busNode diagramId="12" equipmentId="FFR1AA1_0"/>
+                <nad:busNode diagramId="13" equipmentId="FFR1AA1_1"/>
+                <nad:busNode diagramId="15" equipmentId="FFR3AA1_0"/>
+                <nad:busNode diagramId="17" equipmentId="NNL1AA1_0"/>
+                <nad:busNode diagramId="19" equipmentId="NNL2AA1_0"/>
+                <nad:busNode diagramId="21" equipmentId="NNL3AA1_0"/>
             </nad:busNodes>
             <nad:nodes>
                 <nad:node diagramId="0" equipmentId="BBE1AA1" x="-474.24" y="-207.95"/>

--- a/network-area-diagram/src/test/resources/simple-eu-loop100.svg
+++ b/network-area-diagram/src/test/resources/simple-eu-loop100.svg
@@ -114,50 +114,50 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="BBE1AA1_0"/>
-                <nad:busNode diagramId="2" equipmentId="BBE1AA1_1"/>
-                <nad:busNode diagramId="4" equipmentId="BBE2AA1_0"/>
-                <nad:busNode diagramId="6" equipmentId="DDE1AA1_0"/>
-                <nad:busNode diagramId="8" equipmentId="DDE2AA1_0"/>
-                <nad:busNode diagramId="10" equipmentId="DDE3AA1_0"/>
-                <nad:busNode diagramId="12" equipmentId="FFR1AA1_0"/>
-                <nad:busNode diagramId="13" equipmentId="FFR1AA1_1"/>
-                <nad:busNode diagramId="15" equipmentId="FFR3AA1_0"/>
-                <nad:busNode diagramId="17" equipmentId="NNL1AA1_0"/>
-                <nad:busNode diagramId="19" equipmentId="NNL2AA1_0"/>
-                <nad:busNode diagramId="21" equipmentId="NNL3AA1_0"/>
+                <nad:busNode svgId="1" equipmentId="BBE1AA1_0"/>
+                <nad:busNode svgId="2" equipmentId="BBE1AA1_1"/>
+                <nad:busNode svgId="4" equipmentId="BBE2AA1_0"/>
+                <nad:busNode svgId="6" equipmentId="DDE1AA1_0"/>
+                <nad:busNode svgId="8" equipmentId="DDE2AA1_0"/>
+                <nad:busNode svgId="10" equipmentId="DDE3AA1_0"/>
+                <nad:busNode svgId="12" equipmentId="FFR1AA1_0"/>
+                <nad:busNode svgId="13" equipmentId="FFR1AA1_1"/>
+                <nad:busNode svgId="15" equipmentId="FFR3AA1_0"/>
+                <nad:busNode svgId="17" equipmentId="NNL1AA1_0"/>
+                <nad:busNode svgId="19" equipmentId="NNL2AA1_0"/>
+                <nad:busNode svgId="21" equipmentId="NNL3AA1_0"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node diagramId="0" equipmentId="BBE1AA1" x="-474.24" y="-207.95"/>
-                <nad:node diagramId="3" equipmentId="BBE2AA1" x="-554.05" y="231.25"/>
-                <nad:node diagramId="5" equipmentId="DDE1AA1" x="705.62" y="274.16"/>
-                <nad:node diagramId="7" equipmentId="DDE2AA1" x="450.15" y="0.62"/>
-                <nad:node diagramId="9" equipmentId="DDE3AA1" x="374.91" y="436.80"/>
-                <nad:node diagramId="11" equipmentId="FFR1AA1" x="36.39" y="731.65"/>
-                <nad:node diagramId="14" equipmentId="FFR3AA1" x="-372.12" y="626.05"/>
-                <nad:node diagramId="16" equipmentId="NNL1AA1" x="123.07" y="-803.45"/>
-                <nad:node diagramId="18" equipmentId="NNL2AA1" x="-149.64" y="-534.70"/>
-                <nad:node diagramId="20" equipmentId="NNL3AA1" x="251.99" y="-442.28"/>
+                <nad:node svgId="0" equipmentId="BBE1AA1" x="-474.24" y="-207.95"/>
+                <nad:node svgId="3" equipmentId="BBE2AA1" x="-554.05" y="231.25"/>
+                <nad:node svgId="5" equipmentId="DDE1AA1" x="705.62" y="274.16"/>
+                <nad:node svgId="7" equipmentId="DDE2AA1" x="450.15" y="0.62"/>
+                <nad:node svgId="9" equipmentId="DDE3AA1" x="374.91" y="436.80"/>
+                <nad:node svgId="11" equipmentId="FFR1AA1" x="36.39" y="731.65"/>
+                <nad:node svgId="14" equipmentId="FFR3AA1" x="-372.12" y="626.05"/>
+                <nad:node svgId="16" equipmentId="NNL1AA1" x="123.07" y="-803.45"/>
+                <nad:node svgId="18" equipmentId="NNL2AA1" x="-149.64" y="-534.70"/>
+                <nad:node svgId="20" equipmentId="NNL3AA1" x="251.99" y="-442.28"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge diagramId="22" equipmentId="BBE1AA1  BBE2AA1  1"/>
-                <nad:edge diagramId="23" equipmentId="BBE1AA1  BBE3AA1  1"/>
-                <nad:edge diagramId="24" equipmentId="BBE2AA1  BBE3AA1  1"/>
-                <nad:edge diagramId="25" equipmentId="NNL2AA1  BBE3AA1  1"/>
-                <nad:edge diagramId="26" equipmentId="BBE1AA1  BBE3AA1  2"/>
-                <nad:edge diagramId="27" equipmentId="BBE2AA1  FFR3AA1  1"/>
-                <nad:edge diagramId="28" equipmentId="DDE1AA1  DDE2AA1  1"/>
-                <nad:edge diagramId="29" equipmentId="DDE1AA1  DDE3AA1  1"/>
-                <nad:edge diagramId="30" equipmentId="DDE2AA1  DDE3AA1  1"/>
-                <nad:edge diagramId="31" equipmentId="DDE2AA1  NNL3AA1  1"/>
-                <nad:edge diagramId="32" equipmentId="FFR2AA1  DDE3AA1  1"/>
-                <nad:edge diagramId="33" equipmentId="FFR1AA1  FFR2AA1  1"/>
-                <nad:edge diagramId="34" equipmentId="FFR1AA1  FFR3AA1  1"/>
-                <nad:edge diagramId="35" equipmentId="FFR2AA1  FFR3AA1  1"/>
-                <nad:edge diagramId="36" equipmentId="FFR1AA1  FFR2AA1  2"/>
-                <nad:edge diagramId="37" equipmentId="NNL1AA1  NNL2AA1  1"/>
-                <nad:edge diagramId="38" equipmentId="NNL1AA1  NNL3AA1  1"/>
-                <nad:edge diagramId="39" equipmentId="NNL2AA1  NNL3AA1  1"/>
+                <nad:edge svgId="22" equipmentId="BBE1AA1  BBE2AA1  1"/>
+                <nad:edge svgId="23" equipmentId="BBE1AA1  BBE3AA1  1"/>
+                <nad:edge svgId="24" equipmentId="BBE2AA1  BBE3AA1  1"/>
+                <nad:edge svgId="25" equipmentId="NNL2AA1  BBE3AA1  1"/>
+                <nad:edge svgId="26" equipmentId="BBE1AA1  BBE3AA1  2"/>
+                <nad:edge svgId="27" equipmentId="BBE2AA1  FFR3AA1  1"/>
+                <nad:edge svgId="28" equipmentId="DDE1AA1  DDE2AA1  1"/>
+                <nad:edge svgId="29" equipmentId="DDE1AA1  DDE3AA1  1"/>
+                <nad:edge svgId="30" equipmentId="DDE2AA1  DDE3AA1  1"/>
+                <nad:edge svgId="31" equipmentId="DDE2AA1  NNL3AA1  1"/>
+                <nad:edge svgId="32" equipmentId="FFR2AA1  DDE3AA1  1"/>
+                <nad:edge svgId="33" equipmentId="FFR1AA1  FFR2AA1  1"/>
+                <nad:edge svgId="34" equipmentId="FFR1AA1  FFR3AA1  1"/>
+                <nad:edge svgId="35" equipmentId="FFR2AA1  FFR3AA1  1"/>
+                <nad:edge svgId="36" equipmentId="FFR1AA1  FFR2AA1  2"/>
+                <nad:edge svgId="37" equipmentId="NNL1AA1  NNL2AA1  1"/>
+                <nad:edge svgId="38" equipmentId="NNL1AA1  NNL3AA1  1"/>
+                <nad:edge svgId="39" equipmentId="NNL2AA1  NNL3AA1  1"/>
             </nad:edges>
         </nad:nad>
     </metadata>

--- a/network-area-diagram/src/test/resources/simple-eu-loop80.svg
+++ b/network-area-diagram/src/test/resources/simple-eu-loop80.svg
@@ -114,18 +114,18 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="BBE1AA1_0" x="-474.24" y="-207.95"/>
-                <nad:busNode diagramId="2" equipmentId="BBE1AA1_1" x="-474.24" y="-207.95"/>
-                <nad:busNode diagramId="4" equipmentId="BBE2AA1_0" x="-554.05" y="231.25"/>
-                <nad:busNode diagramId="6" equipmentId="DDE1AA1_0" x="705.62" y="274.16"/>
-                <nad:busNode diagramId="8" equipmentId="DDE2AA1_0" x="450.15" y="0.62"/>
-                <nad:busNode diagramId="10" equipmentId="DDE3AA1_0" x="374.91" y="436.80"/>
-                <nad:busNode diagramId="12" equipmentId="FFR1AA1_0" x="36.39" y="731.65"/>
-                <nad:busNode diagramId="13" equipmentId="FFR1AA1_1" x="36.39" y="731.65"/>
-                <nad:busNode diagramId="15" equipmentId="FFR3AA1_0" x="-372.12" y="626.05"/>
-                <nad:busNode diagramId="17" equipmentId="NNL1AA1_0" x="123.07" y="-803.45"/>
-                <nad:busNode diagramId="19" equipmentId="NNL2AA1_0" x="-149.64" y="-534.70"/>
-                <nad:busNode diagramId="21" equipmentId="NNL3AA1_0" x="251.99" y="-442.28"/>
+                <nad:busNode diagramId="1" equipmentId="BBE1AA1_0"/>
+                <nad:busNode diagramId="2" equipmentId="BBE1AA1_1"/>
+                <nad:busNode diagramId="4" equipmentId="BBE2AA1_0"/>
+                <nad:busNode diagramId="6" equipmentId="DDE1AA1_0"/>
+                <nad:busNode diagramId="8" equipmentId="DDE2AA1_0"/>
+                <nad:busNode diagramId="10" equipmentId="DDE3AA1_0"/>
+                <nad:busNode diagramId="12" equipmentId="FFR1AA1_0"/>
+                <nad:busNode diagramId="13" equipmentId="FFR1AA1_1"/>
+                <nad:busNode diagramId="15" equipmentId="FFR3AA1_0"/>
+                <nad:busNode diagramId="17" equipmentId="NNL1AA1_0"/>
+                <nad:busNode diagramId="19" equipmentId="NNL2AA1_0"/>
+                <nad:busNode diagramId="21" equipmentId="NNL3AA1_0"/>
             </nad:busNodes>
             <nad:nodes>
                 <nad:node diagramId="0" equipmentId="BBE1AA1" x="-474.24" y="-207.95"/>

--- a/network-area-diagram/src/test/resources/simple-eu-loop80.svg
+++ b/network-area-diagram/src/test/resources/simple-eu-loop80.svg
@@ -114,50 +114,50 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="BBE1AA1_0"/>
-                <nad:busNode diagramId="2" equipmentId="BBE1AA1_1"/>
-                <nad:busNode diagramId="4" equipmentId="BBE2AA1_0"/>
-                <nad:busNode diagramId="6" equipmentId="DDE1AA1_0"/>
-                <nad:busNode diagramId="8" equipmentId="DDE2AA1_0"/>
-                <nad:busNode diagramId="10" equipmentId="DDE3AA1_0"/>
-                <nad:busNode diagramId="12" equipmentId="FFR1AA1_0"/>
-                <nad:busNode diagramId="13" equipmentId="FFR1AA1_1"/>
-                <nad:busNode diagramId="15" equipmentId="FFR3AA1_0"/>
-                <nad:busNode diagramId="17" equipmentId="NNL1AA1_0"/>
-                <nad:busNode diagramId="19" equipmentId="NNL2AA1_0"/>
-                <nad:busNode diagramId="21" equipmentId="NNL3AA1_0"/>
+                <nad:busNode svgId="1" equipmentId="BBE1AA1_0"/>
+                <nad:busNode svgId="2" equipmentId="BBE1AA1_1"/>
+                <nad:busNode svgId="4" equipmentId="BBE2AA1_0"/>
+                <nad:busNode svgId="6" equipmentId="DDE1AA1_0"/>
+                <nad:busNode svgId="8" equipmentId="DDE2AA1_0"/>
+                <nad:busNode svgId="10" equipmentId="DDE3AA1_0"/>
+                <nad:busNode svgId="12" equipmentId="FFR1AA1_0"/>
+                <nad:busNode svgId="13" equipmentId="FFR1AA1_1"/>
+                <nad:busNode svgId="15" equipmentId="FFR3AA1_0"/>
+                <nad:busNode svgId="17" equipmentId="NNL1AA1_0"/>
+                <nad:busNode svgId="19" equipmentId="NNL2AA1_0"/>
+                <nad:busNode svgId="21" equipmentId="NNL3AA1_0"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node diagramId="0" equipmentId="BBE1AA1" x="-474.24" y="-207.95"/>
-                <nad:node diagramId="3" equipmentId="BBE2AA1" x="-554.05" y="231.25"/>
-                <nad:node diagramId="5" equipmentId="DDE1AA1" x="705.62" y="274.16"/>
-                <nad:node diagramId="7" equipmentId="DDE2AA1" x="450.15" y="0.62"/>
-                <nad:node diagramId="9" equipmentId="DDE3AA1" x="374.91" y="436.80"/>
-                <nad:node diagramId="11" equipmentId="FFR1AA1" x="36.39" y="731.65"/>
-                <nad:node diagramId="14" equipmentId="FFR3AA1" x="-372.12" y="626.05"/>
-                <nad:node diagramId="16" equipmentId="NNL1AA1" x="123.07" y="-803.45"/>
-                <nad:node diagramId="18" equipmentId="NNL2AA1" x="-149.64" y="-534.70"/>
-                <nad:node diagramId="20" equipmentId="NNL3AA1" x="251.99" y="-442.28"/>
+                <nad:node svgId="0" equipmentId="BBE1AA1" x="-474.24" y="-207.95"/>
+                <nad:node svgId="3" equipmentId="BBE2AA1" x="-554.05" y="231.25"/>
+                <nad:node svgId="5" equipmentId="DDE1AA1" x="705.62" y="274.16"/>
+                <nad:node svgId="7" equipmentId="DDE2AA1" x="450.15" y="0.62"/>
+                <nad:node svgId="9" equipmentId="DDE3AA1" x="374.91" y="436.80"/>
+                <nad:node svgId="11" equipmentId="FFR1AA1" x="36.39" y="731.65"/>
+                <nad:node svgId="14" equipmentId="FFR3AA1" x="-372.12" y="626.05"/>
+                <nad:node svgId="16" equipmentId="NNL1AA1" x="123.07" y="-803.45"/>
+                <nad:node svgId="18" equipmentId="NNL2AA1" x="-149.64" y="-534.70"/>
+                <nad:node svgId="20" equipmentId="NNL3AA1" x="251.99" y="-442.28"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge diagramId="22" equipmentId="BBE1AA1  BBE2AA1  1"/>
-                <nad:edge diagramId="23" equipmentId="BBE1AA1  BBE3AA1  1"/>
-                <nad:edge diagramId="24" equipmentId="BBE2AA1  BBE3AA1  1"/>
-                <nad:edge diagramId="25" equipmentId="NNL2AA1  BBE3AA1  1"/>
-                <nad:edge diagramId="26" equipmentId="BBE1AA1  BBE3AA1  2"/>
-                <nad:edge diagramId="27" equipmentId="BBE2AA1  FFR3AA1  1"/>
-                <nad:edge diagramId="28" equipmentId="DDE1AA1  DDE2AA1  1"/>
-                <nad:edge diagramId="29" equipmentId="DDE1AA1  DDE3AA1  1"/>
-                <nad:edge diagramId="30" equipmentId="DDE2AA1  DDE3AA1  1"/>
-                <nad:edge diagramId="31" equipmentId="DDE2AA1  NNL3AA1  1"/>
-                <nad:edge diagramId="32" equipmentId="FFR2AA1  DDE3AA1  1"/>
-                <nad:edge diagramId="33" equipmentId="FFR1AA1  FFR2AA1  1"/>
-                <nad:edge diagramId="34" equipmentId="FFR1AA1  FFR3AA1  1"/>
-                <nad:edge diagramId="35" equipmentId="FFR2AA1  FFR3AA1  1"/>
-                <nad:edge diagramId="36" equipmentId="FFR1AA1  FFR2AA1  2"/>
-                <nad:edge diagramId="37" equipmentId="NNL1AA1  NNL2AA1  1"/>
-                <nad:edge diagramId="38" equipmentId="NNL1AA1  NNL3AA1  1"/>
-                <nad:edge diagramId="39" equipmentId="NNL2AA1  NNL3AA1  1"/>
+                <nad:edge svgId="22" equipmentId="BBE1AA1  BBE2AA1  1"/>
+                <nad:edge svgId="23" equipmentId="BBE1AA1  BBE3AA1  1"/>
+                <nad:edge svgId="24" equipmentId="BBE2AA1  BBE3AA1  1"/>
+                <nad:edge svgId="25" equipmentId="NNL2AA1  BBE3AA1  1"/>
+                <nad:edge svgId="26" equipmentId="BBE1AA1  BBE3AA1  2"/>
+                <nad:edge svgId="27" equipmentId="BBE2AA1  FFR3AA1  1"/>
+                <nad:edge svgId="28" equipmentId="DDE1AA1  DDE2AA1  1"/>
+                <nad:edge svgId="29" equipmentId="DDE1AA1  DDE3AA1  1"/>
+                <nad:edge svgId="30" equipmentId="DDE2AA1  DDE3AA1  1"/>
+                <nad:edge svgId="31" equipmentId="DDE2AA1  NNL3AA1  1"/>
+                <nad:edge svgId="32" equipmentId="FFR2AA1  DDE3AA1  1"/>
+                <nad:edge svgId="33" equipmentId="FFR1AA1  FFR2AA1  1"/>
+                <nad:edge svgId="34" equipmentId="FFR1AA1  FFR3AA1  1"/>
+                <nad:edge svgId="35" equipmentId="FFR2AA1  FFR3AA1  1"/>
+                <nad:edge svgId="36" equipmentId="FFR1AA1  FFR2AA1  2"/>
+                <nad:edge svgId="37" equipmentId="NNL1AA1  NNL2AA1  1"/>
+                <nad:edge svgId="38" equipmentId="NNL1AA1  NNL3AA1  1"/>
+                <nad:edge svgId="39" equipmentId="NNL2AA1  NNL3AA1  1"/>
             </nad:edges>
         </nad:nad>
     </metadata>

--- a/network-area-diagram/src/test/resources/simple-eu.svg
+++ b/network-area-diagram/src/test/resources/simple-eu.svg
@@ -114,18 +114,18 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="BBE1AA1_0" x="-474.24" y="-207.95"/>
-                <nad:busNode diagramId="2" equipmentId="BBE1AA1_1" x="-474.24" y="-207.95"/>
-                <nad:busNode diagramId="4" equipmentId="BBE2AA1_0" x="-554.05" y="231.25"/>
-                <nad:busNode diagramId="6" equipmentId="DDE1AA1_0" x="705.62" y="274.16"/>
-                <nad:busNode diagramId="8" equipmentId="DDE2AA1_0" x="450.15" y="0.62"/>
-                <nad:busNode diagramId="10" equipmentId="DDE3AA1_0" x="374.91" y="436.80"/>
-                <nad:busNode diagramId="12" equipmentId="FFR1AA1_0" x="36.39" y="731.65"/>
-                <nad:busNode diagramId="13" equipmentId="FFR1AA1_1" x="36.39" y="731.65"/>
-                <nad:busNode diagramId="15" equipmentId="FFR3AA1_0" x="-372.12" y="626.05"/>
-                <nad:busNode diagramId="17" equipmentId="NNL1AA1_0" x="123.07" y="-803.45"/>
-                <nad:busNode diagramId="19" equipmentId="NNL2AA1_0" x="-149.64" y="-534.70"/>
-                <nad:busNode diagramId="21" equipmentId="NNL3AA1_0" x="251.99" y="-442.28"/>
+                <nad:busNode diagramId="1" equipmentId="BBE1AA1_0"/>
+                <nad:busNode diagramId="2" equipmentId="BBE1AA1_1"/>
+                <nad:busNode diagramId="4" equipmentId="BBE2AA1_0"/>
+                <nad:busNode diagramId="6" equipmentId="DDE1AA1_0"/>
+                <nad:busNode diagramId="8" equipmentId="DDE2AA1_0"/>
+                <nad:busNode diagramId="10" equipmentId="DDE3AA1_0"/>
+                <nad:busNode diagramId="12" equipmentId="FFR1AA1_0"/>
+                <nad:busNode diagramId="13" equipmentId="FFR1AA1_1"/>
+                <nad:busNode diagramId="15" equipmentId="FFR3AA1_0"/>
+                <nad:busNode diagramId="17" equipmentId="NNL1AA1_0"/>
+                <nad:busNode diagramId="19" equipmentId="NNL2AA1_0"/>
+                <nad:busNode diagramId="21" equipmentId="NNL3AA1_0"/>
             </nad:busNodes>
             <nad:nodes>
                 <nad:node diagramId="0" equipmentId="BBE1AA1" x="-474.24" y="-207.95"/>

--- a/network-area-diagram/src/test/resources/simple-eu.svg
+++ b/network-area-diagram/src/test/resources/simple-eu.svg
@@ -114,50 +114,50 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="BBE1AA1_0"/>
-                <nad:busNode diagramId="2" equipmentId="BBE1AA1_1"/>
-                <nad:busNode diagramId="4" equipmentId="BBE2AA1_0"/>
-                <nad:busNode diagramId="6" equipmentId="DDE1AA1_0"/>
-                <nad:busNode diagramId="8" equipmentId="DDE2AA1_0"/>
-                <nad:busNode diagramId="10" equipmentId="DDE3AA1_0"/>
-                <nad:busNode diagramId="12" equipmentId="FFR1AA1_0"/>
-                <nad:busNode diagramId="13" equipmentId="FFR1AA1_1"/>
-                <nad:busNode diagramId="15" equipmentId="FFR3AA1_0"/>
-                <nad:busNode diagramId="17" equipmentId="NNL1AA1_0"/>
-                <nad:busNode diagramId="19" equipmentId="NNL2AA1_0"/>
-                <nad:busNode diagramId="21" equipmentId="NNL3AA1_0"/>
+                <nad:busNode svgId="1" equipmentId="BBE1AA1_0"/>
+                <nad:busNode svgId="2" equipmentId="BBE1AA1_1"/>
+                <nad:busNode svgId="4" equipmentId="BBE2AA1_0"/>
+                <nad:busNode svgId="6" equipmentId="DDE1AA1_0"/>
+                <nad:busNode svgId="8" equipmentId="DDE2AA1_0"/>
+                <nad:busNode svgId="10" equipmentId="DDE3AA1_0"/>
+                <nad:busNode svgId="12" equipmentId="FFR1AA1_0"/>
+                <nad:busNode svgId="13" equipmentId="FFR1AA1_1"/>
+                <nad:busNode svgId="15" equipmentId="FFR3AA1_0"/>
+                <nad:busNode svgId="17" equipmentId="NNL1AA1_0"/>
+                <nad:busNode svgId="19" equipmentId="NNL2AA1_0"/>
+                <nad:busNode svgId="21" equipmentId="NNL3AA1_0"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node diagramId="0" equipmentId="BBE1AA1" x="-474.24" y="-207.95"/>
-                <nad:node diagramId="3" equipmentId="BBE2AA1" x="-554.05" y="231.25"/>
-                <nad:node diagramId="5" equipmentId="DDE1AA1" x="705.62" y="274.16"/>
-                <nad:node diagramId="7" equipmentId="DDE2AA1" x="450.15" y="0.62"/>
-                <nad:node diagramId="9" equipmentId="DDE3AA1" x="374.91" y="436.80"/>
-                <nad:node diagramId="11" equipmentId="FFR1AA1" x="36.39" y="731.65"/>
-                <nad:node diagramId="14" equipmentId="FFR3AA1" x="-372.12" y="626.05"/>
-                <nad:node diagramId="16" equipmentId="NNL1AA1" x="123.07" y="-803.45"/>
-                <nad:node diagramId="18" equipmentId="NNL2AA1" x="-149.64" y="-534.70"/>
-                <nad:node diagramId="20" equipmentId="NNL3AA1" x="251.99" y="-442.28"/>
+                <nad:node svgId="0" equipmentId="BBE1AA1" x="-474.24" y="-207.95"/>
+                <nad:node svgId="3" equipmentId="BBE2AA1" x="-554.05" y="231.25"/>
+                <nad:node svgId="5" equipmentId="DDE1AA1" x="705.62" y="274.16"/>
+                <nad:node svgId="7" equipmentId="DDE2AA1" x="450.15" y="0.62"/>
+                <nad:node svgId="9" equipmentId="DDE3AA1" x="374.91" y="436.80"/>
+                <nad:node svgId="11" equipmentId="FFR1AA1" x="36.39" y="731.65"/>
+                <nad:node svgId="14" equipmentId="FFR3AA1" x="-372.12" y="626.05"/>
+                <nad:node svgId="16" equipmentId="NNL1AA1" x="123.07" y="-803.45"/>
+                <nad:node svgId="18" equipmentId="NNL2AA1" x="-149.64" y="-534.70"/>
+                <nad:node svgId="20" equipmentId="NNL3AA1" x="251.99" y="-442.28"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge diagramId="22" equipmentId="BBE1AA1  BBE2AA1  1"/>
-                <nad:edge diagramId="23" equipmentId="BBE1AA1  BBE3AA1  1"/>
-                <nad:edge diagramId="24" equipmentId="BBE2AA1  BBE3AA1  1"/>
-                <nad:edge diagramId="25" equipmentId="NNL2AA1  BBE3AA1  1"/>
-                <nad:edge diagramId="26" equipmentId="BBE1AA1  BBE3AA1  2"/>
-                <nad:edge diagramId="27" equipmentId="BBE2AA1  FFR3AA1  1"/>
-                <nad:edge diagramId="28" equipmentId="DDE1AA1  DDE2AA1  1"/>
-                <nad:edge diagramId="29" equipmentId="DDE1AA1  DDE3AA1  1"/>
-                <nad:edge diagramId="30" equipmentId="DDE2AA1  DDE3AA1  1"/>
-                <nad:edge diagramId="31" equipmentId="DDE2AA1  NNL3AA1  1"/>
-                <nad:edge diagramId="32" equipmentId="FFR2AA1  DDE3AA1  1"/>
-                <nad:edge diagramId="33" equipmentId="FFR1AA1  FFR2AA1  1"/>
-                <nad:edge diagramId="34" equipmentId="FFR1AA1  FFR3AA1  1"/>
-                <nad:edge diagramId="35" equipmentId="FFR2AA1  FFR3AA1  1"/>
-                <nad:edge diagramId="36" equipmentId="FFR1AA1  FFR2AA1  2"/>
-                <nad:edge diagramId="37" equipmentId="NNL1AA1  NNL2AA1  1"/>
-                <nad:edge diagramId="38" equipmentId="NNL1AA1  NNL3AA1  1"/>
-                <nad:edge diagramId="39" equipmentId="NNL2AA1  NNL3AA1  1"/>
+                <nad:edge svgId="22" equipmentId="BBE1AA1  BBE2AA1  1"/>
+                <nad:edge svgId="23" equipmentId="BBE1AA1  BBE3AA1  1"/>
+                <nad:edge svgId="24" equipmentId="BBE2AA1  BBE3AA1  1"/>
+                <nad:edge svgId="25" equipmentId="NNL2AA1  BBE3AA1  1"/>
+                <nad:edge svgId="26" equipmentId="BBE1AA1  BBE3AA1  2"/>
+                <nad:edge svgId="27" equipmentId="BBE2AA1  FFR3AA1  1"/>
+                <nad:edge svgId="28" equipmentId="DDE1AA1  DDE2AA1  1"/>
+                <nad:edge svgId="29" equipmentId="DDE1AA1  DDE3AA1  1"/>
+                <nad:edge svgId="30" equipmentId="DDE2AA1  DDE3AA1  1"/>
+                <nad:edge svgId="31" equipmentId="DDE2AA1  NNL3AA1  1"/>
+                <nad:edge svgId="32" equipmentId="FFR2AA1  DDE3AA1  1"/>
+                <nad:edge svgId="33" equipmentId="FFR1AA1  FFR2AA1  1"/>
+                <nad:edge svgId="34" equipmentId="FFR1AA1  FFR3AA1  1"/>
+                <nad:edge svgId="35" equipmentId="FFR2AA1  FFR3AA1  1"/>
+                <nad:edge svgId="36" equipmentId="FFR1AA1  FFR2AA1  2"/>
+                <nad:edge svgId="37" equipmentId="NNL1AA1  NNL2AA1  1"/>
+                <nad:edge svgId="38" equipmentId="NNL1AA1  NNL3AA1  1"/>
+                <nad:edge svgId="39" equipmentId="NNL2AA1  NNL3AA1  1"/>
             </nad:edges>
         </nad:nad>
     </metadata>

--- a/network-area-diagram/src/test/resources/vl_description_id.svg
+++ b/network-area-diagram/src/test/resources/vl_description_id.svg
@@ -114,15 +114,15 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="vl1_0"/>
-                <nad:busNode diagramId="3" equipmentId="vl2_0"/>
+                <nad:busNode svgId="1" equipmentId="vl1_0"/>
+                <nad:busNode svgId="3" equipmentId="vl2_0"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node diagramId="0" equipmentId="vl1" x="159.59" y="-88.93"/>
-                <nad:node diagramId="2" equipmentId="vl2" x="-84.74" y="167.62"/>
+                <nad:node svgId="0" equipmentId="vl1" x="159.59" y="-88.93"/>
+                <nad:node svgId="2" equipmentId="vl2" x="-84.74" y="167.62"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge diagramId="4" equipmentId="l1"/>
+                <nad:edge svgId="4" equipmentId="l1"/>
             </nad:edges>
         </nad:nad>
     </metadata>

--- a/network-area-diagram/src/test/resources/vl_description_id.svg
+++ b/network-area-diagram/src/test/resources/vl_description_id.svg
@@ -114,8 +114,8 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="vl1_0" x="159.59" y="-88.93"/>
-                <nad:busNode diagramId="3" equipmentId="vl2_0" x="-84.74" y="167.62"/>
+                <nad:busNode diagramId="1" equipmentId="vl1_0"/>
+                <nad:busNode diagramId="3" equipmentId="vl2_0"/>
             </nad:busNodes>
             <nad:nodes>
                 <nad:node diagramId="0" equipmentId="vl1" x="159.59" y="-88.93"/>

--- a/network-area-diagram/src/test/resources/vl_description_substation.svg
+++ b/network-area-diagram/src/test/resources/vl_description_substation.svg
@@ -114,15 +114,15 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="vl1_0"/>
-                <nad:busNode diagramId="3" equipmentId="vl2_0"/>
+                <nad:busNode svgId="1" equipmentId="vl1_0"/>
+                <nad:busNode svgId="3" equipmentId="vl2_0"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node diagramId="0" equipmentId="vl1" x="159.59" y="-88.93"/>
-                <nad:node diagramId="2" equipmentId="vl2" x="-84.74" y="167.62"/>
+                <nad:node svgId="0" equipmentId="vl1" x="159.59" y="-88.93"/>
+                <nad:node svgId="2" equipmentId="vl2" x="-84.74" y="167.62"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge diagramId="4" equipmentId="l1"/>
+                <nad:edge svgId="4" equipmentId="l1"/>
             </nad:edges>
         </nad:nad>
     </metadata>

--- a/network-area-diagram/src/test/resources/vl_description_substation.svg
+++ b/network-area-diagram/src/test/resources/vl_description_substation.svg
@@ -114,8 +114,8 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="vl1_0" x="159.59" y="-88.93"/>
-                <nad:busNode diagramId="3" equipmentId="vl2_0" x="-84.74" y="167.62"/>
+                <nad:busNode diagramId="1" equipmentId="vl1_0"/>
+                <nad:busNode diagramId="3" equipmentId="vl2_0"/>
             </nad:busNodes>
             <nad:nodes>
                 <nad:node diagramId="0" equipmentId="vl1" x="159.59" y="-88.93"/>

--- a/network-area-diagram/src/test/resources/vl_description_substation_id.svg
+++ b/network-area-diagram/src/test/resources/vl_description_substation_id.svg
@@ -114,15 +114,15 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="vl1_0"/>
-                <nad:busNode diagramId="3" equipmentId="vl2_0"/>
+                <nad:busNode svgId="1" equipmentId="vl1_0"/>
+                <nad:busNode svgId="3" equipmentId="vl2_0"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node diagramId="0" equipmentId="vl1" x="159.59" y="-88.93"/>
-                <nad:node diagramId="2" equipmentId="vl2" x="-84.74" y="167.62"/>
+                <nad:node svgId="0" equipmentId="vl1" x="159.59" y="-88.93"/>
+                <nad:node svgId="2" equipmentId="vl2" x="-84.74" y="167.62"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge diagramId="4" equipmentId="l1"/>
+                <nad:edge svgId="4" equipmentId="l1"/>
             </nad:edges>
         </nad:nad>
     </metadata>

--- a/network-area-diagram/src/test/resources/vl_description_substation_id.svg
+++ b/network-area-diagram/src/test/resources/vl_description_substation_id.svg
@@ -114,8 +114,8 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="vl1_0" x="159.59" y="-88.93"/>
-                <nad:busNode diagramId="3" equipmentId="vl2_0" x="-84.74" y="167.62"/>
+                <nad:busNode diagramId="1" equipmentId="vl1_0"/>
+                <nad:busNode diagramId="3" equipmentId="vl2_0"/>
             </nad:busNodes>
             <nad:nodes>
                 <nad:node diagramId="0" equipmentId="vl1" x="159.59" y="-88.93"/>

--- a/network-area-diagram/src/test/resources/voltage_limits.svg
+++ b/network-area-diagram/src/test/resources/voltage_limits.svg
@@ -49,17 +49,17 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="vl1_0"/>
-                <nad:busNode diagramId="2" equipmentId="vl1_1"/>
-                <nad:busNode diagramId="4" equipmentId="vl2_0"/>
+                <nad:busNode svgId="1" equipmentId="vl1_0"/>
+                <nad:busNode svgId="2" equipmentId="vl1_1"/>
+                <nad:busNode svgId="4" equipmentId="vl2_0"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node diagramId="0" equipmentId="vl1" x="159.59" y="-88.93"/>
-                <nad:node diagramId="3" equipmentId="vl2" x="-84.74" y="167.62"/>
+                <nad:node svgId="0" equipmentId="vl1" x="159.59" y="-88.93"/>
+                <nad:node svgId="3" equipmentId="vl2" x="-84.74" y="167.62"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge diagramId="5" equipmentId="l1"/>
-                <nad:edge diagramId="6" equipmentId="l2"/>
+                <nad:edge svgId="5" equipmentId="l1"/>
+                <nad:edge svgId="6" equipmentId="l2"/>
             </nad:edges>
         </nad:nad>
     </metadata>

--- a/network-area-diagram/src/test/resources/voltage_limits.svg
+++ b/network-area-diagram/src/test/resources/voltage_limits.svg
@@ -49,9 +49,9 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode diagramId="1" equipmentId="vl1_0" x="159.59" y="-88.93"/>
-                <nad:busNode diagramId="2" equipmentId="vl1_1" x="159.59" y="-88.93"/>
-                <nad:busNode diagramId="4" equipmentId="vl2_0" x="-84.74" y="167.62"/>
+                <nad:busNode diagramId="1" equipmentId="vl1_0"/>
+                <nad:busNode diagramId="2" equipmentId="vl1_1"/>
+                <nad:busNode diagramId="4" equipmentId="vl2_0"/>
             </nad:busNodes>
             <nad:nodes>
                 <nad:node diagramId="0" equipmentId="vl1" x="159.59" y="-88.93"/>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem ?**
No


**What kind of change does this PR introduce?**
Code simplification


**What is the current behavior?**
Metadata formats coordinates according to default locale `Locale`.
Metadata objects are the same for BusNode and Node, whereas they may contain different attributes.
When writing metadata objects, one needs to know whether they have already been prefixed or not.
metadata package has a dependence on other packages

**What is the new behavior (if this is a feature change)?**
Metadata coordinates are `String`, hence already formatted.
One NodeMetadata object, one BusNodeMetadata object
Metadata objects contain the svgId, not the diagramId, hence not wondering what's in prefix.
metadata package has no dependence on other packages


**Does this PR introduce a breaking change or deprecate an API?**
No