### PR TITLE
Edge parts can be stretchable or glued

### DIFF
--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/StyleProvider.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/StyleProvider.java
@@ -39,6 +39,9 @@ public interface StyleProvider {
     String LABEL_BOX_CLASS = CLASSES_PREFIX + "label-box";
     String LEGEND_SQUARE_CLASS = CLASSES_PREFIX + "legend-square";
     String PST_ARROW_CLASS = CLASSES_PREFIX + "pst-arrow";
+    String STRETCHABLE_CLASS = CLASSES_PREFIX + "stretchable";
+    String GLUED_CLASS = CLASSES_PREFIX + "glued";
+    String GLUED_CENTER_CLASS = CLASSES_PREFIX + "glued-center";
 
     List<String> getCssFilenames();
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/SvgWriter.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/SvgWriter.java
@@ -130,14 +130,7 @@ public class SvgWriter {
             drawHalfEdge(graph, writer, edge, BranchEdge.Side.ONE);
             drawHalfEdge(graph, writer, edge, BranchEdge.Side.TWO);
             if (edge.isTransformerEdge()) {
-                writer.writeStartElement(GROUP_ELEMENT_NAME);
-                writer.writeAttribute(CLASS_ATTRIBUTE, StyleProvider.GLUED_CENTER_CLASS);
-                draw2WtWinding(writer, edge, BranchEdge.Side.ONE);
-                draw2WtWinding(writer, edge, BranchEdge.Side.TWO);
-                writer.writeEndElement();
-                if (BranchEdge.PST_EDGE.equals(edge.getType())) {
-                    drawPstArrow(writer, edge);
-                }
+                draw2Wt(writer, edge);
             }
 
             if (edge.getType().equals(BranchEdge.HVDC_LINE_EDGE)) {
@@ -145,6 +138,17 @@ public class SvgWriter {
             }
 
             writer.writeEndElement();
+        }
+        writer.writeEndElement();
+    }
+
+    private void draw2Wt(XMLStreamWriter writer, BranchEdge edge) throws XMLStreamException {
+        writer.writeStartElement(GROUP_ELEMENT_NAME);
+        writer.writeAttribute(CLASS_ATTRIBUTE, StyleProvider.GLUED_CENTER_CLASS);
+        draw2WtWinding(writer, edge, BranchEdge.Side.ONE);
+        draw2WtWinding(writer, edge, BranchEdge.Side.TWO);
+        if (BranchEdge.PST_EDGE.equals(edge.getType())) {
+            drawPstArrow(writer, edge);
         }
         writer.writeEndElement();
     }

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/SvgWriter.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/SvgWriter.java
@@ -274,26 +274,30 @@ public class SvgWriter {
     }
 
     private void drawLoopEdgeInfo(XMLStreamWriter writer, BranchEdge edge, BranchEdge.Side side, List<EdgeInfo> edgeInfos) throws XMLStreamException {
-        List<String> styles = Collections.singletonList(StyleProvider.EDGE_INFOS_CLASS);
-        drawEdgeInfo(writer, styles, edgeInfos, edge.getPoints(side).get(1), edge.getEdgeStartAngle(side));
+        drawEdgeInfo(writer, edgeInfos, edge.getPoints(side).get(1), edge.getEdgeStartAngle(side));
     }
 
     private void drawBranchEdgeInfo(Graph graph, XMLStreamWriter writer, BranchEdge edge, BranchEdge.Side side, List<EdgeInfo> edgeInfos) throws XMLStreamException {
         VoltageLevelNode vlNode = graph.getVoltageLevelNode(edge, side);
         BusNode busNode = graph.getBusGraphNode(edge, side);
-        List<String> styles = List.of(StyleProvider.GLUED_CLASS + "-" + side.getNum(), StyleProvider.EDGE_INFOS_CLASS);
-        drawEdgeInfo(writer, styles, edgeInfos, getArrowCenter(vlNode, busNode, edge.getPoints(side)), edge.getEdgeEndAngle(side));
+        List<String> additionalStyles = List.of(StyleProvider.GLUED_CLASS + "-" + side.getNum());
+        drawEdgeInfo(writer, additionalStyles, edgeInfos, getArrowCenter(vlNode, busNode, edge.getPoints(side)), edge.getEdgeEndAngle(side));
     }
 
     private void drawThreeWtEdgeInfo(Graph graph, XMLStreamWriter writer, ThreeWtEdge edge, List<EdgeInfo> edgeInfos) throws XMLStreamException {
         VoltageLevelNode vlNode = graph.getVoltageLevelNode(edge);
         BusNode busNode = graph.getBusGraphNode(edge);
-        List<String> styles = Collections.singletonList(StyleProvider.EDGE_INFOS_CLASS);
-        drawEdgeInfo(writer, styles, edgeInfos, getArrowCenter(vlNode, busNode, edge.getPoints()), edge.getEdgeAngle());
+        drawEdgeInfo(writer, edgeInfos, getArrowCenter(vlNode, busNode, edge.getPoints()), edge.getEdgeAngle());
     }
 
-    private void drawEdgeInfo(XMLStreamWriter writer, List<String> styles, List<EdgeInfo> edgeInfos, Point infoCenter, double edgeAngle) throws XMLStreamException {
+    private void drawEdgeInfo(XMLStreamWriter writer, List<EdgeInfo> edgeInfos, Point infoCenter, double edgeAngle) throws XMLStreamException {
+        drawEdgeInfo(writer, Collections.emptyList(), edgeInfos, infoCenter, edgeAngle);
+    }
+
+    private void drawEdgeInfo(XMLStreamWriter writer, List<String> additionalStyles, List<EdgeInfo> edgeInfos, Point infoCenter, double edgeAngle) throws XMLStreamException {
         writer.writeStartElement(GROUP_ELEMENT_NAME);
+        List<String> styles = new ArrayList<>(additionalStyles);
+        styles.add(StyleProvider.EDGE_INFOS_CLASS);
         writer.writeAttribute(CLASS_ATTRIBUTE, String.join(" ", styles));
         writer.writeAttribute(TRANSFORM_ATTRIBUTE, getTranslateString(infoCenter));
         for (EdgeInfo info : edgeInfos) {

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/SvgWriter.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/SvgWriter.java
@@ -129,28 +129,39 @@ public class SvgWriter {
 
             drawHalfEdge(graph, writer, edge, BranchEdge.Side.ONE);
             drawHalfEdge(graph, writer, edge, BranchEdge.Side.TWO);
-            if (edge.isTransformerEdge()) {
-                draw2Wt(writer, edge);
-            }
-
-            if (edge.getType().equals(BranchEdge.HVDC_LINE_EDGE)) {
-                drawConverterStation(writer, edge);
-            }
+            drawEdgeCenter(writer, edge);
 
             writer.writeEndElement();
         }
         writer.writeEndElement();
     }
 
-    private void draw2Wt(XMLStreamWriter writer, BranchEdge edge) throws XMLStreamException {
+    private void drawEdgeCenter(XMLStreamWriter writer, BranchEdge edge) throws XMLStreamException {
+        if (BranchEdge.LINE_EDGE.equals(edge.getType())) {
+            return;
+        }
         writer.writeStartElement(GROUP_ELEMENT_NAME);
         writer.writeAttribute(CLASS_ATTRIBUTE, StyleProvider.GLUED_CENTER_CLASS);
+        switch (edge.getType()) {
+            case BranchEdge.PST_EDGE:
+            case BranchEdge.TWO_WT_EDGE:
+                draw2Wt(writer, edge);
+                break;
+            case BranchEdge.HVDC_LINE_EDGE:
+                drawConverterStation(writer, edge);
+                break;
+            default:
+                // Should not happen as lines are discarded beforehand
+        }
+        writer.writeEndElement();
+    }
+
+    private void draw2Wt(XMLStreamWriter writer, BranchEdge edge) throws XMLStreamException {
         draw2WtWinding(writer, edge, BranchEdge.Side.ONE);
         draw2WtWinding(writer, edge, BranchEdge.Side.TWO);
         if (BranchEdge.PST_EDGE.equals(edge.getType())) {
             drawPstArrow(writer, edge);
         }
-        writer.writeEndElement();
     }
 
     private void drawConverterStation(XMLStreamWriter writer, BranchEdge edge) throws XMLStreamException {

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/SvgWriter.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/SvgWriter.java
@@ -412,10 +412,10 @@ public class SvgWriter {
     }
 
     private void draw2WtWinding(XMLStreamWriter writer, BranchEdge edge, BranchEdge.Side side) throws XMLStreamException {
-        writer.writeStartElement(GROUP_ELEMENT_NAME);
-        addStylesIfAny(writer, styleProvider.getSideEdgeStyleClasses(edge, side));
         writer.writeEmptyElement(CIRCLE_ELEMENT_NAME);
-        writer.writeAttribute(CLASS_ATTRIBUTE, StyleProvider.WINDING_CLASS);
+        List<String> styles = new ArrayList<>(styleProvider.getSideEdgeStyleClasses(edge, side));
+        styles.add(StyleProvider.WINDING_CLASS);
+        addStylesIfAny(writer, styles);
         List<Point> halfPoints = edge.getPoints(side);
         Point point1 = halfPoints.get(halfPoints.size() - 1); // point near 2wt
         Point point2 = halfPoints.get(halfPoints.size() - 2); // point near voltage level, or control point for loops
@@ -424,7 +424,6 @@ public class SvgWriter {
         writer.writeAttribute("cx", getFormattedValue(circleCenter.getX()));
         writer.writeAttribute("cy", getFormattedValue(circleCenter.getY()));
         writer.writeAttribute(CIRCLE_RADIUS_ATTRIBUTE, getFormattedValue(radius));
-        writer.writeEndElement();
     }
 
     private void drawPstArrow(XMLStreamWriter writer, BranchEdge edge) throws XMLStreamException {
@@ -439,7 +438,7 @@ public class SvgWriter {
         writer.writeEmptyElement(PATH_ELEMENT_NAME);
         writer.writeAttribute(PATH_D_ATTRIBUTE, getPstArrowPath(arrowSize));
         writer.writeAttribute(TRANSFORM_ATTRIBUTE, getMatrixString(matrix));
-        writer.writeAttribute(CLASS_ATTRIBUTE, StyleProvider.PST_ARROW_CLASS + " " + StyleProvider.GLUED_CENTER_CLASS);
+        writer.writeAttribute(CLASS_ATTRIBUTE, StyleProvider.PST_ARROW_CLASS);
     }
 
     private String getPstArrowPath(double arrowSize) {

--- a/network-area-diagram/src/test/resources/IEEE_118_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_118_bus.svg
@@ -3150,12 +3150,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180-line">
-                    <circle class="nad-winding" cx="-893.50" cy="-1255.99" r="20.00"/>
-                </g>
-                <g class="nad-vl120to180-line">
-                    <circle class="nad-winding" cx="-886.25" cy="-1274.63" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180-line nad-winding" cx="-893.50" cy="-1255.99" r="20.00"/>
+                <circle class="nad-vl120to180-line nad-winding" cx="-886.25" cy="-1274.63" r="20.00"/>
             </g>
         </g>
         <g id="288">
@@ -3691,12 +3687,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180-line">
-                    <circle class="nad-winding" cx="-1857.70" cy="-1127.60" r="20.00"/>
-                </g>
-                <g class="nad-vl120to180-line">
-                    <circle class="nad-winding" cx="-1877.56" cy="-1129.97" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180-line nad-winding" cx="-1857.70" cy="-1127.60" r="20.00"/>
+                <circle class="nad-vl120to180-line nad-winding" cx="-1877.56" cy="-1129.97" r="20.00"/>
             </g>
         </g>
         <g id="301">
@@ -4437,12 +4429,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180-line">
-                    <circle class="nad-winding" cx="-146.55" cy="394.40" r="20.00"/>
-                </g>
-                <g class="nad-vl120to180-line">
-                    <circle class="nad-winding" cx="-127.80" cy="401.36" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180-line nad-winding" cx="-146.55" cy="394.40" r="20.00"/>
+                <circle class="nad-vl120to180-line nad-winding" cx="-127.80" cy="401.36" r="20.00"/>
             </g>
         </g>
         <g id="319">
@@ -5511,12 +5499,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180-line">
-                    <circle class="nad-winding" cx="-531.96" cy="-2328.43" r="20.00"/>
-                </g>
-                <g class="nad-vl120to180-line">
-                    <circle class="nad-winding" cx="-516.95" cy="-2341.64" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180-line nad-winding" cx="-531.96" cy="-2328.43" r="20.00"/>
+                <circle class="nad-vl120to180-line nad-winding" cx="-516.95" cy="-2341.64" r="20.00"/>
             </g>
         </g>
         <g id="345">
@@ -6216,12 +6200,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180-line">
-                    <circle class="nad-winding" cx="-1599.84" cy="2332.72" r="20.00"/>
-                </g>
-                <g class="nad-vl120to180-line">
-                    <circle class="nad-winding" cx="-1607.23" cy="2351.31" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180-line nad-winding" cx="-1599.84" cy="2332.72" r="20.00"/>
+                <circle class="nad-vl120to180-line nad-winding" cx="-1607.23" cy="2351.31" r="20.00"/>
             </g>
         </g>
         <g id="362">
@@ -6429,12 +6409,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180-line">
-                    <circle class="nad-winding" cx="-1230.01" cy="2283.50" r="20.00"/>
-                </g>
-                <g class="nad-vl120to180-line">
-                    <circle class="nad-winding" cx="-1230.40" cy="2303.49" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180-line nad-winding" cx="-1230.01" cy="2283.50" r="20.00"/>
+                <circle class="nad-vl120to180-line nad-winding" cx="-1230.40" cy="2303.49" r="20.00"/>
             </g>
         </g>
         <g id="367">
@@ -6683,12 +6659,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180-line">
-                    <circle class="nad-winding" cx="-782.61" cy="1786.80" r="20.00"/>
-                </g>
-                <g class="nad-vl120to180-line">
-                    <circle class="nad-winding" cx="-780.34" cy="1806.67" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180-line nad-winding" cx="-782.61" cy="1786.80" r="20.00"/>
+                <circle class="nad-vl120to180-line nad-winding" cx="-780.34" cy="1806.67" r="20.00"/>
             </g>
         </g>
         <g id="373">
@@ -6814,12 +6786,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180-line">
-                    <circle class="nad-winding" cx="-575.02" cy="826.35" r="20.00"/>
-                </g>
-                <g class="nad-vl120to180-line">
-                    <circle class="nad-winding" cx="-594.94" cy="824.55" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180-line nad-winding" cx="-575.02" cy="826.35" r="20.00"/>
+                <circle class="nad-vl120to180-line nad-winding" cx="-594.94" cy="824.55" r="20.00"/>
             </g>
         </g>
         <g id="376">
@@ -7765,12 +7733,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180-line">
-                    <circle class="nad-winding" cx="827.01" cy="94.74" r="20.00"/>
-                </g>
-                <g class="nad-vl120to180-line">
-                    <circle class="nad-winding" cx="843.41" cy="83.30" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180-line nad-winding" cx="827.01" cy="94.74" r="20.00"/>
+                <circle class="nad-vl120to180-line nad-winding" cx="843.41" cy="83.30" r="20.00"/>
             </g>
         </g>
         <g id="399">

--- a/network-area-diagram/src/test/resources/IEEE_118_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_118_bus.svg
@@ -1021,8 +1021,8 @@
         <g id="236">
             <desc>L1-2-1</desc>
             <g id="236.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="741.47,-2946.11 766.47,-2794.78"/>
-                <g class="nad-edge-infos" transform="translate(746.77,-2914.04)">
+                <polyline class="nad-edge-path nad-stretchable" points="741.47,-2946.11 766.47,-2794.78"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(746.77,-2914.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(170.62)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1040,8 +1040,8 @@
                 </g>
             </g>
             <g id="236.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="791.47,-2643.45 766.47,-2794.78"/>
-                <g class="nad-edge-infos" transform="translate(786.17,-2675.51)">
+                <polyline class="nad-edge-path nad-stretchable" points="791.47,-2643.45 766.47,-2794.78"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(786.17,-2675.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-9.38)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1062,8 +1062,8 @@
         <g id="237">
             <desc>L1-3-1</desc>
             <g id="237.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="714.74,-2957.07 542.93,-2832.17"/>
-                <g class="nad-edge-infos" transform="translate(688.46,-2937.96)">
+                <polyline class="nad-edge-path nad-stretchable" points="714.74,-2957.07 542.93,-2832.17"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(688.46,-2937.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-126.02)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1081,8 +1081,8 @@
                 </g>
             </g>
             <g id="237.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="371.12,-2707.26 542.93,-2832.17"/>
-                <g class="nad-edge-infos" transform="translate(397.41,-2726.37)">
+                <polyline class="nad-edge-path nad-stretchable" points="371.12,-2707.26 542.93,-2832.17"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(397.41,-2726.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(53.98)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1103,8 +1103,8 @@
         <g id="238">
             <desc>L9-10-1</desc>
             <g id="238.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1123.22,-2570.33 -1208.91,-2732.35"/>
-                <g class="nad-edge-infos" transform="translate(-1138.41,-2599.06)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1123.22,-2570.33 -1208.91,-2732.35"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1138.41,-2599.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-27.87)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1122,8 +1122,8 @@
                 </g>
             </g>
             <g id="238.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1294.60,-2894.37 -1208.91,-2732.35"/>
-                <g class="nad-edge-infos" transform="translate(-1279.40,-2865.64)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1294.60,-2894.37 -1208.91,-2732.35"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1279.40,-2865.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(152.13)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1144,8 +1144,8 @@
         <g id="239">
             <desc>L92-100-1</desc>
             <g id="239.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2680.60,263.30 2508.24,-90.81"/>
-                <g class="nad-edge-infos" transform="translate(2666.38,234.08)">
+                <polyline class="nad-edge-path nad-stretchable" points="2680.60,263.30 2508.24,-90.81"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2666.38,234.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-25.95)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1163,8 +1163,8 @@
                 </g>
             </g>
             <g id="239.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2335.88,-444.93 2508.24,-90.81"/>
-                <g class="nad-edge-infos" transform="translate(2350.10,-415.71)">
+                <polyline class="nad-edge-path nad-stretchable" points="2335.88,-444.93 2508.24,-90.81"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(2350.10,-415.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(154.05)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1185,8 +1185,8 @@
         <g id="240">
             <desc>L94-100-1</desc>
             <g id="240.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2203.64,116.63 2260.98,-163.04"/>
-                <g class="nad-edge-infos" transform="translate(2210.17,84.79)">
+                <polyline class="nad-edge-path nad-stretchable" points="2203.64,116.63 2260.98,-163.04"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2210.17,84.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(11.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1204,8 +1204,8 @@
                 </g>
             </g>
             <g id="240.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2318.32,-442.72 2260.98,-163.04"/>
-                <g class="nad-edge-infos" transform="translate(2311.79,-410.88)">
+                <polyline class="nad-edge-path nad-stretchable" points="2318.32,-442.72 2260.98,-163.04"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(2311.79,-410.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-168.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1226,8 +1226,8 @@
         <g id="241">
             <desc>L98-100-1</desc>
             <g id="241.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1661.77,-572.17 1979.22,-523.02"/>
-                <g class="nad-edge-infos" transform="translate(1693.89,-567.20)">
+                <polyline class="nad-edge-path nad-stretchable" points="1661.77,-572.17 1979.22,-523.02"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1693.89,-567.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(98.80)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1245,8 +1245,8 @@
                 </g>
             </g>
             <g id="241.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2296.67,-473.87 1979.22,-523.02"/>
-                <g class="nad-edge-infos" transform="translate(2264.55,-478.84)">
+                <polyline class="nad-edge-path nad-stretchable" points="2296.67,-473.87 1979.22,-523.02"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(2264.55,-478.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-81.20)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1267,8 +1267,8 @@
         <g id="242">
             <desc>L99-100-1</desc>
             <g id="242.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1820.91,-304.17 2059.32,-382.62"/>
-                <g class="nad-edge-infos" transform="translate(1851.78,-314.33)">
+                <polyline class="nad-edge-path nad-stretchable" points="1820.91,-304.17 2059.32,-382.62"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1851.78,-314.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(71.79)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1286,8 +1286,8 @@
                 </g>
             </g>
             <g id="242.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2297.72,-461.06 2059.32,-382.62"/>
-                <g class="nad-edge-infos" transform="translate(2266.85,-450.90)">
+                <polyline class="nad-edge-path nad-stretchable" points="2297.72,-461.06 2059.32,-382.62"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(2266.85,-450.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-108.21)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1308,8 +1308,8 @@
         <g id="243">
             <desc>L100-101-1</desc>
             <g id="243.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2349.71,-460.31 2555.79,-385.77"/>
-                <g class="nad-edge-infos" transform="translate(2380.27,-449.25)">
+                <polyline class="nad-edge-path nad-stretchable" points="2349.71,-460.31 2555.79,-385.77"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2380.27,-449.25)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(109.88)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1327,8 +1327,8 @@
                 </g>
             </g>
             <g id="243.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2761.88,-311.24 2555.79,-385.77"/>
-                <g class="nad-edge-infos" transform="translate(2731.32,-322.29)">
+                <polyline class="nad-edge-path nad-stretchable" points="2761.88,-311.24 2555.79,-385.77"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(2731.32,-322.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-70.12)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1349,8 +1349,8 @@
         <g id="244">
             <desc>L100-103-1</desc>
             <g id="244.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2323.64,-497.16 2320.89,-858.25"/>
-                <g class="nad-edge-infos" transform="translate(2323.39,-529.66)">
+                <polyline class="nad-edge-path nad-stretchable" points="2323.64,-497.16 2320.89,-858.25"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2323.39,-529.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-0.44)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1368,8 +1368,8 @@
                 </g>
             </g>
             <g id="244.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2318.14,-1219.35 2320.89,-858.25"/>
-                <g class="nad-edge-infos" transform="translate(2318.38,-1186.85)">
+                <polyline class="nad-edge-path nad-stretchable" points="2318.14,-1219.35 2320.89,-858.25"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(2318.38,-1186.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(179.56)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1390,8 +1390,8 @@
         <g id="245">
             <desc>L100-104-1</desc>
             <g id="245.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2327.79,-496.87 2357.25,-700.06"/>
-                <g class="nad-edge-infos" transform="translate(2332.46,-529.04)">
+                <polyline class="nad-edge-path nad-stretchable" points="2327.79,-496.87 2357.25,-700.06"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2332.46,-529.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(8.25)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1409,8 +1409,8 @@
                 </g>
             </g>
             <g id="245.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2386.71,-903.24 2357.25,-700.06"/>
-                <g class="nad-edge-infos" transform="translate(2382.05,-871.07)">
+                <polyline class="nad-edge-path nad-stretchable" points="2386.71,-903.24 2357.25,-700.06"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(2382.05,-871.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-171.75)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1431,8 +1431,8 @@
         <g id="246">
             <desc>L100-106-1</desc>
             <g id="246.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2345.94,-486.03 2570.70,-652.59"/>
-                <g class="nad-edge-infos" transform="translate(2372.05,-505.38)">
+                <polyline class="nad-edge-path nad-stretchable" points="2345.94,-486.03 2570.70,-652.59"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2372.05,-505.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(53.46)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1450,8 +1450,8 @@
                 </g>
             </g>
             <g id="246.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2795.46,-819.15 2570.70,-652.59"/>
-                <g class="nad-edge-infos" transform="translate(2769.35,-799.80)">
+                <polyline class="nad-edge-path nad-stretchable" points="2795.46,-819.15 2570.70,-652.59"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(2769.35,-799.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-126.54)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1472,8 +1472,8 @@
         <g id="247">
             <desc>L101-102-1</desc>
             <g id="247.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2805.31,-280.73 2912.83,-151.25"/>
-                <g class="nad-edge-infos" transform="translate(2826.07,-255.73)">
+                <polyline class="nad-edge-path nad-stretchable" points="2805.31,-280.73 2912.83,-151.25"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2826.07,-255.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(140.30)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1491,8 +1491,8 @@
                 </g>
             </g>
             <g id="247.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="3020.34,-21.77 2912.83,-151.25"/>
-                <g class="nad-edge-infos" transform="translate(2999.58,-46.77)">
+                <polyline class="nad-edge-path nad-stretchable" points="3020.34,-21.77 2912.83,-151.25"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(2999.58,-46.77)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-39.70)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1513,8 +1513,8 @@
         <g id="248">
             <desc>L92-102-1</desc>
             <g id="248.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2713.73,270.39 2865.27,143.71"/>
-                <g class="nad-edge-infos" transform="translate(2738.67,249.55)">
+                <polyline class="nad-edge-path nad-stretchable" points="2713.73,270.39 2865.27,143.71"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2738.67,249.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(50.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1532,8 +1532,8 @@
                 </g>
             </g>
             <g id="248.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="3016.81,17.03 2865.27,143.71"/>
-                <g class="nad-edge-infos" transform="translate(2991.88,37.87)">
+                <polyline class="nad-edge-path nad-stretchable" points="3016.81,17.03 2865.27,143.71"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(2991.88,37.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-129.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1554,8 +1554,8 @@
         <g id="249">
             <desc>L103-104-1</desc>
             <g id="249.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2324.09,-1220.05 2354.29,-1088.65"/>
-                <g class="nad-edge-infos" transform="translate(2331.37,-1188.38)">
+                <polyline class="nad-edge-path nad-stretchable" points="2324.09,-1220.05 2354.29,-1088.65"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2331.37,-1188.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(167.05)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1573,8 +1573,8 @@
                 </g>
             </g>
             <g id="249.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2384.50,-957.25 2354.29,-1088.65"/>
-                <g class="nad-edge-infos" transform="translate(2377.22,-988.93)">
+                <polyline class="nad-edge-path nad-stretchable" points="2384.50,-957.25 2354.29,-1088.65"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(2377.22,-988.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-12.95)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1595,8 +1595,8 @@
         <g id="250">
             <desc>L103-105-1</desc>
             <g id="250.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2345.41,-1245.77 2529.69,-1238.49"/>
-                <g class="nad-edge-infos" transform="translate(2377.88,-1244.48)">
+                <polyline class="nad-edge-path nad-stretchable" points="2345.41,-1245.77 2529.69,-1238.49"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2377.88,-1244.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(92.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1614,8 +1614,8 @@
                 </g>
             </g>
             <g id="250.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2713.97,-1231.22 2529.69,-1238.49"/>
-                <g class="nad-edge-infos" transform="translate(2681.50,-1232.50)">
+                <polyline class="nad-edge-path nad-stretchable" points="2713.97,-1231.22 2529.69,-1238.49"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(2681.50,-1232.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-87.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1636,8 +1636,8 @@
         <g id="251">
             <desc>L103-110-1</desc>
             <g id="251.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2314.98,-1274.19 2282.78,-1572.97"/>
-                <g class="nad-edge-infos" transform="translate(2311.50,-1306.50)">
+                <polyline class="nad-edge-path nad-stretchable" points="2314.98,-1274.19 2282.78,-1572.97"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2311.50,-1306.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-6.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1655,8 +1655,8 @@
                 </g>
             </g>
             <g id="251.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2250.57,-1871.76 2282.78,-1572.97"/>
-                <g class="nad-edge-infos" transform="translate(2254.06,-1839.44)">
+                <polyline class="nad-edge-path nad-stretchable" points="2250.57,-1871.76 2282.78,-1572.97"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(2254.06,-1839.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(173.85)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1677,8 +1677,8 @@
         <g id="252">
             <desc>L104-105-1</desc>
             <g id="252.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2411.57,-948.32 2566.06,-1080.30"/>
-                <g class="nad-edge-infos" transform="translate(2436.28,-969.43)">
+                <polyline class="nad-edge-path nad-stretchable" points="2411.57,-948.32 2566.06,-1080.30"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2436.28,-969.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(49.49)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1696,8 +1696,8 @@
                 </g>
             </g>
             <g id="252.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2720.54,-1212.27 2566.06,-1080.30"/>
-                <g class="nad-edge-infos" transform="translate(2695.83,-1191.16)">
+                <polyline class="nad-edge-path nad-stretchable" points="2720.54,-1212.27 2566.06,-1080.30"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(2695.83,-1191.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-130.51)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1718,8 +1718,8 @@
         <g id="253">
             <desc>L105-106-1</desc>
             <g id="253.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2746.66,-1203.13 2779.50,-1032.83"/>
-                <g class="nad-edge-infos" transform="translate(2752.81,-1171.22)">
+                <polyline class="nad-edge-path nad-stretchable" points="2746.66,-1203.13 2779.50,-1032.83"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2752.81,-1171.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(169.08)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1737,8 +1737,8 @@
                 </g>
             </g>
             <g id="253.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2812.35,-862.52 2779.50,-1032.83"/>
-                <g class="nad-edge-infos" transform="translate(2806.19,-894.44)">
+                <polyline class="nad-edge-path nad-stretchable" points="2812.35,-862.52 2779.50,-1032.83"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(2806.19,-894.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-10.92)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1759,8 +1759,8 @@
         <g id="254">
             <desc>L105-107-1</desc>
             <g id="254.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2767.15,-1220.35 2934.23,-1156.75"/>
-                <g class="nad-edge-infos" transform="translate(2797.53,-1208.79)">
+                <polyline class="nad-edge-path nad-stretchable" points="2767.15,-1220.35 2934.23,-1156.75"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2797.53,-1208.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(110.84)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1778,8 +1778,8 @@
                 </g>
             </g>
             <g id="254.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="3101.32,-1093.15 2934.23,-1156.75"/>
-                <g class="nad-edge-infos" transform="translate(3070.94,-1104.71)">
+                <polyline class="nad-edge-path nad-stretchable" points="3101.32,-1093.15 2934.23,-1156.75"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(3070.94,-1104.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-69.16)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1800,8 +1800,8 @@
         <g id="255">
             <desc>L105-108-1</desc>
             <g id="255.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2750.20,-1256.21 2818.75,-1460.35"/>
-                <g class="nad-edge-infos" transform="translate(2760.55,-1287.02)">
+                <polyline class="nad-edge-path nad-stretchable" points="2750.20,-1256.21 2818.75,-1460.35"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2760.55,-1287.02)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(18.56)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1819,8 +1819,8 @@
                 </g>
             </g>
             <g id="255.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2887.30,-1664.49 2818.75,-1460.35"/>
-                <g class="nad-edge-infos" transform="translate(2876.95,-1633.68)">
+                <polyline class="nad-edge-path nad-stretchable" points="2887.30,-1664.49 2818.75,-1460.35"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(2876.95,-1633.68)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-161.44)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1841,8 +1841,8 @@
         <g id="256">
             <desc>L106-107-1</desc>
             <g id="256.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2839.02,-852.71 2972.29,-959.44"/>
-                <g class="nad-edge-infos" transform="translate(2864.39,-873.03)">
+                <polyline class="nad-edge-path nad-stretchable" points="2839.02,-852.71 2972.29,-959.44"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2864.39,-873.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(51.31)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1860,8 +1860,8 @@
                 </g>
             </g>
             <g id="256.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="3105.55,-1066.18 2972.29,-959.44"/>
-                <g class="nad-edge-infos" transform="translate(3080.19,-1045.86)">
+                <polyline class="nad-edge-path nad-stretchable" points="3105.55,-1066.18 2972.29,-959.44"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(3080.19,-1045.86)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-128.69)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1882,8 +1882,8 @@
         <g id="257">
             <desc>L108-109-1</desc>
             <g id="257.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2879.84,-1712.77 2780.68,-1848.59"/>
-                <g class="nad-edge-infos" transform="translate(2860.67,-1739.02)">
+                <polyline class="nad-edge-path nad-stretchable" points="2879.84,-1712.77 2780.68,-1848.59"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2860.67,-1739.02)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-36.13)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1901,8 +1901,8 @@
                 </g>
             </g>
             <g id="257.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2681.52,-1984.41 2780.68,-1848.59"/>
-                <g class="nad-edge-infos" transform="translate(2700.68,-1958.16)">
+                <polyline class="nad-edge-path nad-stretchable" points="2681.52,-1984.41 2780.68,-1848.59"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(2700.68,-1958.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(143.87)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1923,8 +1923,8 @@
         <g id="258">
             <desc>L109-110-1</desc>
             <g id="258.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2638.67,-1999.77 2456.47,-1952.86"/>
-                <g class="nad-edge-infos" transform="translate(2607.20,-1991.67)">
+                <polyline class="nad-edge-path nad-stretchable" points="2638.67,-1999.77 2456.47,-1952.86"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2607.20,-1991.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-104.44)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1942,8 +1942,8 @@
                 </g>
             </g>
             <g id="258.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2274.26,-1905.95 2456.47,-1952.86"/>
-                <g class="nad-edge-infos" transform="translate(2305.73,-1914.06)">
+                <polyline class="nad-edge-path nad-stretchable" points="2274.26,-1905.95 2456.47,-1952.86"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(2305.73,-1914.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(75.56)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1964,8 +1964,8 @@
         <g id="259">
             <desc>L4-11-1</desc>
             <g id="259.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-432.62,-2422.92 -261.80,-2324.23"/>
-                <g class="nad-edge-infos" transform="translate(-404.48,-2406.66)">
+                <polyline class="nad-edge-path nad-stretchable" points="-432.62,-2422.92 -261.80,-2324.23"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-404.48,-2406.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(120.01)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1983,8 +1983,8 @@
                 </g>
             </g>
             <g id="259.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-90.97,-2225.55 -261.80,-2324.23"/>
-                <g class="nad-edge-infos" transform="translate(-119.11,-2241.81)">
+                <polyline class="nad-edge-path nad-stretchable" points="-90.97,-2225.55 -261.80,-2324.23"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-119.11,-2241.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-59.99)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2005,8 +2005,8 @@
         <g id="260">
             <desc>L5-11-1</desc>
             <g id="260.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-215.66,-2572.00 -146.65,-2404.61"/>
-                <g class="nad-edge-infos" transform="translate(-203.27,-2541.96)">
+                <polyline class="nad-edge-path nad-stretchable" points="-215.66,-2572.00 -146.65,-2404.61"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-203.27,-2541.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(157.60)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2024,8 +2024,8 @@
                 </g>
             </g>
             <g id="260.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-77.64,-2237.22 -146.65,-2404.61"/>
-                <g class="nad-edge-infos" transform="translate(-90.03,-2267.27)">
+                <polyline class="nad-edge-path nad-stretchable" points="-77.64,-2237.22 -146.65,-2404.61"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-90.03,-2267.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-22.40)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2046,8 +2046,8 @@
         <g id="261">
             <desc>L11-12-1</desc>
             <g id="261.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-40.13,-2216.84 130.04,-2248.63"/>
-                <g class="nad-edge-infos" transform="translate(-8.18,-2222.81)">
+                <polyline class="nad-edge-path nad-stretchable" points="-40.13,-2216.84 130.04,-2248.63"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-8.18,-2222.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(79.42)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2065,8 +2065,8 @@
                 </g>
             </g>
             <g id="261.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="300.21,-2280.41 130.04,-2248.63"/>
-                <g class="nad-edge-infos" transform="translate(268.27,-2274.44)">
+                <polyline class="nad-edge-path nad-stretchable" points="300.21,-2280.41 130.04,-2248.63"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(268.27,-2274.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-100.58)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2087,8 +2087,8 @@
         <g id="262">
             <desc>L11-13-1</desc>
             <g id="262.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-64.66,-2184.41 -40.19,-1916.37"/>
-                <g class="nad-edge-infos" transform="translate(-61.71,-2152.04)">
+                <polyline class="nad-edge-path nad-stretchable" points="-64.66,-2184.41 -40.19,-1916.37"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-61.71,-2152.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(174.78)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2106,8 +2106,8 @@
                 </g>
             </g>
             <g id="262.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-15.73,-1648.34 -40.19,-1916.37"/>
-                <g class="nad-edge-infos" transform="translate(-18.68,-1680.70)">
+                <polyline class="nad-edge-path nad-stretchable" points="-15.73,-1648.34 -40.19,-1916.37"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-18.68,-1680.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-5.22)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2128,8 +2128,8 @@
         <g id="263">
             <desc>L110-111-1</desc>
             <g id="263.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2221.58,-1907.93 2053.03,-1965.10"/>
-                <g class="nad-edge-infos" transform="translate(2190.81,-1918.37)">
+                <polyline class="nad-edge-path nad-stretchable" points="2221.58,-1907.93 2053.03,-1965.10"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2190.81,-1918.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-71.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2147,8 +2147,8 @@
                 </g>
             </g>
             <g id="263.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1884.48,-2022.27 2053.03,-1965.10"/>
-                <g class="nad-edge-infos" transform="translate(1915.26,-2011.83)">
+                <polyline class="nad-edge-path nad-stretchable" points="1884.48,-2022.27 2053.03,-1965.10"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1915.26,-2011.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(108.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2169,8 +2169,8 @@
         <g id="264">
             <desc>L110-112-1</desc>
             <g id="264.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2246.89,-1926.59 2241.32,-2135.72"/>
-                <g class="nad-edge-infos" transform="translate(2246.03,-1959.08)">
+                <polyline class="nad-edge-path nad-stretchable" points="2246.89,-1926.59 2241.32,-2135.72"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2246.03,-1959.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-1.53)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2188,8 +2188,8 @@
                 </g>
             </g>
             <g id="264.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2235.74,-2344.85 2241.32,-2135.72"/>
-                <g class="nad-edge-infos" transform="translate(2236.61,-2312.36)">
+                <polyline class="nad-edge-path nad-stretchable" points="2235.74,-2344.85 2241.32,-2135.72"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(2236.61,-2312.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(178.47)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2210,8 +2210,8 @@
         <g id="265">
             <desc>L17-113-1</desc>
             <g id="265.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-839.12,-1469.00 -1098.76,-1496.41"/>
-                <g class="nad-edge-infos" transform="translate(-871.44,-1472.41)">
+                <polyline class="nad-edge-path nad-stretchable" points="-839.12,-1469.00 -1098.76,-1496.41"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-871.44,-1472.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-83.98)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2229,8 +2229,8 @@
                 </g>
             </g>
             <g id="265.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1358.41,-1523.81 -1098.76,-1496.41"/>
-                <g class="nad-edge-infos" transform="translate(-1326.09,-1520.40)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1358.41,-1523.81 -1098.76,-1496.41"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1326.09,-1520.40)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(96.02)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2251,8 +2251,8 @@
         <g id="266">
             <desc>L32-113-1</desc>
             <g id="266.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1988.65,-1543.15 -1700.95,-1535.30"/>
-                <g class="nad-edge-infos" transform="translate(-1956.17,-1542.27)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1988.65,-1543.15 -1700.95,-1535.30"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1956.17,-1542.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(91.56)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2270,8 +2270,8 @@
                 </g>
             </g>
             <g id="266.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1413.25,-1527.45 -1700.95,-1535.30"/>
-                <g class="nad-edge-infos" transform="translate(-1445.74,-1528.33)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1413.25,-1527.45 -1700.95,-1535.30"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1445.74,-1528.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-88.44)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2292,8 +2292,8 @@
         <g id="267">
             <desc>L32-114-1</desc>
             <g id="267.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2041.07,-1555.52 -2315.77,-1683.48"/>
-                <g class="nad-edge-infos" transform="translate(-2070.53,-1569.24)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2041.07,-1555.52 -2315.77,-1683.48"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-2070.53,-1569.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-65.02)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2311,8 +2311,8 @@
                 </g>
             </g>
             <g id="267.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2590.47,-1811.45 -2315.77,-1683.48"/>
-                <g class="nad-edge-infos" transform="translate(-2561.01,-1797.73)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2590.47,-1811.45 -2315.77,-1683.48"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-2561.01,-1797.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(114.98)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2333,8 +2333,8 @@
         <g id="268">
             <desc>L114-115-1</desc>
             <g id="268.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2635.95,-1804.80 -2741.72,-1710.82"/>
-                <g class="nad-edge-infos" transform="translate(-2660.25,-1783.21)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2635.95,-1804.80 -2741.72,-1710.82"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-2660.25,-1783.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-131.62)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2352,8 +2352,8 @@
                 </g>
             </g>
             <g id="268.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2847.49,-1616.85 -2741.72,-1710.82"/>
-                <g class="nad-edge-infos" transform="translate(-2823.19,-1638.44)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2847.49,-1616.85 -2741.72,-1710.82"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-2823.19,-1638.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.38)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2374,8 +2374,8 @@
         <g id="269">
             <desc>L27-115-1</desc>
             <g id="269.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2423.50,-1577.06 -2632.04,-1587.16"/>
-                <g class="nad-edge-infos" transform="translate(-2455.96,-1578.63)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2423.50,-1577.06 -2632.04,-1587.16"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-2455.96,-1578.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-87.23)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2393,8 +2393,8 @@
                 </g>
             </g>
             <g id="269.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2840.58,-1597.26 -2632.04,-1587.16"/>
-                <g class="nad-edge-infos" transform="translate(-2808.12,-1595.68)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2840.58,-1597.26 -2632.04,-1587.16"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-2808.12,-1595.68)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(92.77)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2415,8 +2415,8 @@
         <g id="270">
             <desc>L68-116-1</desc>
             <g id="270.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-460.27,840.92 -751.79,859.68"/>
-                <g class="nad-edge-infos" transform="translate(-492.70,843.01)">
+                <polyline class="nad-edge-path nad-stretchable" points="-460.27,840.92 -751.79,859.68"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-492.70,843.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-93.68)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2434,8 +2434,8 @@
                 </g>
             </g>
             <g id="270.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1043.32,878.43 -751.79,859.68"/>
-                <g class="nad-edge-infos" transform="translate(-1010.88,876.35)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1043.32,878.43 -751.79,859.68"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1010.88,876.35)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(86.32)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2456,8 +2456,8 @@
         <g id="271">
             <desc>L12-117-1</desc>
             <g id="271.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="353.27,-2276.58 555.32,-2207.69"/>
-                <g class="nad-edge-infos" transform="translate(384.04,-2266.09)">
+                <polyline class="nad-edge-path nad-stretchable" points="353.27,-2276.58 555.32,-2207.69"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(384.04,-2266.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(108.83)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2475,8 +2475,8 @@
                 </g>
             </g>
             <g id="271.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="757.36,-2138.80 555.32,-2207.69"/>
-                <g class="nad-edge-infos" transform="translate(726.60,-2149.29)">
+                <polyline class="nad-edge-path nad-stretchable" points="757.36,-2138.80 555.32,-2207.69"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(726.60,-2149.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-71.17)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2497,8 +2497,8 @@
         <g id="272">
             <desc>L75-118-1</desc>
             <g id="272.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-860.72,277.56 -771.02,108.98"/>
-                <g class="nad-edge-infos" transform="translate(-845.46,248.87)">
+                <polyline class="nad-edge-path nad-stretchable" points="-860.72,277.56 -771.02,108.98"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-845.46,248.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(28.02)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2516,8 +2516,8 @@
                 </g>
             </g>
             <g id="272.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-681.31,-59.60 -771.02,108.98"/>
-                <g class="nad-edge-infos" transform="translate(-696.57,-30.91)">
+                <polyline class="nad-edge-path nad-stretchable" points="-681.31,-59.60 -771.02,108.98"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-696.57,-30.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-151.98)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2538,8 +2538,8 @@
         <g id="273">
             <desc>L76-118-1</desc>
             <g id="273.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-235.29,-91.89 -438.09,-88.14"/>
-                <g class="nad-edge-infos" transform="translate(-267.78,-91.29)">
+                <polyline class="nad-edge-path nad-stretchable" points="-235.29,-91.89 -438.09,-88.14"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-267.78,-91.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-91.06)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2557,8 +2557,8 @@
                 </g>
             </g>
             <g id="273.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-640.89,-84.38 -438.09,-88.14"/>
-                <g class="nad-edge-infos" transform="translate(-608.40,-84.98)">
+                <polyline class="nad-edge-path nad-stretchable" points="-640.89,-84.38 -438.09,-88.14"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-608.40,-84.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(88.94)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2579,8 +2579,8 @@
         <g id="274">
             <desc>L2-12-1</desc>
             <g id="274.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="773.49,-2600.46 561.60,-2450.89"/>
-                <g class="nad-edge-infos" transform="translate(746.94,-2581.71)">
+                <polyline class="nad-edge-path nad-stretchable" points="773.49,-2600.46 561.60,-2450.89"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(746.94,-2581.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-125.22)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2598,8 +2598,8 @@
                 </g>
             </g>
             <g id="274.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="349.71,-2301.32 561.60,-2450.89"/>
-                <g class="nad-edge-infos" transform="translate(376.26,-2320.06)">
+                <polyline class="nad-edge-path nad-stretchable" points="349.71,-2301.32 561.60,-2450.89"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(376.26,-2320.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(54.78)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2620,8 +2620,8 @@
         <g id="275">
             <desc>L3-12-1</desc>
             <g id="275.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="347.41,-2663.63 338.06,-2488.27"/>
-                <g class="nad-edge-infos" transform="translate(345.68,-2631.18)">
+                <polyline class="nad-edge-path nad-stretchable" points="347.41,-2663.63 338.06,-2488.27"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(345.68,-2631.18)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-176.95)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2639,8 +2639,8 @@
                 </g>
             </g>
             <g id="275.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="328.71,-2312.92 338.06,-2488.27"/>
-                <g class="nad-edge-infos" transform="translate(330.44,-2345.37)">
+                <polyline class="nad-edge-path nad-stretchable" points="328.71,-2312.92 338.06,-2488.27"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(330.44,-2345.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(3.05)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2661,8 +2661,8 @@
         <g id="276">
             <desc>L7-12-1</desc>
             <g id="276.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="127.78,-2924.27 223.42,-2617.99"/>
-                <g class="nad-edge-infos" transform="translate(137.47,-2893.25)">
+                <polyline class="nad-edge-path nad-stretchable" points="127.78,-2924.27 223.42,-2617.99"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(137.47,-2893.25)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(162.66)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2680,8 +2680,8 @@
                 </g>
             </g>
             <g id="276.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="319.05,-2311.71 223.42,-2617.99"/>
-                <g class="nad-edge-infos" transform="translate(309.36,-2342.73)">
+                <polyline class="nad-edge-path nad-stretchable" points="319.05,-2311.71 223.42,-2617.99"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(309.36,-2342.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-17.34)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2702,8 +2702,8 @@
         <g id="277">
             <desc>L12-14-1</desc>
             <g id="277.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="328.74,-2258.00 344.33,-1971.29"/>
-                <g class="nad-edge-infos" transform="translate(330.50,-2225.55)">
+                <polyline class="nad-edge-path nad-stretchable" points="328.74,-2258.00 344.33,-1971.29"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(330.50,-2225.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(176.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2721,8 +2721,8 @@
                 </g>
             </g>
             <g id="277.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="359.92,-1684.57 344.33,-1971.29"/>
-                <g class="nad-edge-infos" transform="translate(358.15,-1717.03)">
+                <polyline class="nad-edge-path nad-stretchable" points="359.92,-1684.57 344.33,-1971.29"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(358.15,-1717.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-3.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2743,8 +2743,8 @@
         <g id="278">
             <desc>L12-16-1</desc>
             <g id="278.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="304.20,-2270.45 7.32,-2077.10"/>
-                <g class="nad-edge-infos" transform="translate(276.97,-2252.71)">
+                <polyline class="nad-edge-path nad-stretchable" points="304.20,-2270.45 7.32,-2077.10"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(276.97,-2252.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-123.07)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2762,8 +2762,8 @@
                 </g>
             </g>
             <g id="278.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-289.56,-1883.75 7.32,-2077.10"/>
-                <g class="nad-edge-infos" transform="translate(-262.33,-1901.49)">
+                <polyline class="nad-edge-path nad-stretchable" points="-289.56,-1883.75 7.32,-2077.10"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-262.33,-1901.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(56.93)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2784,8 +2784,8 @@
         <g id="279">
             <desc>L13-15-1</desc>
             <g id="279.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-17.87,-1593.84 -54.07,-1382.36"/>
-                <g class="nad-edge-infos" transform="translate(-23.35,-1561.81)">
+                <polyline class="nad-edge-path nad-stretchable" points="-17.87,-1593.84 -54.07,-1382.36"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-23.35,-1561.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-170.29)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2803,8 +2803,8 @@
                 </g>
             </g>
             <g id="279.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-90.26,-1170.87 -54.07,-1382.36"/>
-                <g class="nad-edge-infos" transform="translate(-84.78,-1202.91)">
+                <polyline class="nad-edge-path nad-stretchable" points="-90.26,-1170.87 -54.07,-1382.36"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-84.78,-1202.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(9.71)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2825,8 +2825,8 @@
         <g id="280">
             <desc>L14-15-1</desc>
             <g id="280.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="343.14,-1636.56 133.25,-1400.44"/>
-                <g class="nad-edge-infos" transform="translate(321.55,-1612.27)">
+                <polyline class="nad-edge-path nad-stretchable" points="343.14,-1636.56 133.25,-1400.44"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(321.55,-1612.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-138.37)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2844,8 +2844,8 @@
                 </g>
             </g>
             <g id="280.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-76.63,-1164.32 133.25,-1400.44"/>
-                <g class="nad-edge-infos" transform="translate(-55.04,-1188.61)">
+                <polyline class="nad-edge-path nad-stretchable" points="-76.63,-1164.32 133.25,-1400.44"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-55.04,-1188.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(41.63)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2866,8 +2866,8 @@
         <g id="281">
             <desc>L15-17-1</desc>
             <g id="281.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-119.99,-1155.04 -453.34,-1304.94"/>
-                <g class="nad-edge-infos" transform="translate(-149.63,-1168.37)">
+                <polyline class="nad-edge-path nad-stretchable" points="-119.99,-1155.04 -453.34,-1304.94"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-149.63,-1168.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-65.79)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2885,8 +2885,8 @@
                 </g>
             </g>
             <g id="281.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-786.69,-1454.84 -453.34,-1304.94"/>
-                <g class="nad-edge-infos" transform="translate(-757.04,-1441.51)">
+                <polyline class="nad-edge-path nad-stretchable" points="-786.69,-1454.84 -453.34,-1304.94"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-757.04,-1441.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(114.21)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2907,8 +2907,8 @@
         <g id="282">
             <desc>L15-19-1</desc>
             <g id="282.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-108.16,-1119.67 -252.89,-856.57"/>
-                <g class="nad-edge-infos" transform="translate(-123.82,-1091.19)">
+                <polyline class="nad-edge-path nad-stretchable" points="-108.16,-1119.67 -252.89,-856.57"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-123.82,-1091.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-151.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2926,8 +2926,8 @@
                 </g>
             </g>
             <g id="282.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-397.63,-593.47 -252.89,-856.57"/>
-                <g class="nad-edge-infos" transform="translate(-381.97,-621.95)">
+                <polyline class="nad-edge-path nad-stretchable" points="-397.63,-593.47 -252.89,-856.57"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-381.97,-621.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(28.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2948,8 +2948,8 @@
         <g id="283">
             <desc>L15-33-1</desc>
             <g id="283.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-85.98,-1117.75 23.00,-800.06"/>
-                <g class="nad-edge-infos" transform="translate(-75.44,-1087.01)">
+                <polyline class="nad-edge-path nad-stretchable" points="-85.98,-1117.75 23.00,-800.06"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-75.44,-1087.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(161.07)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2967,8 +2967,8 @@
                 </g>
             </g>
             <g id="283.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="131.97,-482.37 23.00,-800.06"/>
-                <g class="nad-edge-infos" transform="translate(121.43,-513.12)">
+                <polyline class="nad-edge-path nad-stretchable" points="131.97,-482.37 23.00,-800.06"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(121.43,-513.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-18.93)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2989,8 +2989,8 @@
         <g id="284">
             <desc>L16-17-1</desc>
             <g id="284.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-334.01,-1851.48 -562.18,-1667.43"/>
-                <g class="nad-edge-infos" transform="translate(-359.30,-1831.08)">
+                <polyline class="nad-edge-path nad-stretchable" points="-334.01,-1851.48 -562.18,-1667.43"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-359.30,-1831.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-128.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3008,8 +3008,8 @@
                 </g>
             </g>
             <g id="284.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-790.36,-1483.38 -562.18,-1667.43"/>
-                <g class="nad-edge-infos" transform="translate(-765.07,-1503.78)">
+                <polyline class="nad-edge-path nad-stretchable" points="-790.36,-1483.38 -562.18,-1667.43"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-765.07,-1503.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(51.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3030,8 +3030,8 @@
         <g id="285">
             <desc>L17-18-1</desc>
             <g id="285.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-797.19,-1442.80 -680.14,-1255.53"/>
-                <g class="nad-edge-infos" transform="translate(-779.97,-1415.24)">
+                <polyline class="nad-edge-path nad-stretchable" points="-797.19,-1442.80 -680.14,-1255.53"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-779.97,-1415.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(147.99)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3049,8 +3049,8 @@
                 </g>
             </g>
             <g id="285.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-563.09,-1068.26 -680.14,-1255.53"/>
-                <g class="nad-edge-infos" transform="translate(-580.32,-1095.82)">
+                <polyline class="nad-edge-path nad-stretchable" points="-563.09,-1068.26 -680.14,-1255.53"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-580.32,-1095.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-32.01)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3071,8 +3071,8 @@
         <g id="286">
             <desc>L17-31-1</desc>
             <g id="286.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-836.24,-1478.66 -1187.55,-1658.70"/>
-                <g class="nad-edge-infos" transform="translate(-865.16,-1493.48)">
+                <polyline class="nad-edge-path nad-stretchable" points="-836.24,-1478.66 -1187.55,-1658.70"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-865.16,-1493.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-62.87)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3090,8 +3090,8 @@
                 </g>
             </g>
             <g id="286.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1538.87,-1838.73 -1187.55,-1658.70"/>
-                <g class="nad-edge-infos" transform="translate(-1509.94,-1823.91)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1538.87,-1838.73 -1187.55,-1658.70"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1509.94,-1823.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(117.13)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3112,8 +3112,8 @@
         <g id="287">
             <desc>T30-17-1</desc>
             <g id="287.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-958.02,-1090.14 -900.75,-1237.35"/>
-                <g class="nad-edge-infos" transform="translate(-946.24,-1120.43)">
+                <polyline class="nad-edge-path nad-stretchable" points="-958.02,-1090.14 -900.75,-1237.35"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-946.24,-1120.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(21.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3129,11 +3129,10 @@
                         <text transform="rotate(-68.74)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-893.50" cy="-1255.99" r="20.00"/>
             </g>
             <g id="287.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-821.74,-1440.49 -879.00,-1293.27"/>
-                <g class="nad-edge-infos" transform="translate(-833.52,-1410.20)">
+                <polyline class="nad-edge-path nad-stretchable" points="-821.74,-1440.49 -879.00,-1293.27"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-833.52,-1410.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-158.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3149,14 +3148,21 @@
                         <text transform="rotate(-68.74)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-886.25" cy="-1274.63" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180-line">
+                    <circle class="nad-winding" cx="-893.50" cy="-1255.99" r="20.00"/>
+                </g>
+                <g class="nad-vl120to180-line">
+                    <circle class="nad-winding" cx="-886.25" cy="-1274.63" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="288">
             <desc>L18-19-1</desc>
             <g id="288.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-540.87,-1018.53 -479.70,-807.16"/>
-                <g class="nad-edge-infos" transform="translate(-531.83,-987.31)">
+                <polyline class="nad-edge-path nad-stretchable" points="-540.87,-1018.53 -479.70,-807.16"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-531.83,-987.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(163.86)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3174,8 +3180,8 @@
                 </g>
             </g>
             <g id="288.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-418.53,-595.79 -479.70,-807.16"/>
-                <g class="nad-edge-infos" transform="translate(-427.56,-627.01)">
+                <polyline class="nad-edge-path nad-stretchable" points="-418.53,-595.79 -479.70,-807.16"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-427.56,-627.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-16.14)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3196,8 +3202,8 @@
         <g id="289">
             <desc>L19-20-1</desc>
             <g id="289.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-438.35,-568.05 -706.46,-555.11"/>
-                <g class="nad-edge-infos" transform="translate(-470.82,-566.49)">
+                <polyline class="nad-edge-path nad-stretchable" points="-438.35,-568.05 -706.46,-555.11"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-470.82,-566.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-92.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3215,8 +3221,8 @@
                 </g>
             </g>
             <g id="289.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-974.57,-542.18 -706.46,-555.11"/>
-                <g class="nad-edge-infos" transform="translate(-942.11,-543.74)">
+                <polyline class="nad-edge-path nad-stretchable" points="-974.57,-542.18 -706.46,-555.11"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-942.11,-543.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(87.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3237,8 +3243,8 @@
         <g id="290">
             <desc>L19-34-1</desc>
             <g id="290.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-402.93,-543.05 -249.35,-35.09"/>
-                <g class="nad-edge-infos" transform="translate(-393.52,-511.94)">
+                <polyline class="nad-edge-path nad-stretchable" points="-402.93,-543.05 -249.35,-35.09"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-393.52,-511.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(163.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3256,8 +3262,8 @@
                 </g>
             </g>
             <g id="290.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-95.78,472.88 -249.35,-35.09"/>
-                <g class="nad-edge-infos" transform="translate(-105.18,441.77)">
+                <polyline class="nad-edge-path nad-stretchable" points="-95.78,472.88 -249.35,-35.09"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-105.18,441.77)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-16.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3278,8 +3284,8 @@
         <g id="291">
             <desc>L20-21-1</desc>
             <g id="291.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1029.48,-539.09 -1249.18,-524.97"/>
-                <g class="nad-edge-infos" transform="translate(-1061.92,-537.00)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1029.48,-539.09 -1249.18,-524.97"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1061.92,-537.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-93.68)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3297,8 +3303,8 @@
                 </g>
             </g>
             <g id="291.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1468.87,-510.85 -1249.18,-524.97"/>
-                <g class="nad-edge-infos" transform="translate(-1436.44,-512.94)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1468.87,-510.85 -1249.18,-524.97"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1436.44,-512.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(86.32)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3319,8 +3325,8 @@
         <g id="292">
             <desc>L21-22-1</desc>
             <g id="292.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1523.53,-513.06 -1711.44,-540.51"/>
-                <g class="nad-edge-infos" transform="translate(-1555.69,-517.76)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1523.53,-513.06 -1711.44,-540.51"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1555.69,-517.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-81.69)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3338,8 +3344,8 @@
                 </g>
             </g>
             <g id="292.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1899.36,-567.96 -1711.44,-540.51"/>
-                <g class="nad-edge-infos" transform="translate(-1867.20,-563.26)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1899.36,-567.96 -1711.44,-540.51"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1867.20,-563.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(98.31)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3360,8 +3366,8 @@
         <g id="293">
             <desc>L22-23-1</desc>
             <g id="293.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1947.34,-589.96 -2064.17,-691.32"/>
-                <g class="nad-edge-infos" transform="translate(-1971.89,-611.26)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1947.34,-589.96 -2064.17,-691.32"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1971.89,-611.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-49.05)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3379,8 +3385,8 @@
                 </g>
             </g>
             <g id="293.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2181.00,-792.68 -2064.17,-691.32"/>
-                <g class="nad-edge-infos" transform="translate(-2156.45,-771.38)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2181.00,-792.68 -2064.17,-691.32"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-2156.45,-771.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(130.95)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3401,8 +3407,8 @@
         <g id="294">
             <desc>L23-24-1</desc>
             <g id="294.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2198.60,-783.39 -2161.87,-467.14"/>
-                <g class="nad-edge-infos" transform="translate(-2194.85,-751.11)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2198.60,-783.39 -2161.87,-467.14"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-2194.85,-751.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(173.38)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3420,8 +3426,8 @@
                 </g>
             </g>
             <g id="294.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2125.14,-150.89 -2161.87,-467.14"/>
-                <g class="nad-edge-infos" transform="translate(-2128.89,-183.17)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2125.14,-150.89 -2161.87,-467.14"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-2128.89,-183.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-6.62)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3442,8 +3448,8 @@
         <g id="295">
             <desc>L23-25-1</desc>
             <g id="295.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2197.80,-837.92 -2176.10,-986.64"/>
-                <g class="nad-edge-infos" transform="translate(-2193.11,-870.08)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2197.80,-837.92 -2176.10,-986.64"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-2193.11,-870.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(8.30)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3461,8 +3467,8 @@
                 </g>
             </g>
             <g id="295.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2154.39,-1135.37 -2176.10,-986.64"/>
-                <g class="nad-edge-infos" transform="translate(-2159.08,-1103.21)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2154.39,-1135.37 -2176.10,-986.64"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-2159.08,-1103.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-171.70)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3483,8 +3489,8 @@
         <g id="296">
             <desc>L23-32-1</desc>
             <g id="296.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2195.03,-837.36 -2108.96,-1177.30"/>
-                <g class="nad-edge-infos" transform="translate(-2187.05,-868.87)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2195.03,-837.36 -2108.96,-1177.30"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-2187.05,-868.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(14.21)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3502,8 +3508,8 @@
                 </g>
             </g>
             <g id="296.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2022.89,-1517.25 -2108.96,-1177.30"/>
-                <g class="nad-edge-infos" transform="translate(-2030.87,-1485.74)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2022.89,-1517.25 -2108.96,-1177.30"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-2030.87,-1485.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-165.79)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3524,8 +3530,8 @@
         <g id="297">
             <desc>L24-70-1</desc>
             <g id="297.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2101.59,-105.11 -1845.96,126.53"/>
-                <g class="nad-edge-infos" transform="translate(-2077.51,-83.28)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2101.59,-105.11 -1845.96,126.53"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-2077.51,-83.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(132.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3543,8 +3549,8 @@
                 </g>
             </g>
             <g id="297.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1590.32,358.18 -1845.96,126.53"/>
-                <g class="nad-edge-infos" transform="translate(-1614.40,336.35)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1590.32,358.18 -1845.96,126.53"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1614.40,336.35)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-47.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3565,8 +3571,8 @@
         <g id="298">
             <desc>L24-72-1</desc>
             <g id="298.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2145.83,-109.89 -2301.67,-20.50"/>
-                <g class="nad-edge-infos" transform="translate(-2174.02,-93.72)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2145.83,-109.89 -2301.67,-20.50"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-2174.02,-93.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-119.84)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3584,8 +3590,8 @@
                 </g>
             </g>
             <g id="298.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2457.51,68.88 -2301.67,-20.50"/>
-                <g class="nad-edge-infos" transform="translate(-2429.32,52.71)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2457.51,68.88 -2301.67,-20.50"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-2429.32,52.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(60.16)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3606,8 +3612,8 @@
         <g id="299">
             <desc>L25-27-1</desc>
             <g id="299.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2164.47,-1186.22 -2273.22,-1369.16"/>
-                <g class="nad-edge-infos" transform="translate(-2181.08,-1214.16)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2164.47,-1186.22 -2273.22,-1369.16"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-2181.08,-1214.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-30.73)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3625,8 +3631,8 @@
                 </g>
             </g>
             <g id="299.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2381.98,-1552.09 -2273.22,-1369.16"/>
-                <g class="nad-edge-infos" transform="translate(-2365.37,-1524.16)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2381.98,-1552.09 -2273.22,-1369.16"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-2365.37,-1524.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(149.27)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3647,8 +3653,8 @@
         <g id="300">
             <desc>T26-25-1</desc>
             <g id="300.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1612.14,-1098.25 -1837.84,-1125.23"/>
-                <g class="nad-edge-infos" transform="translate(-1644.41,-1102.11)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1612.14,-1098.25 -1837.84,-1125.23"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1644.41,-1102.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-83.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3664,11 +3670,10 @@
                         <text transform="rotate(-353.18)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-1857.70" cy="-1127.60" r="20.00"/>
             </g>
             <g id="300.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2123.11,-1159.32 -1897.41,-1132.35"/>
-                <g class="nad-edge-infos" transform="translate(-2090.84,-1155.46)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2123.11,-1159.32 -1897.41,-1132.35"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-2090.84,-1155.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(96.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3684,14 +3689,21 @@
                         <text transform="rotate(6.82)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-1877.56" cy="-1129.97" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180-line">
+                    <circle class="nad-winding" cx="-1857.70" cy="-1127.60" r="20.00"/>
+                </g>
+                <g class="nad-vl120to180-line">
+                    <circle class="nad-winding" cx="-1877.56" cy="-1129.97" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="301">
             <desc>L26-30-1</desc>
             <g id="301.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1557.37,-1093.63 -1276.41,-1079.75"/>
-                <g class="nad-edge-infos" transform="translate(-1524.91,-1092.03)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1557.37,-1093.63 -1276.41,-1079.75"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1524.91,-1092.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(92.83)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3709,8 +3721,8 @@
                 </g>
             </g>
             <g id="301.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-995.45,-1065.86 -1276.41,-1079.75"/>
-                <g class="nad-edge-infos" transform="translate(-1027.91,-1067.47)">
+                <polyline class="nad-edge-path nad-stretchable" points="-995.45,-1065.86 -1276.41,-1079.75"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1027.91,-1067.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-87.17)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3731,8 +3743,8 @@
         <g id="302">
             <desc>L27-28-1</desc>
             <g id="302.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2390.34,-1602.64 -2339.07,-1845.18"/>
-                <g class="nad-edge-infos" transform="translate(-2383.62,-1634.43)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2390.34,-1602.64 -2339.07,-1845.18"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-2383.62,-1634.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(11.93)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3750,8 +3762,8 @@
                 </g>
             </g>
             <g id="302.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2287.81,-2087.73 -2339.07,-1845.18"/>
-                <g class="nad-edge-infos" transform="translate(-2294.53,-2055.93)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2287.81,-2087.73 -2339.07,-1845.18"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-2294.53,-2055.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-168.07)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3772,8 +3784,8 @@
         <g id="303">
             <desc>L27-32-1</desc>
             <g id="303.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2368.62,-1573.43 -2206.09,-1559.82"/>
-                <g class="nad-edge-infos" transform="translate(-2336.24,-1570.72)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2368.62,-1573.43 -2206.09,-1559.82"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-2336.24,-1570.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(94.79)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3791,8 +3803,8 @@
                 </g>
             </g>
             <g id="303.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2043.55,-1546.20 -2206.09,-1559.82"/>
-                <g class="nad-edge-infos" transform="translate(-2075.93,-1548.91)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2043.55,-1546.20 -2206.09,-1559.82"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-2075.93,-1548.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-85.21)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3813,8 +3825,8 @@
         <g id="304">
             <desc>L28-29-1</desc>
             <g id="304.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2255.53,-2121.66 -2088.85,-2165.65"/>
-                <g class="nad-edge-infos" transform="translate(-2224.11,-2129.95)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2255.53,-2121.66 -2088.85,-2165.65"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-2224.11,-2129.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(75.22)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3832,8 +3844,8 @@
                 </g>
             </g>
             <g id="304.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1922.16,-2209.64 -2088.85,-2165.65"/>
-                <g class="nad-edge-infos" transform="translate(-1953.59,-2201.35)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1922.16,-2209.64 -2088.85,-2165.65"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1953.59,-2201.35)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-104.78)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3854,8 +3866,8 @@
         <g id="305">
             <desc>L29-31-1</desc>
             <g id="305.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1877.07,-2196.31 -1729.46,-2033.97"/>
-                <g class="nad-edge-infos" transform="translate(-1855.21,-2172.27)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1877.07,-2196.31 -1729.46,-2033.97"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1855.21,-2172.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(137.72)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3873,8 +3885,8 @@
                 </g>
             </g>
             <g id="305.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1581.84,-1871.62 -1729.46,-2033.97"/>
-                <g class="nad-edge-infos" transform="translate(-1603.71,-1895.67)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1581.84,-1871.62 -1729.46,-2033.97"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1603.71,-1895.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-42.28)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3895,8 +3907,8 @@
         <g id="306">
             <desc>L3-5-1</desc>
             <g id="306.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="321.73,-2686.67 61.37,-2644.26"/>
-                <g class="nad-edge-infos" transform="translate(289.66,-2681.44)">
+                <polyline class="nad-edge-path nad-stretchable" points="321.73,-2686.67 61.37,-2644.26"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(289.66,-2681.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-99.25)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3914,8 +3926,8 @@
                 </g>
             </g>
             <g id="306.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-199.00,-2601.85 61.37,-2644.26"/>
-                <g class="nad-edge-infos" transform="translate(-166.92,-2607.07)">
+                <polyline class="nad-edge-path nad-stretchable" points="-199.00,-2601.85 61.37,-2644.26"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-166.92,-2607.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(80.75)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3936,8 +3948,8 @@
         <g id="307">
             <desc>L8-30-1</desc>
             <g id="307.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-826.69,-2045.41 -895.38,-1568.57"/>
-                <g class="nad-edge-infos" transform="translate(-831.33,-2013.24)">
+                <polyline class="nad-edge-path nad-stretchable" points="-826.69,-2045.41 -895.38,-1568.57"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-831.33,-2013.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-171.80)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3955,8 +3967,8 @@
                 </g>
             </g>
             <g id="307.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-964.07,-1091.73 -895.38,-1568.57"/>
-                <g class="nad-edge-infos" transform="translate(-959.43,-1123.89)">
+                <polyline class="nad-edge-path nad-stretchable" points="-964.07,-1091.73 -895.38,-1568.57"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-959.43,-1123.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(8.20)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3977,8 +3989,8 @@
         <g id="308">
             <desc>L30-38-1</desc>
             <g id="308.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-959.09,-1038.49 -741.99,-403.62"/>
-                <g class="nad-edge-infos" transform="translate(-948.57,-1007.73)">
+                <polyline class="nad-edge-path nad-stretchable" points="-959.09,-1038.49 -741.99,-403.62"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-948.57,-1007.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(161.12)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3996,8 +4008,8 @@
                 </g>
             </g>
             <g id="308.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-524.89,231.24 -741.99,-403.62"/>
-                <g class="nad-edge-infos" transform="translate(-535.40,200.49)">
+                <polyline class="nad-edge-path nad-stretchable" points="-524.89,231.24 -741.99,-403.62"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-535.40,200.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-18.88)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4018,8 +4030,8 @@
         <g id="309">
             <desc>L31-32-1</desc>
             <g id="309.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1586.09,-1835.83 -1789.74,-1697.59"/>
-                <g class="nad-edge-infos" transform="translate(-1612.98,-1817.58)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1586.09,-1835.83 -1789.74,-1697.59"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1612.98,-1817.58)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-124.17)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4037,8 +4049,8 @@
                 </g>
             </g>
             <g id="309.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1993.39,-1559.35 -1789.74,-1697.59"/>
-                <g class="nad-edge-infos" transform="translate(-1966.50,-1577.60)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1993.39,-1559.35 -1789.74,-1697.59"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1966.50,-1577.60)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(55.83)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4059,8 +4071,8 @@
         <g id="310">
             <desc>L33-37-1</desc>
             <g id="310.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="143.67,-429.00 191.27,41.07"/>
-                <g class="nad-edge-infos" transform="translate(146.94,-396.67)">
+                <polyline class="nad-edge-path nad-stretchable" points="143.67,-429.00 191.27,41.07"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(146.94,-396.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(174.22)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4078,8 +4090,8 @@
                 </g>
             </g>
             <g id="310.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="238.88,511.14 191.27,41.07"/>
-                <g class="nad-edge-infos" transform="translate(235.60,478.80)">
+                <polyline class="nad-edge-path nad-stretchable" points="238.88,511.14 191.27,41.07"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(235.60,478.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-5.78)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4100,8 +4112,8 @@
         <g id="311">
             <desc>L34-36-1</desc>
             <g id="311.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-71.95,521.66 38.67,678.19"/>
-                <g class="nad-edge-infos" transform="translate(-53.19,548.20)">
+                <polyline class="nad-edge-path nad-stretchable" points="-71.95,521.66 38.67,678.19"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-53.19,548.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(144.75)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4119,8 +4131,8 @@
                 </g>
             </g>
             <g id="311.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="149.28,834.71 38.67,678.19"/>
-                <g class="nad-edge-infos" transform="translate(130.52,808.17)">
+                <polyline class="nad-edge-path nad-stretchable" points="149.28,834.71 38.67,678.19"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(130.52,808.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-35.25)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4141,8 +4153,8 @@
         <g id="312">
             <desc>L34-37-1</desc>
             <g id="312.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-60.51,502.46 76.91,518.85"/>
-                <g class="nad-edge-infos" transform="translate(-28.24,506.31)">
+                <polyline class="nad-edge-path nad-stretchable" points="-60.51,502.46 76.91,518.85"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-28.24,506.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(96.80)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4160,8 +4172,8 @@
                 </g>
             </g>
             <g id="312.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="214.34,535.24 76.91,518.85"/>
-                <g class="nad-edge-infos" transform="translate(182.07,531.39)">
+                <polyline class="nad-edge-path nad-stretchable" points="214.34,535.24 76.91,518.85"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(182.07,531.39)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-83.20)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4182,8 +4194,8 @@
         <g id="313">
             <desc>L34-43-1</desc>
             <g id="313.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-83.03,526.28 -16.39,902.95"/>
-                <g class="nad-edge-infos" transform="translate(-77.37,558.29)">
+                <polyline class="nad-edge-path nad-stretchable" points="-83.03,526.28 -16.39,902.95"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-77.37,558.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(169.97)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4201,8 +4213,8 @@
                 </g>
             </g>
             <g id="313.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="50.24,1279.62 -16.39,902.95"/>
-                <g class="nad-edge-infos" transform="translate(44.58,1247.62)">
+                <polyline class="nad-edge-path nad-stretchable" points="50.24,1279.62 -16.39,902.95"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(44.58,1247.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-10.03)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4223,8 +4235,8 @@
         <g id="314">
             <desc>L35-36-1</desc>
             <g id="314.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="497.48,746.28 344.36,797.37"/>
-                <g class="nad-edge-infos" transform="translate(466.65,756.57)">
+                <polyline class="nad-edge-path nad-stretchable" points="497.48,746.28 344.36,797.37"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(466.65,756.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-108.45)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4242,8 +4254,8 @@
                 </g>
             </g>
             <g id="314.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="191.24,848.46 344.36,797.37"/>
-                <g class="nad-edge-infos" transform="translate(222.07,838.18)">
+                <polyline class="nad-edge-path nad-stretchable" points="191.24,848.46 344.36,797.37"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(222.07,838.18)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(71.55)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4264,8 +4276,8 @@
         <g id="315">
             <desc>L35-37-1</desc>
             <g id="315.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="501.11,721.72 382.61,638.04"/>
-                <g class="nad-edge-infos" transform="translate(474.56,702.97)">
+                <polyline class="nad-edge-path nad-stretchable" points="501.11,721.72 382.61,638.04"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(474.56,702.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-54.77)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4283,8 +4295,8 @@
                 </g>
             </g>
             <g id="315.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="264.11,554.36 382.61,638.04"/>
-                <g class="nad-edge-infos" transform="translate(290.66,573.11)">
+                <polyline class="nad-edge-path nad-stretchable" points="264.11,554.36 382.61,638.04"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(290.66,573.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(125.23)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4305,8 +4317,8 @@
         <g id="316">
             <desc>L37-39-1</desc>
             <g id="316.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="260.38,558.63 474.53,788.88"/>
-                <g class="nad-edge-infos" transform="translate(282.51,582.43)">
+                <polyline class="nad-edge-path nad-stretchable" points="260.38,558.63 474.53,788.88"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(282.51,582.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(137.07)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4324,8 +4336,8 @@
                 </g>
             </g>
             <g id="316.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="688.69,1019.13 474.53,788.88"/>
-                <g class="nad-edge-infos" transform="translate(666.56,995.33)">
+                <polyline class="nad-edge-path nad-stretchable" points="688.69,1019.13 474.53,788.88"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(666.56,995.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-42.93)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4346,8 +4358,8 @@
         <g id="317">
             <desc>L37-40-1</desc>
             <g id="317.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="250.48,564.54 377.19,938.11"/>
-                <g class="nad-edge-infos" transform="translate(260.92,595.32)">
+                <polyline class="nad-edge-path nad-stretchable" points="250.48,564.54 377.19,938.11"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(260.92,595.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(161.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4365,8 +4377,8 @@
                 </g>
             </g>
             <g id="317.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="503.91,1311.67 377.19,938.11"/>
-                <g class="nad-edge-infos" transform="translate(493.47,1280.90)">
+                <polyline class="nad-edge-path nad-stretchable" points="503.91,1311.67 377.19,938.11"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(493.47,1280.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-18.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4387,8 +4399,8 @@
         <g id="318">
             <desc>T38-37-1</desc>
             <g id="318.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-490.21,266.84 -165.30,387.44"/>
-                <g class="nad-edge-infos" transform="translate(-459.74,278.15)">
+                <polyline class="nad-edge-path nad-stretchable" points="-490.21,266.84 -165.30,387.44"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-459.74,278.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(110.36)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4404,11 +4416,10 @@
                         <text transform="rotate(20.36)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-146.55" cy="394.40" r="20.00"/>
             </g>
             <g id="318.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="215.87,528.93 -109.05,408.32"/>
-                <g class="nad-edge-infos" transform="translate(185.40,517.62)">
+                <polyline class="nad-edge-path nad-stretchable" points="215.87,528.93 -109.05,408.32"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(185.40,517.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-69.64)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4424,14 +4435,21 @@
                         <text transform="rotate(-339.64)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-127.80" cy="401.36" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180-line">
+                    <circle class="nad-winding" cx="-146.55" cy="394.40" r="20.00"/>
+                </g>
+                <g class="nad-vl120to180-line">
+                    <circle class="nad-winding" cx="-127.80" cy="401.36" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="319">
             <desc>L38-65-1</desc>
             <g id="319.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-524.09,283.55 -677.00,779.87"/>
-                <g class="nad-edge-infos" transform="translate(-533.66,314.61)">
+                <polyline class="nad-edge-path nad-stretchable" points="-524.09,283.55 -677.00,779.87"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-533.66,314.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-162.88)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4449,8 +4467,8 @@
                 </g>
             </g>
             <g id="319.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-829.92,1276.19 -677.00,779.87"/>
-                <g class="nad-edge-infos" transform="translate(-820.35,1245.13)">
+                <polyline class="nad-edge-path nad-stretchable" points="-829.92,1276.19 -677.00,779.87"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-820.35,1245.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(17.12)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4471,8 +4489,8 @@
         <g id="320">
             <desc>L39-40-1</desc>
             <g id="320.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="692.40,1062.30 610.08,1188.49"/>
-                <g class="nad-edge-infos" transform="translate(674.64,1089.52)">
+                <polyline class="nad-edge-path nad-stretchable" points="692.40,1062.30 610.08,1188.49"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(674.64,1089.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-146.88)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4490,8 +4508,8 @@
                 </g>
             </g>
             <g id="320.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="527.77,1314.68 610.08,1188.49"/>
-                <g class="nad-edge-infos" transform="translate(545.52,1287.46)">
+                <polyline class="nad-edge-path nad-stretchable" points="527.77,1314.68 610.08,1188.49"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(545.52,1287.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(33.12)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4512,8 +4530,8 @@
         <g id="321">
             <desc>L4-5-1</desc>
             <g id="321.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-433.89,-2452.41 -341.29,-2517.05"/>
-                <g class="nad-edge-infos" transform="translate(-407.24,-2471.02)">
+                <polyline class="nad-edge-path nad-stretchable" points="-433.89,-2452.41 -341.29,-2517.05"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-407.24,-2471.02)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(55.08)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4531,8 +4549,8 @@
                 </g>
             </g>
             <g id="321.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-248.69,-2581.69 -341.29,-2517.05"/>
-                <g class="nad-edge-infos" transform="translate(-275.34,-2563.09)">
+                <polyline class="nad-edge-path nad-stretchable" points="-248.69,-2581.69 -341.29,-2517.05"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-275.34,-2563.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-124.92)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4553,8 +4571,8 @@
         <g id="322">
             <desc>L40-41-1</desc>
             <g id="322.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="520.22,1364.18 573.48,1552.73"/>
-                <g class="nad-edge-infos" transform="translate(529.05,1395.46)">
+                <polyline class="nad-edge-path nad-stretchable" points="520.22,1364.18 573.48,1552.73"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(529.05,1395.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(164.23)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4572,8 +4590,8 @@
                 </g>
             </g>
             <g id="322.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="626.74,1741.29 573.48,1552.73"/>
-                <g class="nad-edge-infos" transform="translate(617.90,1710.01)">
+                <polyline class="nad-edge-path nad-stretchable" points="626.74,1741.29 573.48,1552.73"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(617.90,1710.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-15.77)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4594,8 +4612,8 @@
         <g id="323">
             <desc>L40-42-1</desc>
             <g id="323.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="493.32,1357.19 331.36,1519.60"/>
-                <g class="nad-edge-infos" transform="translate(470.37,1380.20)">
+                <polyline class="nad-edge-path nad-stretchable" points="493.32,1357.19 331.36,1519.60"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(470.37,1380.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-135.08)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4613,8 +4631,8 @@
                 </g>
             </g>
             <g id="323.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="169.41,1682.01 331.36,1519.60"/>
-                <g class="nad-edge-infos" transform="translate(192.35,1658.99)">
+                <polyline class="nad-edge-path nad-stretchable" points="169.41,1682.01 331.36,1519.60"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(192.35,1658.99)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(44.92)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4635,8 +4653,8 @@
         <g id="324">
             <desc>L41-42-1</desc>
             <g id="324.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="606.96,1764.02 392.10,1734.62"/>
-                <g class="nad-edge-infos" transform="translate(574.76,1759.62)">
+                <polyline class="nad-edge-path nad-stretchable" points="606.96,1764.02 392.10,1734.62"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(574.76,1759.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-82.21)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4654,8 +4672,8 @@
                 </g>
             </g>
             <g id="324.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="177.23,1705.21 392.10,1734.62"/>
-                <g class="nad-edge-infos" transform="translate(209.43,1709.62)">
+                <polyline class="nad-edge-path nad-stretchable" points="177.23,1705.21 392.10,1734.62"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(209.43,1709.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(97.79)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4676,8 +4694,8 @@
         <g id="325">
             <desc>L42-49-1</desc>
             <g id="325.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="124.92,1690.18 77.05,1668.61 -361.96,1712.72"/>
-                <g class="nad-edge-infos" transform="translate(47.20,1671.61)">
+                <polyline class="nad-edge-path nad-stretchable" points="124.92,1690.18 77.05,1668.61 -361.96,1712.72"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(47.20,1671.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-95.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4695,8 +4713,8 @@
                 </g>
             </g>
             <g id="325.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-843.58,1787.50 -800.97,1756.83 -361.96,1712.72"/>
-                <g class="nad-edge-infos" transform="translate(-771.12,1753.83)">
+                <polyline class="nad-edge-path nad-stretchable" points="-843.58,1787.50 -800.97,1756.83 -361.96,1712.72"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-771.12,1753.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(84.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4717,8 +4735,8 @@
         <g id="326">
             <desc>L42-49-2</desc>
             <g id="326.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="127.67,1717.54 85.05,1748.21 -353.96,1792.32"/>
-                <g class="nad-edge-infos" transform="translate(55.20,1751.21)">
+                <polyline class="nad-edge-path nad-stretchable" points="127.67,1717.54 85.05,1748.21 -353.96,1792.32"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(55.20,1751.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-95.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4736,8 +4754,8 @@
                 </g>
             </g>
             <g id="326.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-840.83,1814.86 -792.97,1836.43 -353.96,1792.32"/>
-                <g class="nad-edge-infos" transform="translate(-763.12,1833.43)">
+                <polyline class="nad-edge-path nad-stretchable" points="-840.83,1814.86 -792.97,1836.43 -353.96,1792.32"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-763.12,1833.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(84.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4758,8 +4776,8 @@
         <g id="327">
             <desc>L43-44-1</desc>
             <g id="327.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="60.36,1333.68 128.77,1680.25"/>
-                <g class="nad-edge-infos" transform="translate(66.65,1365.56)">
+                <polyline class="nad-edge-path nad-stretchable" points="60.36,1333.68 128.77,1680.25"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(66.65,1365.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(168.83)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4777,8 +4795,8 @@
                 </g>
             </g>
             <g id="327.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="197.17,2026.83 128.77,1680.25"/>
-                <g class="nad-edge-infos" transform="translate(190.88,1994.94)">
+                <polyline class="nad-edge-path nad-stretchable" points="197.17,2026.83 128.77,1680.25"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(190.88,1994.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-11.17)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4799,8 +4817,8 @@
         <g id="328">
             <desc>L44-45-1</desc>
             <g id="328.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="175.64,2059.70 -0.88,2098.41"/>
-                <g class="nad-edge-infos" transform="translate(143.89,2066.66)">
+                <polyline class="nad-edge-path nad-stretchable" points="175.64,2059.70 -0.88,2098.41"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(143.89,2066.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-102.37)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4818,8 +4836,8 @@
                 </g>
             </g>
             <g id="328.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-177.39,2137.13 -0.88,2098.41"/>
-                <g class="nad-edge-infos" transform="translate(-145.64,2130.16)">
+                <polyline class="nad-edge-path nad-stretchable" points="-177.39,2137.13 -0.88,2098.41"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-145.64,2130.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(77.63)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4840,8 +4858,8 @@
         <g id="329">
             <desc>L45-46-1</desc>
             <g id="329.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-212.20,2116.69 -255.95,1971.75"/>
-                <g class="nad-edge-infos" transform="translate(-221.59,2085.58)">
+                <polyline class="nad-edge-path nad-stretchable" points="-212.20,2116.69 -255.95,1971.75"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-221.59,2085.58)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-16.80)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4859,8 +4877,8 @@
                 </g>
             </g>
             <g id="329.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-299.70,1826.81 -255.95,1971.75"/>
-                <g class="nad-edge-infos" transform="translate(-290.31,1857.92)">
+                <polyline class="nad-edge-path nad-stretchable" points="-299.70,1826.81 -255.95,1971.75"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-290.31,1857.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(163.20)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4881,8 +4899,8 @@
         <g id="330">
             <desc>L45-49-1</desc>
             <g id="330.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-228.72,2130.46 -535.08,1973.29"/>
-                <g class="nad-edge-infos" transform="translate(-257.63,2115.63)">
+                <polyline class="nad-edge-path nad-stretchable" points="-228.72,2130.46 -535.08,1973.29"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-257.63,2115.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-62.84)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4900,8 +4918,8 @@
                 </g>
             </g>
             <g id="330.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-841.44,1816.11 -535.08,1973.29"/>
-                <g class="nad-edge-infos" transform="translate(-812.52,1830.95)">
+                <polyline class="nad-edge-path nad-stretchable" points="-841.44,1816.11 -535.08,1973.29"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-812.52,1830.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(117.16)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4922,8 +4940,8 @@
         <g id="331">
             <desc>L46-47-1</desc>
             <g id="331.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-323.55,1778.04 -434.67,1621.29"/>
-                <g class="nad-edge-infos" transform="translate(-342.34,1751.53)">
+                <polyline class="nad-edge-path nad-stretchable" points="-323.55,1778.04 -434.67,1621.29"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-342.34,1751.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-35.33)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4941,8 +4959,8 @@
                 </g>
             </g>
             <g id="331.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-545.78,1464.54 -434.67,1621.29"/>
-                <g class="nad-edge-infos" transform="translate(-526.99,1491.05)">
+                <polyline class="nad-edge-path nad-stretchable" points="-545.78,1464.54 -434.67,1621.29"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-526.99,1491.05)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(144.67)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4963,8 +4981,8 @@
         <g id="332">
             <desc>L46-48-1</desc>
             <g id="332.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-330.59,1815.63 -437.70,1886.37"/>
-                <g class="nad-edge-infos" transform="translate(-357.71,1833.54)">
+                <polyline class="nad-edge-path nad-stretchable" points="-330.59,1815.63 -437.70,1886.37"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-357.71,1833.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-123.44)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4982,8 +5000,8 @@
                 </g>
             </g>
             <g id="332.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-544.80,1957.10 -437.70,1886.37"/>
-                <g class="nad-edge-infos" transform="translate(-517.68,1939.19)">
+                <polyline class="nad-edge-path nad-stretchable" points="-544.80,1957.10 -437.70,1886.37"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-517.68,1939.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(56.56)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5004,8 +5022,8 @@
         <g id="333">
             <desc>L47-49-1</desc>
             <g id="333.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-579.39,1463.14 -713.80,1622.83"/>
-                <g class="nad-edge-infos" transform="translate(-600.32,1488.01)">
+                <polyline class="nad-edge-path nad-stretchable" points="-579.39,1463.14 -713.80,1622.83"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-600.32,1488.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-139.91)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5023,8 +5041,8 @@
                 </g>
             </g>
             <g id="333.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-848.20,1782.52 -713.80,1622.83"/>
-                <g class="nad-edge-infos" transform="translate(-827.27,1757.66)">
+                <polyline class="nad-edge-path nad-stretchable" points="-848.20,1782.52 -713.80,1622.83"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-827.27,1757.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(40.09)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5045,8 +5063,8 @@
         <g id="334">
             <desc>L47-69-1</desc>
             <g id="334.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-569.06,1415.61 -649.41,1126.92"/>
-                <g class="nad-edge-infos" transform="translate(-577.77,1384.30)">
+                <polyline class="nad-edge-path nad-stretchable" points="-569.06,1415.61 -649.41,1126.92"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-577.77,1384.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-15.55)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5064,8 +5082,8 @@
                 </g>
             </g>
             <g id="334.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-729.75,838.23 -649.41,1126.92"/>
-                <g class="nad-edge-infos" transform="translate(-721.04,869.54)">
+                <polyline class="nad-edge-path nad-stretchable" points="-729.75,838.23 -649.41,1126.92"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-721.04,869.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(164.45)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5086,8 +5104,8 @@
         <g id="335">
             <desc>L48-49-1</desc>
             <g id="335.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-591.68,1958.71 -716.83,1887.91"/>
-                <g class="nad-edge-infos" transform="translate(-619.97,1942.71)">
+                <polyline class="nad-edge-path nad-stretchable" points="-591.68,1958.71 -716.83,1887.91"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-619.97,1942.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-60.50)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5105,8 +5123,8 @@
                 </g>
             </g>
             <g id="335.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-841.97,1817.10 -716.83,1887.91"/>
-                <g class="nad-edge-infos" transform="translate(-813.68,1833.11)">
+                <polyline class="nad-edge-path nad-stretchable" points="-841.97,1817.10 -716.83,1887.91"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-813.68,1833.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(119.50)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5127,8 +5145,8 @@
         <g id="336">
             <desc>L49-50-1</desc>
             <g id="336.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-880.78,1826.69 -1041.09,2075.99"/>
-                <g class="nad-edge-infos" transform="translate(-898.36,1854.03)">
+                <polyline class="nad-edge-path nad-stretchable" points="-880.78,1826.69 -1041.09,2075.99"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-898.36,1854.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-147.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5146,8 +5164,8 @@
                 </g>
             </g>
             <g id="336.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1201.41,2325.29 -1041.09,2075.99"/>
-                <g class="nad-edge-infos" transform="translate(-1183.83,2297.96)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1201.41,2325.29 -1041.09,2075.99"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1183.83,2297.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(32.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5168,8 +5186,8 @@
         <g id="337">
             <desc>L49-51-1</desc>
             <g id="337.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-892.47,1796.45 -1300.80,1687.14"/>
-                <g class="nad-edge-infos" transform="translate(-923.86,1788.04)">
+                <polyline class="nad-edge-path nad-stretchable" points="-892.47,1796.45 -1300.80,1687.14"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-923.86,1788.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-75.01)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5187,8 +5205,8 @@
                 </g>
             </g>
             <g id="337.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1709.13,1577.84 -1300.80,1687.14"/>
-                <g class="nad-edge-infos" transform="translate(-1677.74,1586.24)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1709.13,1577.84 -1300.80,1687.14"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1677.74,1586.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.99)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5209,8 +5227,8 @@
         <g id="338">
             <desc>L49-54-1</desc>
             <g id="338.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-892.97,1798.67 -944.63,1789.34 -1382.08,1946.52"/>
-                <g class="nad-edge-infos" transform="translate(-972.86,1799.49)">
+                <polyline class="nad-edge-path nad-stretchable" points="-892.97,1798.67 -944.63,1789.34 -1382.08,1946.52"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-972.86,1799.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-109.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5228,8 +5246,8 @@
                 </g>
             </g>
             <g id="338.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1853.43,2143.78 -1819.52,2103.70 -1382.08,1946.52"/>
-                <g class="nad-edge-infos" transform="translate(-1791.29,2093.55)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1853.43,2143.78 -1819.52,2103.70 -1382.08,1946.52"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1791.29,2093.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(70.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5250,8 +5268,8 @@
         <g id="339">
             <desc>L49-54-2</desc>
             <g id="339.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-883.67,1824.55 -917.58,1864.63 -1355.02,2021.81"/>
-                <g class="nad-edge-infos" transform="translate(-945.81,1874.78)">
+                <polyline class="nad-edge-path nad-stretchable" points="-883.67,1824.55 -917.58,1864.63 -1355.02,2021.81"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-945.81,1874.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-109.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5269,8 +5287,8 @@
                 </g>
             </g>
             <g id="339.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1844.13,2169.66 -1792.47,2178.98 -1355.02,2021.81"/>
-                <g class="nad-edge-infos" transform="translate(-1764.23,2168.84)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1844.13,2169.66 -1792.47,2178.98 -1355.02,2021.81"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1764.23,2168.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(70.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5291,8 +5309,8 @@
         <g id="340">
             <desc>L49-66-1</desc>
             <g id="340.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-872.50,1830.26 -885.08,1881.23 -833.85,2058.39"/>
-                <g class="nad-edge-infos" transform="translate(-876.75,1910.05)">
+                <polyline class="nad-edge-path nad-stretchable" points="-872.50,1830.26 -885.08,1881.23 -833.85,2058.39"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-876.75,1910.05)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(163.87)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5310,8 +5328,8 @@
                 </g>
             </g>
             <g id="340.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-744.76,2271.94 -782.61,2235.56 -833.85,2058.39"/>
-                <g class="nad-edge-infos" transform="translate(-790.94,2206.74)">
+                <polyline class="nad-edge-path nad-stretchable" points="-744.76,2271.94 -782.61,2235.56 -833.85,2058.39"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-790.94,2206.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-16.13)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5332,8 +5350,8 @@
         <g id="341">
             <desc>L49-66-2</desc>
             <g id="341.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-846.08,1822.62 -808.23,1859.00 -757.00,2036.17"/>
-                <g class="nad-edge-infos" transform="translate(-799.90,1887.82)">
+                <polyline class="nad-edge-path nad-stretchable" points="-846.08,1822.62 -808.23,1859.00 -757.00,2036.17"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-799.90,1887.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(163.87)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5351,8 +5369,8 @@
                 </g>
             </g>
             <g id="341.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-718.34,2264.30 -705.76,2213.33 -757.00,2036.17"/>
-                <g class="nad-edge-infos" transform="translate(-714.09,2184.51)">
+                <polyline class="nad-edge-path nad-stretchable" points="-718.34,2264.30 -705.76,2213.33 -757.00,2036.17"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-714.09,2184.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-16.13)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5373,8 +5391,8 @@
         <g id="342">
             <desc>L49-69-1</desc>
             <g id="342.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-862.36,1776.29 -801.52,1307.65"/>
-                <g class="nad-edge-infos" transform="translate(-858.18,1744.06)">
+                <polyline class="nad-edge-path nad-stretchable" points="-862.36,1776.29 -801.52,1307.65"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-858.18,1744.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(7.40)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5392,8 +5410,8 @@
                 </g>
             </g>
             <g id="342.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-740.67,839.01 -801.52,1307.65"/>
-                <g class="nad-edge-infos" transform="translate(-744.85,871.24)">
+                <polyline class="nad-edge-path nad-stretchable" points="-740.67,839.01 -801.52,1307.65"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-744.85,871.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-172.60)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5414,8 +5432,8 @@
         <g id="343">
             <desc>L5-6-1</desc>
             <g id="343.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-226.23,-2624.93 -226.94,-2838.16"/>
-                <g class="nad-edge-infos" transform="translate(-226.34,-2657.43)">
+                <polyline class="nad-edge-path nad-stretchable" points="-226.23,-2624.93 -226.94,-2838.16"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-226.34,-2657.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-0.19)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5433,8 +5451,8 @@
                 </g>
             </g>
             <g id="343.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-227.66,-3051.39 -226.94,-2838.16"/>
-                <g class="nad-edge-infos" transform="translate(-227.55,-3018.89)">
+                <polyline class="nad-edge-path nad-stretchable" points="-227.66,-3051.39 -226.94,-2838.16"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-227.55,-3018.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(179.81)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5455,8 +5473,8 @@
         <g id="344">
             <desc>T8-5-1</desc>
             <g id="344.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-802.12,-2090.79 -546.98,-2315.22"/>
-                <g class="nad-edge-infos" transform="translate(-777.72,-2112.26)">
+                <polyline class="nad-edge-path nad-stretchable" points="-802.12,-2090.79 -546.98,-2315.22"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-777.72,-2112.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.67)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5472,11 +5490,10 @@
                         <text transform="rotate(-41.33)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-531.96" cy="-2328.43" r="20.00"/>
             </g>
             <g id="344.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-246.79,-2579.27 -501.93,-2354.84"/>
-                <g class="nad-edge-infos" transform="translate(-271.19,-2557.80)">
+                <polyline class="nad-edge-path nad-stretchable" points="-246.79,-2579.27 -501.93,-2354.84"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-271.19,-2557.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-131.33)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5492,14 +5509,21 @@
                         <text transform="rotate(-41.33)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-516.95" cy="-2341.64" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180-line">
+                    <circle class="nad-winding" cx="-531.96" cy="-2328.43" r="20.00"/>
+                </g>
+                <g class="nad-vl120to180-line">
+                    <circle class="nad-winding" cx="-516.95" cy="-2341.64" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="345">
             <desc>L50-57-1</desc>
             <g id="345.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1236.73,2366.81 -1486.97,2591.77"/>
-                <g class="nad-edge-infos" transform="translate(-1260.90,2388.54)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1236.73,2366.81 -1486.97,2591.77"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1260.90,2388.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-131.96)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5517,8 +5541,8 @@
                 </g>
             </g>
             <g id="345.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1737.20,2816.74 -1486.97,2591.77"/>
-                <g class="nad-edge-infos" transform="translate(-1713.03,2795.01)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1737.20,2816.74 -1486.97,2591.77"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1713.03,2795.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.04)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5539,8 +5563,8 @@
         <g id="346">
             <desc>L51-52-1</desc>
             <g id="346.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1762.53,1564.72 -2002.97,1510.97"/>
-                <g class="nad-edge-infos" transform="translate(-1794.25,1557.63)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1762.53,1564.72 -2002.97,1510.97"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1794.25,1557.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-77.40)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5558,8 +5582,8 @@
                 </g>
             </g>
             <g id="346.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2243.41,1457.22 -2002.97,1510.97"/>
-                <g class="nad-edge-infos" transform="translate(-2211.69,1464.31)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2243.41,1457.22 -2002.97,1510.97"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-2211.69,1464.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(102.60)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5580,8 +5604,8 @@
         <g id="347">
             <desc>L51-58-1</desc>
             <g id="347.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1756.35,1588.88 -1907.88,1722.09"/>
-                <g class="nad-edge-infos" transform="translate(-1780.76,1610.34)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1756.35,1588.88 -1907.88,1722.09"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1780.76,1610.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-131.32)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5599,8 +5623,8 @@
                 </g>
             </g>
             <g id="347.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2059.41,1855.30 -1907.88,1722.09"/>
-                <g class="nad-edge-infos" transform="translate(-2035.00,1833.84)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2059.41,1855.30 -1907.88,1722.09"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-2035.00,1833.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.68)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5621,8 +5645,8 @@
         <g id="348">
             <desc>L52-53-1</desc>
             <g id="348.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2282.17,1476.00 -2360.45,1638.73"/>
-                <g class="nad-edge-infos" transform="translate(-2296.26,1505.28)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2282.17,1476.00 -2360.45,1638.73"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-2296.26,1505.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-154.31)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5640,8 +5664,8 @@
                 </g>
             </g>
             <g id="348.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2438.74,1801.46 -2360.45,1638.73"/>
-                <g class="nad-edge-infos" transform="translate(-2424.65,1772.17)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2438.74,1801.46 -2360.45,1638.73"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-2424.65,1772.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(25.69)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5662,8 +5686,8 @@
         <g id="349">
             <desc>L53-54-1</desc>
             <g id="349.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2426.92,1840.12 -2160.93,1995.51"/>
-                <g class="nad-edge-infos" transform="translate(-2398.85,1856.51)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2426.92,1840.12 -2160.93,1995.51"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-2398.85,1856.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(120.29)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5681,8 +5705,8 @@
                 </g>
             </g>
             <g id="349.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1894.94,2150.90 -2160.93,1995.51"/>
-                <g class="nad-edge-infos" transform="translate(-1923.00,2134.50)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1894.94,2150.90 -2160.93,1995.51"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1923.00,2134.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-59.71)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5703,8 +5727,8 @@
         <g id="350">
             <desc>L54-55-1</desc>
             <g id="350.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1886.07,2187.90 -2021.72,2398.78"/>
-                <g class="nad-edge-infos" transform="translate(-1903.65,2215.23)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1886.07,2187.90 -2021.72,2398.78"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1903.65,2215.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-147.25)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5722,8 +5746,8 @@
                 </g>
             </g>
             <g id="350.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2157.36,2609.67 -2021.72,2398.78"/>
-                <g class="nad-edge-infos" transform="translate(-2139.78,2582.34)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2157.36,2609.67 -2021.72,2398.78"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-2139.78,2582.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(32.75)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5744,8 +5768,8 @@
         <g id="351">
             <desc>L54-56-1</desc>
             <g id="351.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1887.55,2186.87 -1959.26,2283.77"/>
-                <g class="nad-edge-infos" transform="translate(-1906.89,2213.00)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1887.55,2186.87 -1959.26,2283.77"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1906.89,2213.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-143.50)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5763,8 +5787,8 @@
                 </g>
             </g>
             <g id="351.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2030.96,2380.67 -1959.26,2283.77"/>
-                <g class="nad-edge-infos" transform="translate(-2011.63,2354.54)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2030.96,2380.67 -1959.26,2283.77"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-2011.63,2354.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(36.50)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5785,8 +5809,8 @@
         <g id="352">
             <desc>L54-59-1</desc>
             <g id="352.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1859.08,2189.45 -1777.78,2355.09"/>
-                <g class="nad-edge-infos" transform="translate(-1844.76,2218.63)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1859.08,2189.45 -1777.78,2355.09"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1844.76,2218.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(153.86)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5804,8 +5828,8 @@
                 </g>
             </g>
             <g id="352.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1696.48,2520.72 -1777.78,2355.09"/>
-                <g class="nad-edge-infos" transform="translate(-1710.80,2491.54)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1696.48,2520.72 -1777.78,2355.09"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1710.80,2491.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-26.14)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5826,8 +5850,8 @@
         <g id="353">
             <desc>L55-56-1</desc>
             <g id="353.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2159.12,2608.63 -2109.78,2517.79"/>
-                <g class="nad-edge-infos" transform="translate(-2143.61,2580.07)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2159.12,2608.63 -2109.78,2517.79"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-2143.61,2580.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(28.50)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5845,8 +5869,8 @@
                 </g>
             </g>
             <g id="353.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2060.44,2426.94 -2109.78,2517.79"/>
-                <g class="nad-edge-infos" transform="translate(-2075.95,2455.50)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2060.44,2426.94 -2109.78,2517.79"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-2075.95,2455.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-151.50)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5867,8 +5891,8 @@
         <g id="354">
             <desc>L55-59-1</desc>
             <g id="354.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2145.17,2627.95 -1928.30,2589.10"/>
-                <g class="nad-edge-infos" transform="translate(-2113.18,2622.22)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2145.17,2627.95 -1928.30,2589.10"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-2113.18,2622.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(79.84)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5886,8 +5910,8 @@
                 </g>
             </g>
             <g id="354.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1711.43,2550.25 -1928.30,2589.10"/>
-                <g class="nad-edge-infos" transform="translate(-1743.42,2555.98)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1711.43,2550.25 -1928.30,2589.10"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1743.42,2555.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-100.16)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5908,8 +5932,8 @@
         <g id="355">
             <desc>L56-57-1</desc>
             <g id="355.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2032.01,2425.62 -1902.49,2618.95"/>
-                <g class="nad-edge-infos" transform="translate(-2013.92,2452.62)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2032.01,2425.62 -1902.49,2618.95"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-2013.92,2452.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(146.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5927,8 +5951,8 @@
                 </g>
             </g>
             <g id="355.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1772.96,2812.28 -1902.49,2618.95"/>
-                <g class="nad-edge-infos" transform="translate(-1791.05,2785.28)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1772.96,2812.28 -1902.49,2618.95"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1791.05,2785.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-33.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5949,8 +5973,8 @@
         <g id="356">
             <desc>L56-58-1</desc>
             <g id="356.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2049.02,2375.33 -2063.69,2138.11"/>
-                <g class="nad-edge-infos" transform="translate(-2051.02,2342.89)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2049.02,2375.33 -2063.69,2138.11"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-2051.02,2342.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-3.54)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5968,8 +5992,8 @@
                 </g>
             </g>
             <g id="356.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2078.37,1900.90 -2063.69,2138.11"/>
-                <g class="nad-edge-infos" transform="translate(-2076.36,1933.34)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2078.37,1900.90 -2063.69,2138.11"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-2076.36,1933.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(176.46)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5990,8 +6014,8 @@
         <g id="357">
             <desc>L56-59-1</desc>
             <g id="357.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2030.18,2424.28 -1997.47,2465.34 -1880.47,2511.32"/>
-                <g class="nad-edge-infos" transform="translate(-1969.55,2476.31)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2030.18,2424.28 -1997.47,2465.34 -1880.47,2511.32"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1969.55,2476.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(111.45)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6009,8 +6033,8 @@
                 </g>
             </g>
             <g id="357.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1711.56,2549.49 -1763.47,2557.29 -1880.47,2511.32"/>
-                <g class="nad-edge-infos" transform="translate(-1791.39,2546.32)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1711.56,2549.49 -1763.47,2557.29 -1880.47,2511.32"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1791.39,2546.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-68.55)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6031,8 +6055,8 @@
         <g id="358">
             <desc>L56-59-2</desc>
             <g id="358.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2020.13,2398.69 -1968.21,2390.88 -1851.21,2436.86"/>
-                <g class="nad-edge-infos" transform="translate(-1940.29,2401.86)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2020.13,2398.69 -1968.21,2390.88 -1851.21,2436.86"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1940.29,2401.86)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(111.45)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6050,8 +6074,8 @@
                 </g>
             </g>
             <g id="358.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1701.50,2523.90 -1734.21,2482.84 -1851.21,2436.86"/>
-                <g class="nad-edge-infos" transform="translate(-1762.14,2471.86)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1701.50,2523.90 -1734.21,2482.84 -1851.21,2436.86"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1762.14,2471.86)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-68.55)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6072,8 +6096,8 @@
         <g id="359">
             <desc>L59-60-1</desc>
             <g id="359.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1665.86,2565.75 -1478.60,2771.75"/>
-                <g class="nad-edge-infos" transform="translate(-1644.00,2589.80)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1665.86,2565.75 -1478.60,2771.75"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1644.00,2589.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(137.73)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6091,8 +6115,8 @@
                 </g>
             </g>
             <g id="359.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1291.34,2977.75 -1478.60,2771.75"/>
-                <g class="nad-edge-infos" transform="translate(-1313.20,2953.70)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1291.34,2977.75 -1478.60,2771.75"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1313.20,2953.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-42.27)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6113,8 +6137,8 @@
         <g id="360">
             <desc>L59-61-1</desc>
             <g id="360.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1657.76,2552.36 -1460.85,2603.81"/>
-                <g class="nad-edge-infos" transform="translate(-1626.31,2560.57)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1657.76,2552.36 -1460.85,2603.81"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1626.31,2560.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.65)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6132,8 +6156,8 @@
                 </g>
             </g>
             <g id="360.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1263.95,2655.27 -1460.85,2603.81"/>
-                <g class="nad-edge-infos" transform="translate(-1295.39,2647.05)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1263.95,2655.27 -1460.85,2603.81"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1295.39,2647.05)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-75.35)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6154,8 +6178,8 @@
         <g id="361">
             <desc>T63-59-1</desc>
             <g id="361.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1532.86,2164.19 -1592.46,2314.14"/>
-                <g class="nad-edge-infos" transform="translate(-1544.87,2194.39)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1532.86,2164.19 -1592.46,2314.14"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1544.87,2194.39)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-158.33)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6171,11 +6195,10 @@
                         <text transform="rotate(-68.33)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-1599.84" cy="2332.72" r="20.00"/>
             </g>
             <g id="361.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1674.21,2519.85 -1614.61,2369.90"/>
-                <g class="nad-edge-infos" transform="translate(-1662.20,2489.64)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1674.21,2519.85 -1614.61,2369.90"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1662.20,2489.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(21.67)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6191,14 +6214,21 @@
                         <text transform="rotate(-68.33)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-1607.23" cy="2351.31" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180-line">
+                    <circle class="nad-winding" cx="-1599.84" cy="2332.72" r="20.00"/>
+                </g>
+                <g class="nad-vl120to180-line">
+                    <circle class="nad-winding" cx="-1607.23" cy="2351.31" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="362">
             <desc>L6-7-1</desc>
             <g id="362.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-201.95,-3069.36 -54.08,-3014.71"/>
-                <g class="nad-edge-infos" transform="translate(-171.47,-3058.09)">
+                <polyline class="nad-edge-path nad-stretchable" points="-201.95,-3069.36 -54.08,-3014.71"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-171.47,-3058.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(110.28)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6216,8 +6246,8 @@
                 </g>
             </g>
             <g id="362.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="93.79,-2960.05 -54.08,-3014.71"/>
-                <g class="nad-edge-infos" transform="translate(63.30,-2971.32)">
+                <polyline class="nad-edge-path nad-stretchable" points="93.79,-2960.05 -54.08,-3014.71"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(63.30,-2971.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-69.72)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6238,8 +6268,8 @@
         <g id="363">
             <desc>L60-61-1</desc>
             <g id="363.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1269.95,2970.75 -1255.09,2830.16"/>
-                <g class="nad-edge-infos" transform="translate(-1266.54,2938.43)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1269.95,2970.75 -1255.09,2830.16"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1266.54,2938.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(6.03)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6257,8 +6287,8 @@
                 </g>
             </g>
             <g id="363.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1240.23,2689.57 -1255.09,2830.16"/>
-                <g class="nad-edge-infos" transform="translate(-1243.65,2721.89)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1240.23,2689.57 -1255.09,2830.16"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1243.65,2721.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-173.97)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6279,8 +6309,8 @@
         <g id="364">
             <desc>L60-62-1</desc>
             <g id="364.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1247.26,2988.00 -1064.77,2915.99"/>
-                <g class="nad-edge-infos" transform="translate(-1217.03,2976.07)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1247.26,2988.00 -1064.77,2915.99"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1217.03,2976.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(68.47)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6298,8 +6328,8 @@
                 </g>
             </g>
             <g id="364.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-882.27,2843.98 -1064.77,2915.99"/>
-                <g class="nad-edge-infos" transform="translate(-912.50,2855.91)">
+                <polyline class="nad-edge-path nad-stretchable" points="-882.27,2843.98 -1064.77,2915.99"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-912.50,2855.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-111.53)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6320,8 +6350,8 @@
         <g id="365">
             <desc>L61-62-1</desc>
             <g id="365.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1212.27,2673.53 -1047.02,2748.05"/>
-                <g class="nad-edge-infos" transform="translate(-1182.65,2686.89)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1212.27,2673.53 -1047.02,2748.05"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1182.65,2686.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(114.27)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6339,8 +6369,8 @@
                 </g>
             </g>
             <g id="365.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-881.76,2822.58 -1047.02,2748.05"/>
-                <g class="nad-edge-infos" transform="translate(-911.39,2809.22)">
+                <polyline class="nad-edge-path nad-stretchable" points="-881.76,2822.58 -1047.02,2748.05"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-911.39,2809.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-65.73)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6361,8 +6391,8 @@
         <g id="366">
             <desc>T64-61-1</desc>
             <g id="366.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1223.60,1952.26 -1229.63,2263.50"/>
-                <g class="nad-edge-infos" transform="translate(-1224.23,1984.76)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1223.60,1952.26 -1229.63,2263.50"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1224.23,1984.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-178.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6378,11 +6408,10 @@
                         <text transform="rotate(-88.89)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-1230.01" cy="2283.50" r="20.00"/>
             </g>
             <g id="366.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1236.81,2634.73 -1230.79,2323.49"/>
-                <g class="nad-edge-infos" transform="translate(-1236.18,2602.23)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1236.81,2634.73 -1230.79,2323.49"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1236.18,2602.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(1.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6398,14 +6427,21 @@
                         <text transform="rotate(-88.89)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-1230.40" cy="2303.49" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180-line">
+                    <circle class="nad-winding" cx="-1230.01" cy="2283.50" r="20.00"/>
+                </g>
+                <g class="nad-vl120to180-line">
+                    <circle class="nad-winding" cx="-1230.40" cy="2303.49" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="367">
             <desc>L62-66-1</desc>
             <g id="367.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-850.20,2807.16 -790.81,2562.44"/>
-                <g class="nad-edge-infos" transform="translate(-842.54,2775.58)">
+                <polyline class="nad-edge-path nad-stretchable" points="-850.20,2807.16 -790.81,2562.44"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-842.54,2775.58)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(13.64)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6423,8 +6459,8 @@
                 </g>
             </g>
             <g id="367.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-731.42,2317.72 -790.81,2562.44"/>
-                <g class="nad-edge-infos" transform="translate(-739.09,2349.31)">
+                <polyline class="nad-edge-path nad-stretchable" points="-731.42,2317.72 -790.81,2562.44"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-739.09,2349.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-166.36)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6445,8 +6481,8 @@
         <g id="368">
             <desc>L62-67-1</desc>
             <g id="368.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-829.30,2831.40 -671.08,2817.05"/>
-                <g class="nad-edge-infos" transform="translate(-796.94,2828.46)">
+                <polyline class="nad-edge-path nad-stretchable" points="-829.30,2831.40 -671.08,2817.05"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-796.94,2828.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(84.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6464,8 +6500,8 @@
                 </g>
             </g>
             <g id="368.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-512.85,2802.69 -671.08,2817.05"/>
-                <g class="nad-edge-infos" transform="translate(-545.22,2805.63)">
+                <polyline class="nad-edge-path nad-stretchable" points="-512.85,2802.69 -671.08,2817.05"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-545.22,2805.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-95.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6486,8 +6522,8 @@
         <g id="369">
             <desc>L63-64-1</desc>
             <g id="369.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1500.32,2122.66 -1372.89,2031.70"/>
-                <g class="nad-edge-infos" transform="translate(-1473.87,2103.78)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1500.32,2122.66 -1372.89,2031.70"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1473.87,2103.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(54.48)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6505,8 +6541,8 @@
                 </g>
             </g>
             <g id="369.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1245.45,1940.74 -1372.89,2031.70"/>
-                <g class="nad-edge-infos" transform="translate(-1271.91,1959.63)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1245.45,1940.74 -1372.89,2031.70"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1271.91,1959.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-125.52)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6527,8 +6563,8 @@
         <g id="370">
             <desc>L64-65-1</desc>
             <g id="370.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1208.60,1901.38 -1030.54,1613.62"/>
-                <g class="nad-edge-infos" transform="translate(-1191.50,1873.75)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1208.60,1901.38 -1030.54,1613.62"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1191.50,1873.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(31.75)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6546,8 +6582,8 @@
                 </g>
             </g>
             <g id="370.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-852.48,1325.86 -1030.54,1613.62"/>
-                <g class="nad-edge-infos" transform="translate(-869.59,1353.50)">
+                <polyline class="nad-edge-path nad-stretchable" points="-852.48,1325.86 -1030.54,1613.62"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-869.59,1353.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-148.25)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6568,8 +6604,8 @@
         <g id="371">
             <desc>L65-68-1</desc>
             <g id="371.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-819.91,1281.77 -635.42,1070.82"/>
-                <g class="nad-edge-infos" transform="translate(-798.52,1257.31)">
+                <polyline class="nad-edge-path nad-stretchable" points="-819.91,1281.77 -635.42,1070.82"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-798.52,1257.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(41.17)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6587,8 +6623,8 @@
                 </g>
             </g>
             <g id="371.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-450.93,859.86 -635.42,1070.82"/>
-                <g class="nad-edge-infos" transform="translate(-472.32,884.32)">
+                <polyline class="nad-edge-path nad-stretchable" points="-450.93,859.86 -635.42,1070.82"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-472.32,884.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-138.83)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6609,8 +6645,8 @@
         <g id="372">
             <desc>T65-66-1</desc>
             <g id="372.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-834.89,1329.80 -784.89,1766.93"/>
-                <g class="nad-edge-infos" transform="translate(-831.20,1362.08)">
+                <polyline class="nad-edge-path nad-stretchable" points="-834.89,1329.80 -784.89,1766.93"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-831.20,1362.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(173.47)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6626,11 +6662,10 @@
                         <text transform="rotate(83.47)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-782.61" cy="1786.80" r="20.00"/>
             </g>
             <g id="372.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-728.06,2263.68 -778.07,1826.54"/>
-                <g class="nad-edge-infos" transform="translate(-731.76,2231.39)">
+                <polyline class="nad-edge-path nad-stretchable" points="-728.06,2263.68 -778.07,1826.54"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-731.76,2231.39)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-6.53)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6646,14 +6681,21 @@
                         <text transform="rotate(-276.53)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-780.34" cy="1806.67" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180-line">
+                    <circle class="nad-winding" cx="-782.61" cy="1786.80" r="20.00"/>
+                </g>
+                <g class="nad-vl120to180-line">
+                    <circle class="nad-winding" cx="-780.34" cy="1806.67" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="373">
             <desc>L66-67-1</desc>
             <g id="373.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-713.23,2315.89 -605.20,2545.61"/>
-                <g class="nad-edge-infos" transform="translate(-699.40,2345.30)">
+                <polyline class="nad-edge-path nad-stretchable" points="-713.23,2315.89 -605.20,2545.61"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-699.40,2345.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(154.81)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6671,8 +6713,8 @@
                 </g>
             </g>
             <g id="373.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-497.17,2775.33 -605.20,2545.61"/>
-                <g class="nad-edge-infos" transform="translate(-511.00,2745.91)">
+                <polyline class="nad-edge-path nad-stretchable" points="-497.17,2775.33 -605.20,2545.61"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-511.00,2745.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-25.19)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6693,8 +6735,8 @@
         <g id="374">
             <desc>L68-81-1</desc>
             <g id="374.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-408.85,825.69 61.29,561.70"/>
-                <g class="nad-edge-infos" transform="translate(-380.51,809.78)">
+                <polyline class="nad-edge-path nad-stretchable" points="-408.85,825.69 61.29,561.70"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-380.51,809.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(60.68)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6712,8 +6754,8 @@
                 </g>
             </g>
             <g id="374.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="531.42,297.70 61.29,561.70"/>
-                <g class="nad-edge-infos" transform="translate(503.08,313.61)">
+                <polyline class="nad-edge-path nad-stretchable" points="531.42,297.70 61.29,561.70"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(503.08,313.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-119.32)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6734,8 +6776,8 @@
         <g id="375">
             <desc>T68-69-1</desc>
             <g id="375.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-460.21,836.69 -555.10,828.14"/>
-                <g class="nad-edge-infos" transform="translate(-492.58,833.77)">
+                <polyline class="nad-edge-path nad-stretchable" points="-460.21,836.69 -555.10,828.14"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-492.58,833.77)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-84.85)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6751,11 +6793,10 @@
                         <text transform="rotate(-354.85)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-575.02" cy="826.35" r="20.00"/>
             </g>
             <g id="375.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-709.74,814.21 -614.86,822.76"/>
-                <g class="nad-edge-infos" transform="translate(-677.37,817.12)">
+                <polyline class="nad-edge-path nad-stretchable" points="-709.74,814.21 -614.86,822.76"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-677.37,817.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(95.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6771,14 +6812,21 @@
                         <text transform="rotate(5.15)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-594.94" cy="824.55" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180-line">
+                    <circle class="nad-winding" cx="-575.02" cy="826.35" r="20.00"/>
+                </g>
+                <g class="nad-vl120to180-line">
+                    <circle class="nad-winding" cx="-594.94" cy="824.55" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="376">
             <desc>L69-70-1</desc>
             <g id="376.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-761.50,799.00 -1153.54,594.19"/>
-                <g class="nad-edge-infos" transform="translate(-790.31,783.95)">
+                <polyline class="nad-edge-path nad-stretchable" points="-761.50,799.00 -1153.54,594.19"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-790.31,783.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-62.42)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6796,8 +6844,8 @@
                 </g>
             </g>
             <g id="376.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1545.57,389.38 -1153.54,594.19"/>
-                <g class="nad-edge-infos" transform="translate(-1516.76,404.43)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1545.57,389.38 -1153.54,594.19"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1516.76,404.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(117.58)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6818,8 +6866,8 @@
         <g id="377">
             <desc>L69-75-1</desc>
             <g id="377.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-744.24,785.17 -805.39,556.79"/>
-                <g class="nad-edge-infos" transform="translate(-752.65,753.78)">
+                <polyline class="nad-edge-path nad-stretchable" points="-744.24,785.17 -805.39,556.79"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-752.65,753.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-14.99)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6837,8 +6885,8 @@
                 </g>
             </g>
             <g id="377.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-866.53,328.40 -805.39,556.79"/>
-                <g class="nad-edge-infos" transform="translate(-858.13,359.80)">
+                <polyline class="nad-edge-path nad-stretchable" points="-866.53,328.40 -805.39,556.79"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-858.13,359.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(165.01)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6859,8 +6907,8 @@
         <g id="378">
             <desc>L69-77-1</desc>
             <g id="378.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-714.67,795.87 -276.97,486.61"/>
-                <g class="nad-edge-infos" transform="translate(-688.13,777.12)">
+                <polyline class="nad-edge-path nad-stretchable" points="-714.67,795.87 -276.97,486.61"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-688.13,777.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(54.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6878,8 +6926,8 @@
                 </g>
             </g>
             <g id="378.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="160.74,177.35 -276.97,486.61"/>
-                <g class="nad-edge-infos" transform="translate(134.19,196.11)">
+                <polyline class="nad-edge-path nad-stretchable" points="160.74,177.35 -276.97,486.61"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(134.19,196.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-125.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6900,8 +6948,8 @@
         <g id="379">
             <desc>L70-71-1</desc>
             <g id="379.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1597.37,378.67 -1916.20,402.29"/>
-                <g class="nad-edge-infos" transform="translate(-1629.78,381.07)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1597.37,378.67 -1916.20,402.29"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1629.78,381.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-94.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6919,8 +6967,8 @@
                 </g>
             </g>
             <g id="379.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2235.04,425.91 -1916.20,402.29"/>
-                <g class="nad-edge-infos" transform="translate(-2202.63,423.51)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2235.04,425.91 -1916.20,402.29"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-2202.63,423.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(85.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6941,8 +6989,8 @@
         <g id="380">
             <desc>L70-74-1</desc>
             <g id="380.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1545.64,363.78 -1430.56,302.87"/>
-                <g class="nad-edge-infos" transform="translate(-1516.91,348.57)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1545.64,363.78 -1430.56,302.87"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1516.91,348.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(62.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6960,8 +7008,8 @@
                 </g>
             </g>
             <g id="380.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1315.49,241.96 -1430.56,302.87"/>
-                <g class="nad-edge-infos" transform="translate(-1344.21,257.16)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1315.49,241.96 -1430.56,302.87"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1344.21,257.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-117.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -6982,8 +7030,8 @@
         <g id="381">
             <desc>L70-75-1</desc>
             <g id="381.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1542.60,373.70 -1221.79,339.24"/>
-                <g class="nad-edge-infos" transform="translate(-1510.29,370.23)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1542.60,373.70 -1221.79,339.24"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1510.29,370.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(83.87)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7001,8 +7049,8 @@
                 </g>
             </g>
             <g id="381.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-900.99,304.78 -1221.79,339.24"/>
-                <g class="nad-edge-infos" transform="translate(-933.30,308.25)">
+                <polyline class="nad-edge-path nad-stretchable" points="-900.99,304.78 -1221.79,339.24"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-933.30,308.25)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-96.13)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7023,8 +7071,8 @@
         <g id="382">
             <desc>L71-72-1</desc>
             <g id="382.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2277.19,404.71 -2371.92,255.25"/>
-                <g class="nad-edge-infos" transform="translate(-2294.59,377.26)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2277.19,404.71 -2371.92,255.25"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-2294.59,377.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-32.37)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7042,8 +7090,8 @@
                 </g>
             </g>
             <g id="382.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2466.64,105.79 -2371.92,255.25"/>
-                <g class="nad-edge-infos" transform="translate(-2449.25,133.24)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2466.64,105.79 -2371.92,255.25"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-2449.25,133.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(147.63)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7064,8 +7112,8 @@
         <g id="383">
             <desc>L71-73-1</desc>
             <g id="383.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2288.78,435.92 -2490.75,497.15"/>
-                <g class="nad-edge-infos" transform="translate(-2319.89,445.35)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2288.78,435.92 -2490.75,497.15"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-2319.89,445.35)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-106.87)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7083,8 +7131,8 @@
                 </g>
             </g>
             <g id="383.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-2692.72,558.38 -2490.75,497.15"/>
-                <g class="nad-edge-infos" transform="translate(-2661.61,548.95)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2692.72,558.38 -2490.75,497.15"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-2661.61,548.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(73.13)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7105,8 +7153,8 @@
         <g id="384">
             <desc>L74-75-1</desc>
             <g id="384.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1264.09,233.81 -1082.41,265.46"/>
-                <g class="nad-edge-infos" transform="translate(-1232.07,239.39)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1264.09,233.81 -1082.41,265.46"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1232.07,239.39)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(99.88)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7124,8 +7172,8 @@
                 </g>
             </g>
             <g id="384.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-900.73,297.12 -1082.41,265.46"/>
-                <g class="nad-edge-infos" transform="translate(-932.75,291.54)">
+                <polyline class="nad-edge-path nad-stretchable" points="-900.73,297.12 -1082.41,265.46"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-932.75,291.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-80.12)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7146,8 +7194,8 @@
         <g id="385">
             <desc>L75-77-1</desc>
             <g id="385.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-846.38,298.22 -345.22,231.66"/>
-                <g class="nad-edge-infos" transform="translate(-814.17,293.94)">
+                <polyline class="nad-edge-path nad-stretchable" points="-846.38,298.22 -345.22,231.66"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-814.17,293.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(82.44)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7165,8 +7213,8 @@
                 </g>
             </g>
             <g id="385.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="155.94,165.11 -345.22,231.66"/>
-                <g class="nad-edge-infos" transform="translate(123.72,169.38)">
+                <polyline class="nad-edge-path nad-stretchable" points="155.94,165.11 -345.22,231.66"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(123.72,169.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-97.56)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7187,8 +7235,8 @@
         <g id="386">
             <desc>L76-77-1</desc>
             <g id="386.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-184.73,-77.42 -12.30,34.54"/>
-                <g class="nad-edge-infos" transform="translate(-157.47,-59.72)">
+                <polyline class="nad-edge-path nad-stretchable" points="-184.73,-77.42 -12.30,34.54"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-157.47,-59.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(123.00)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7206,8 +7254,8 @@
                 </g>
             </g>
             <g id="386.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="160.13,146.51 -12.30,34.54"/>
-                <g class="nad-edge-infos" transform="translate(132.88,128.81)">
+                <polyline class="nad-edge-path nad-stretchable" points="160.13,146.51 -12.30,34.54"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(132.88,128.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-57.00)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7228,8 +7276,8 @@
         <g id="387">
             <desc>L77-78-1</desc>
             <g id="387.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="201.49,140.95 374.58,-53.27"/>
-                <g class="nad-edge-infos" transform="translate(223.12,116.69)">
+                <polyline class="nad-edge-path nad-stretchable" points="201.49,140.95 374.58,-53.27"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(223.12,116.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(41.71)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7247,8 +7295,8 @@
                 </g>
             </g>
             <g id="387.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="547.67,-247.49 374.58,-53.27"/>
-                <g class="nad-edge-infos" transform="translate(526.05,-223.23)">
+                <polyline class="nad-edge-path nad-stretchable" points="547.67,-247.49 374.58,-53.27"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(526.05,-223.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-138.29)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7269,8 +7317,8 @@
         <g id="388">
             <desc>L77-80-1</desc>
             <g id="388.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="209.88,168.13 260.83,180.80 660.15,66.09"/>
-                <g class="nad-edge-infos" transform="translate(289.66,172.52)">
+                <polyline class="nad-edge-path nad-stretchable" points="209.88,168.13 260.83,180.80 660.15,66.09"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(289.66,172.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(73.97)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7288,8 +7336,8 @@
                 </g>
             </g>
             <g id="388.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1095.93,-86.40 1059.48,-48.62 660.15,66.09"/>
-                <g class="nad-edge-infos" transform="translate(1030.64,-40.33)">
+                <polyline class="nad-edge-path nad-stretchable" points="1095.93,-86.40 1059.48,-48.62 660.15,66.09"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1030.64,-40.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-106.03)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7310,8 +7358,8 @@
         <g id="389">
             <desc>L77-80-2</desc>
             <g id="389.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="202.29,141.69 238.74,103.91 638.07,-10.80"/>
-                <g class="nad-edge-infos" transform="translate(267.58,95.63)">
+                <polyline class="nad-edge-path nad-stretchable" points="202.29,141.69 238.74,103.91 638.07,-10.80"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(267.58,95.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(73.97)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7329,8 +7377,8 @@
                 </g>
             </g>
             <g id="389.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1088.34,-112.83 1037.39,-125.51 638.07,-10.80"/>
-                <g class="nad-edge-infos" transform="translate(1008.56,-117.22)">
+                <polyline class="nad-edge-path nad-stretchable" points="1088.34,-112.83 1037.39,-125.51 638.07,-10.80"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1008.56,-117.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-106.03)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7351,8 +7399,8 @@
         <g id="390">
             <desc>L77-82-1</desc>
             <g id="390.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="208.08,173.20 684.34,397.39"/>
-                <g class="nad-edge-infos" transform="translate(237.48,187.04)">
+                <polyline class="nad-edge-path nad-stretchable" points="208.08,173.20 684.34,397.39"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(237.48,187.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(115.21)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7370,8 +7418,8 @@
                 </g>
             </g>
             <g id="390.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1160.61,621.58 684.34,397.39"/>
-                <g class="nad-edge-infos" transform="translate(1131.20,607.74)">
+                <polyline class="nad-edge-path nad-stretchable" points="1160.61,621.58 684.34,397.39"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1131.20,607.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-64.79)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7392,8 +7440,8 @@
         <g id="391">
             <desc>L78-79-1</desc>
             <g id="391.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="589.39,-282.44 738.56,-374.30"/>
-                <g class="nad-edge-infos" transform="translate(617.06,-299.48)">
+                <polyline class="nad-edge-path nad-stretchable" points="589.39,-282.44 738.56,-374.30"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(617.06,-299.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(58.38)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7411,8 +7459,8 @@
                 </g>
             </g>
             <g id="391.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="887.73,-466.16 738.56,-374.30"/>
-                <g class="nad-edge-infos" transform="translate(860.05,-449.12)">
+                <polyline class="nad-edge-path nad-stretchable" points="887.73,-466.16 738.56,-374.30"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(860.05,-449.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-121.62)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7433,8 +7481,8 @@
         <g id="392">
             <desc>L79-80-1</desc>
             <g id="392.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="924.30,-456.43 1013.08,-293.38"/>
-                <g class="nad-edge-infos" transform="translate(939.84,-427.89)">
+                <polyline class="nad-edge-path nad-stretchable" points="924.30,-456.43 1013.08,-293.38"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(939.84,-427.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(151.43)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7452,8 +7500,8 @@
                 </g>
             </g>
             <g id="392.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1101.87,-130.34 1013.08,-293.38"/>
-                <g class="nad-edge-infos" transform="translate(1086.33,-158.88)">
+                <polyline class="nad-edge-path nad-stretchable" points="1101.87,-130.34 1013.08,-293.38"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1086.33,-158.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-28.57)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7474,8 +7522,8 @@
         <g id="393">
             <desc>L8-9-1</desc>
             <g id="393.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-837.05,-2096.13 -966.57,-2309.32"/>
-                <g class="nad-edge-infos" transform="translate(-853.93,-2123.91)">
+                <polyline class="nad-edge-path nad-stretchable" points="-837.05,-2096.13 -966.57,-2309.32"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-853.93,-2123.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-31.28)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7493,8 +7541,8 @@
                 </g>
             </g>
             <g id="393.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-1096.08,-2522.51 -966.57,-2309.32"/>
-                <g class="nad-edge-infos" transform="translate(-1079.21,-2494.74)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1096.08,-2522.51 -966.57,-2309.32"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1079.21,-2494.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(148.72)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7515,8 +7563,8 @@
         <g id="394">
             <desc>L80-96-1</desc>
             <g id="394.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1136.03,-88.44 1346.70,89.54"/>
-                <g class="nad-edge-infos" transform="translate(1160.85,-67.47)">
+                <polyline class="nad-edge-path nad-stretchable" points="1136.03,-88.44 1346.70,89.54"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1160.85,-67.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(130.19)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7534,8 +7582,8 @@
                 </g>
             </g>
             <g id="394.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1557.36,267.53 1346.70,89.54"/>
-                <g class="nad-edge-infos" transform="translate(1532.54,246.56)">
+                <polyline class="nad-edge-path nad-stretchable" points="1557.36,267.53 1346.70,89.54"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1532.54,246.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-49.81)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7556,8 +7604,8 @@
         <g id="395">
             <desc>L80-97-1</desc>
             <g id="395.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1140.52,-95.90 1260.76,-47.38"/>
-                <g class="nad-edge-infos" transform="translate(1170.66,-83.74)">
+                <polyline class="nad-edge-path nad-stretchable" points="1140.52,-95.90 1260.76,-47.38"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1170.66,-83.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(111.98)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7575,8 +7623,8 @@
                 </g>
             </g>
             <g id="395.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1380.99,1.15 1260.76,-47.38"/>
-                <g class="nad-edge-infos" transform="translate(1350.85,-11.02)">
+                <polyline class="nad-edge-path nad-stretchable" points="1380.99,1.15 1260.76,-47.38"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1350.85,-11.02)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-68.02)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7597,8 +7645,8 @@
         <g id="396">
             <desc>L80-98-1</desc>
             <g id="396.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1135.41,-124.64 1374.81,-341.29"/>
-                <g class="nad-edge-infos" transform="translate(1159.51,-146.45)">
+                <polyline class="nad-edge-path nad-stretchable" points="1135.41,-124.64 1374.81,-341.29"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1159.51,-146.45)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(47.86)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7616,8 +7664,8 @@
                 </g>
             </g>
             <g id="396.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1614.21,-557.93 1374.81,-341.29"/>
-                <g class="nad-edge-infos" transform="translate(1590.11,-536.12)">
+                <polyline class="nad-edge-path nad-stretchable" points="1614.21,-557.93 1374.81,-341.29"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1590.11,-536.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-132.14)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7638,8 +7686,8 @@
         <g id="397">
             <desc>L80-99-1</desc>
             <g id="397.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1141.51,-113.57 1454.91,-200.88"/>
-                <g class="nad-edge-infos" transform="translate(1172.82,-122.29)">
+                <polyline class="nad-edge-path nad-stretchable" points="1141.51,-113.57 1454.91,-200.88"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1172.82,-122.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(74.43)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7657,8 +7705,8 @@
                 </g>
             </g>
             <g id="397.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1768.30,-288.19 1454.91,-200.88"/>
-                <g class="nad-edge-infos" transform="translate(1736.99,-279.47)">
+                <polyline class="nad-edge-path nad-stretchable" points="1768.30,-288.19 1454.91,-200.88"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1736.99,-279.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-105.57)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7679,8 +7727,8 @@
         <g id="398">
             <desc>T81-80-1</desc>
             <g id="398.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="577.95,268.50 810.61,106.19"/>
-                <g class="nad-edge-infos" transform="translate(604.61,249.90)">
+                <polyline class="nad-edge-path nad-stretchable" points="577.95,268.50 810.61,106.19"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(604.61,249.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(55.10)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7696,11 +7744,10 @@
                         <text transform="rotate(-34.90)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="827.01" cy="94.74" r="20.00"/>
             </g>
             <g id="398.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1092.47,-90.46 859.82,71.86"/>
-                <g class="nad-edge-infos" transform="translate(1065.81,-71.86)">
+                <polyline class="nad-edge-path nad-stretchable" points="1092.47,-90.46 859.82,71.86"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1065.81,-71.86)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-124.90)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7716,14 +7763,21 @@
                         <text transform="rotate(-34.90)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="843.41" cy="83.30" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180-line">
+                    <circle class="nad-winding" cx="827.01" cy="94.74" r="20.00"/>
+                </g>
+                <g class="nad-vl120to180-line">
+                    <circle class="nad-winding" cx="843.41" cy="83.30" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="399">
             <desc>L82-83-1</desc>
             <g id="399.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1203.93,653.69 1452.98,929.28"/>
-                <g class="nad-edge-infos" transform="translate(1225.72,677.81)">
+                <polyline class="nad-edge-path nad-stretchable" points="1203.93,653.69 1452.98,929.28"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1225.72,677.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(137.90)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7741,8 +7795,8 @@
                 </g>
             </g>
             <g id="399.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1702.03,1204.86 1452.98,929.28"/>
-                <g class="nad-edge-infos" transform="translate(1680.24,1180.75)">
+                <polyline class="nad-edge-path nad-stretchable" points="1702.03,1204.86 1452.98,929.28"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1680.24,1180.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-42.10)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7763,8 +7817,8 @@
         <g id="400">
             <desc>L82-96-1</desc>
             <g id="400.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1206.07,615.06 1381.93,459.29"/>
-                <g class="nad-edge-infos" transform="translate(1230.40,593.51)">
+                <polyline class="nad-edge-path nad-stretchable" points="1206.07,615.06 1381.93,459.29"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1230.40,593.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.47)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7782,8 +7836,8 @@
                 </g>
             </g>
             <g id="400.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1557.78,303.51 1381.93,459.29"/>
-                <g class="nad-edge-infos" transform="translate(1533.46,325.06)">
+                <polyline class="nad-edge-path nad-stretchable" points="1557.78,303.51 1381.93,459.29"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1533.46,325.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-131.53)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7804,8 +7858,8 @@
         <g id="401">
             <desc>L83-84-1</desc>
             <g id="401.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1731.00,1250.67 1796.56,1408.75"/>
-                <g class="nad-edge-infos" transform="translate(1743.45,1280.69)">
+                <polyline class="nad-edge-path nad-stretchable" points="1731.00,1250.67 1796.56,1408.75"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1743.45,1280.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(157.48)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7823,8 +7877,8 @@
                 </g>
             </g>
             <g id="401.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1862.12,1566.83 1796.56,1408.75"/>
-                <g class="nad-edge-infos" transform="translate(1849.67,1536.81)">
+                <polyline class="nad-edge-path nad-stretchable" points="1862.12,1566.83 1796.56,1408.75"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1849.67,1536.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-22.52)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7845,8 +7899,8 @@
         <g id="402">
             <desc>L83-85-1</desc>
             <g id="402.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1744.82,1238.04 1987.39,1365.32"/>
-                <g class="nad-edge-infos" transform="translate(1773.60,1253.14)">
+                <polyline class="nad-edge-path nad-stretchable" points="1744.82,1238.04 1987.39,1365.32"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1773.60,1253.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(117.69)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7864,8 +7918,8 @@
                 </g>
             </g>
             <g id="402.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2229.97,1492.60 1987.39,1365.32"/>
-                <g class="nad-edge-infos" transform="translate(2201.19,1477.50)">
+                <polyline class="nad-edge-path nad-stretchable" points="2229.97,1492.60 1987.39,1365.32"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(2201.19,1477.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-62.31)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7886,8 +7940,8 @@
         <g id="403">
             <desc>L84-85-1</desc>
             <g id="403.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1899.47,1586.13 2063.49,1548.81"/>
-                <g class="nad-edge-infos" transform="translate(1931.16,1578.92)">
+                <polyline class="nad-edge-path nad-stretchable" points="1899.47,1586.13 2063.49,1548.81"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1931.16,1578.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(77.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7905,8 +7959,8 @@
                 </g>
             </g>
             <g id="403.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2227.50,1511.48 2063.49,1548.81"/>
-                <g class="nad-edge-infos" transform="translate(2195.81,1518.70)">
+                <polyline class="nad-edge-path nad-stretchable" points="2227.50,1511.48 2063.49,1548.81"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(2195.81,1518.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-102.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7927,8 +7981,8 @@
         <g id="404">
             <desc>L85-86-1</desc>
             <g id="404.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2256.46,1532.80 2275.87,1781.32"/>
-                <g class="nad-edge-infos" transform="translate(2258.99,1565.20)">
+                <polyline class="nad-edge-path nad-stretchable" points="2256.46,1532.80 2275.87,1781.32"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2258.99,1565.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(175.53)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7946,8 +8000,8 @@
                 </g>
             </g>
             <g id="404.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2295.29,2029.83 2275.87,1781.32"/>
-                <g class="nad-edge-infos" transform="translate(2292.76,1997.43)">
+                <polyline class="nad-edge-path nad-stretchable" points="2295.29,2029.83 2275.87,1781.32"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(2292.76,1997.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-4.47)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7968,8 +8022,8 @@
         <g id="405">
             <desc>L85-88-1</desc>
             <g id="405.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2281.71,1502.97 2452.80,1487.93"/>
-                <g class="nad-edge-infos" transform="translate(2314.09,1500.13)">
+                <polyline class="nad-edge-path nad-stretchable" points="2281.71,1502.97 2452.80,1487.93"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2314.09,1500.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(84.98)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -7987,8 +8041,8 @@
                 </g>
             </g>
             <g id="405.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2623.88,1472.89 2452.80,1487.93"/>
-                <g class="nad-edge-infos" transform="translate(2591.51,1475.73)">
+                <polyline class="nad-edge-path nad-stretchable" points="2623.88,1472.89 2452.80,1487.93"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(2591.51,1475.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-95.02)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -8009,8 +8063,8 @@
         <g id="406">
             <desc>L85-89-1</desc>
             <g id="406.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2273.30,1485.49 2467.13,1282.33"/>
-                <g class="nad-edge-infos" transform="translate(2295.74,1461.97)">
+                <polyline class="nad-edge-path nad-stretchable" points="2273.30,1485.49 2467.13,1282.33"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2295.74,1461.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(43.65)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -8028,8 +8082,8 @@
                 </g>
             </g>
             <g id="406.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2660.95,1079.17 2467.13,1282.33"/>
-                <g class="nad-edge-infos" transform="translate(2638.52,1102.69)">
+                <polyline class="nad-edge-path nad-stretchable" points="2660.95,1079.17 2467.13,1282.33"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(2638.52,1102.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-136.35)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -8050,8 +8104,8 @@
         <g id="407">
             <desc>L86-87-1</desc>
             <g id="407.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2296.34,2084.73 2289.37,2261.37"/>
-                <g class="nad-edge-infos" transform="translate(2295.06,2117.20)">
+                <polyline class="nad-edge-path nad-stretchable" points="2296.34,2084.73 2289.37,2261.37"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2295.06,2117.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-177.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -8069,8 +8123,8 @@
                 </g>
             </g>
             <g id="407.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="2282.39,2438.00 2289.37,2261.37"/>
-                <g class="nad-edge-infos" transform="translate(2283.67,2405.53)">
+                <polyline class="nad-edge-path nad-stretchable" points="2282.39,2438.00 2289.37,2261.37"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(2283.67,2405.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(2.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -8091,8 +8145,8 @@
         <g id="408">
             <desc>L88-89-1</desc>
             <g id="408.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2653.19,1443.05 2665.61,1264.88"/>
-                <g class="nad-edge-infos" transform="translate(2655.45,1410.62)">
+                <polyline class="nad-edge-path nad-stretchable" points="2653.19,1443.05 2665.61,1264.88"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2655.45,1410.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(3.99)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -8110,8 +8164,8 @@
                 </g>
             </g>
             <g id="408.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2678.02,1086.71 2665.61,1264.88"/>
-                <g class="nad-edge-infos" transform="translate(2675.76,1119.13)">
+                <polyline class="nad-edge-path nad-stretchable" points="2678.02,1086.71 2665.61,1264.88"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(2675.76,1119.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-176.01)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -8132,8 +8186,8 @@
         <g id="409">
             <desc>L89-90-1</desc>
             <g id="409.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2705.56,1069.27 2754.47,1088.34 2905.61,1065.22"/>
-                <g class="nad-edge-infos" transform="translate(2784.13,1083.80)">
+                <polyline class="nad-edge-path nad-stretchable" points="2705.56,1069.27 2754.47,1088.34 2905.61,1065.22"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2784.13,1083.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(81.30)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -8151,8 +8205,8 @@
                 </g>
             </g>
             <g id="409.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="3097.72,1009.28 3056.75,1042.10 2905.61,1065.22"/>
-                <g class="nad-edge-infos" transform="translate(3027.09,1046.64)">
+                <polyline class="nad-edge-path nad-stretchable" points="3097.72,1009.28 3056.75,1042.10 2905.61,1065.22"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(3027.09,1046.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-98.70)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -8173,8 +8227,8 @@
         <g id="410">
             <desc>L89-90-2</desc>
             <g id="410.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2701.40,1042.08 2742.37,1009.26 2893.51,986.14"/>
-                <g class="nad-edge-infos" transform="translate(2772.03,1004.72)">
+                <polyline class="nad-edge-path nad-stretchable" points="2701.40,1042.08 2742.37,1009.26 2893.51,986.14"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2772.03,1004.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(81.30)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -8192,8 +8246,8 @@
                 </g>
             </g>
             <g id="410.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="3093.56,982.10 3044.65,963.02 2893.51,986.14"/>
-                <g class="nad-edge-infos" transform="translate(3015.00,967.56)">
+                <polyline class="nad-edge-path nad-stretchable" points="3093.56,982.10 3044.65,963.02 2893.51,986.14"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(3015.00,967.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-98.70)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -8214,8 +8268,8 @@
         <g id="411">
             <desc>L89-92-1</desc>
             <g id="411.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2694.08,1035.69 2721.07,990.66 2726.28,674.31"/>
-                <g class="nad-edge-infos" transform="translate(2721.57,960.67)">
+                <polyline class="nad-edge-path nad-stretchable" points="2694.08,1035.69 2721.07,990.66 2726.28,674.31"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2721.57,960.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(0.94)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -8233,8 +8287,8 @@
                 </g>
             </g>
             <g id="411.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2705.99,312.07 2731.49,357.96 2726.28,674.31"/>
-                <g class="nad-edge-infos" transform="translate(2731.00,387.96)">
+                <polyline class="nad-edge-path nad-stretchable" points="2705.99,312.07 2731.49,357.96 2726.28,674.31"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(2731.00,387.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-179.06)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -8255,8 +8309,8 @@
         <g id="412">
             <desc>L89-92-2</desc>
             <g id="412.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2666.58,1035.24 2641.08,989.34 2646.29,672.99"/>
-                <g class="nad-edge-infos" transform="translate(2641.58,959.35)">
+                <polyline class="nad-edge-path nad-stretchable" points="2666.58,1035.24 2641.08,989.34 2646.29,672.99"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2641.58,959.35)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(0.94)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -8274,8 +8328,8 @@
                 </g>
             </g>
             <g id="412.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2678.49,311.61 2651.50,356.64 2646.29,672.99"/>
-                <g class="nad-edge-infos" transform="translate(2651.01,386.64)">
+                <polyline class="nad-edge-path nad-stretchable" points="2678.49,311.61 2651.50,356.64 2646.29,672.99"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(2651.01,386.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-179.06)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -8296,8 +8350,8 @@
         <g id="413">
             <desc>L90-91-1</desc>
             <g id="413.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="3118.70,964.59 3115.71,794.70"/>
-                <g class="nad-edge-infos" transform="translate(3118.13,932.10)">
+                <polyline class="nad-edge-path nad-stretchable" points="3118.70,964.59 3115.71,794.70"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(3118.13,932.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-1.01)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -8315,8 +8369,8 @@
                 </g>
             </g>
             <g id="413.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="3112.73,624.80 3115.71,794.70"/>
-                <g class="nad-edge-infos" transform="translate(3113.30,657.30)">
+                <polyline class="nad-edge-path nad-stretchable" points="3112.73,624.80 3115.71,794.70"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(3113.30,657.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(178.99)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -8337,8 +8391,8 @@
         <g id="414">
             <desc>L91-92-1</desc>
             <g id="414.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="3090.11,580.99 2902.44,442.67"/>
-                <g class="nad-edge-infos" transform="translate(3063.94,561.71)">
+                <polyline class="nad-edge-path nad-stretchable" points="3090.11,580.99 2902.44,442.67"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(3063.94,561.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-53.61)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -8356,8 +8410,8 @@
                 </g>
             </g>
             <g id="414.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2714.77,304.35 2902.44,442.67"/>
-                <g class="nad-edge-infos" transform="translate(2740.93,323.63)">
+                <polyline class="nad-edge-path nad-stretchable" points="2714.77,304.35 2902.44,442.67"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(2740.93,323.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(126.39)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -8378,8 +8432,8 @@
         <g id="415">
             <desc>L92-93-1</desc>
             <g id="415.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2669.60,303.05 2558.90,375.26"/>
-                <g class="nad-edge-infos" transform="translate(2642.38,320.81)">
+                <polyline class="nad-edge-path nad-stretchable" points="2669.60,303.05 2558.90,375.26"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2642.38,320.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-123.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -8397,8 +8451,8 @@
                 </g>
             </g>
             <g id="415.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2448.20,447.47 2558.90,375.26"/>
-                <g class="nad-edge-infos" transform="translate(2475.42,429.71)">
+                <polyline class="nad-edge-path nad-stretchable" points="2448.20,447.47 2558.90,375.26"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(2475.42,429.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(56.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -8419,8 +8473,8 @@
         <g id="416">
             <desc>L92-94-1</desc>
             <g id="416.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2666.24,280.32 2445.38,215.80"/>
-                <g class="nad-edge-infos" transform="translate(2635.04,271.20)">
+                <polyline class="nad-edge-path nad-stretchable" points="2666.24,280.32 2445.38,215.80"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2635.04,271.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-73.72)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -8438,8 +8492,8 @@
                 </g>
             </g>
             <g id="416.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2224.52,151.28 2445.38,215.80"/>
-                <g class="nad-edge-infos" transform="translate(2255.71,160.40)">
+                <polyline class="nad-edge-path nad-stretchable" points="2224.52,151.28 2445.38,215.80"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(2255.71,160.40)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(106.28)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -8460,8 +8514,8 @@
         <g id="417">
             <desc>L93-94-1</desc>
             <g id="417.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2409.21,440.09 2311.64,303.03"/>
-                <g class="nad-edge-infos" transform="translate(2390.36,413.61)">
+                <polyline class="nad-edge-path nad-stretchable" points="2409.21,440.09 2311.64,303.03"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2390.36,413.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-35.45)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -8479,8 +8533,8 @@
                 </g>
             </g>
             <g id="417.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2214.07,165.97 2311.64,303.03"/>
-                <g class="nad-edge-infos" transform="translate(2232.92,192.45)">
+                <polyline class="nad-edge-path nad-stretchable" points="2214.07,165.97 2311.64,303.03"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(2232.92,192.45)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(144.55)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -8501,8 +8555,8 @@
         <g id="418">
             <desc>L94-95-1</desc>
             <g id="418.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2179.07,163.40 2061.10,286.17"/>
-                <g class="nad-edge-infos" transform="translate(2156.55,186.84)">
+                <polyline class="nad-edge-path nad-stretchable" points="2179.07,163.40 2061.10,286.17"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2156.55,186.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-136.14)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -8520,8 +8574,8 @@
                 </g>
             </g>
             <g id="418.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1943.12,408.94 2061.10,286.17"/>
-                <g class="nad-edge-infos" transform="translate(1965.64,385.51)">
+                <polyline class="nad-edge-path nad-stretchable" points="1943.12,408.94 2061.10,286.17"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1965.64,385.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(43.86)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -8542,8 +8596,8 @@
         <g id="419">
             <desc>L94-96-1</desc>
             <g id="419.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="2171.31,149.70 1888.25,214.43"/>
-                <g class="nad-edge-infos" transform="translate(2139.63,156.95)">
+                <polyline class="nad-edge-path nad-stretchable" points="2171.31,149.70 1888.25,214.43"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2139.63,156.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-102.88)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -8561,8 +8615,8 @@
                 </g>
             </g>
             <g id="419.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1605.18,279.15 1888.25,214.43"/>
-                <g class="nad-edge-infos" transform="translate(1636.86,271.91)">
+                <polyline class="nad-edge-path nad-stretchable" points="1605.18,279.15 1888.25,214.43"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1636.86,271.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(77.12)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -8583,8 +8637,8 @@
         <g id="420">
             <desc>L95-96-1</desc>
             <g id="420.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1898.67,418.23 1751.22,357.02"/>
-                <g class="nad-edge-infos" transform="translate(1868.65,405.77)">
+                <polyline class="nad-edge-path nad-stretchable" points="1898.67,418.23 1751.22,357.02"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1868.65,405.77)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-67.46)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -8602,8 +8656,8 @@
                 </g>
             </g>
             <g id="420.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1603.77,295.82 1751.22,357.02"/>
-                <g class="nad-edge-infos" transform="translate(1633.79,308.28)">
+                <polyline class="nad-edge-path nad-stretchable" points="1603.77,295.82 1751.22,357.02"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1633.79,308.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(112.54)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -8624,8 +8678,8 @@
         <g id="421">
             <desc>L96-97-1</desc>
             <g id="421.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1563.75,261.99 1492.43,148.36"/>
-                <g class="nad-edge-infos" transform="translate(1546.47,234.46)">
+                <polyline class="nad-edge-path nad-stretchable" points="1563.75,261.99 1492.43,148.36"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1546.47,234.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-32.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -8643,8 +8697,8 @@
                 </g>
             </g>
             <g id="421.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1421.11,34.73 1492.43,148.36"/>
-                <g class="nad-edge-infos" transform="translate(1438.39,62.26)">
+                <polyline class="nad-edge-path nad-stretchable" points="1421.11,34.73 1492.43,148.36"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1438.39,62.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(147.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/IEEE_118_bus_partial.svg
+++ b/network-area-diagram/src/test/resources/IEEE_118_bus_partial.svg
@@ -1678,12 +1678,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180-line">
-                    <circle class="nad-winding" cx="-127.26" cy="-1129.70" r="20.00"/>
-                </g>
-                <g class="nad-vl120to180-line">
-                    <circle class="nad-winding" cx="-120.61" cy="-1110.84" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180-line nad-winding" cx="-127.26" cy="-1129.70" r="20.00"/>
+                <circle class="nad-vl120to180-line nad-winding" cx="-120.61" cy="-1110.84" r="20.00"/>
             </g>
         </g>
         <g id="84">
@@ -1794,12 +1790,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180-line">
-                    <circle class="nad-winding" cx="-609.22" cy="-1213.64" r="20.00"/>
-                </g>
-                <g class="nad-vl120to180-line">
-                    <circle class="nad-winding" cx="-609.26" cy="-1193.64" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180-line nad-winding" cx="-609.22" cy="-1213.64" r="20.00"/>
+                <circle class="nad-vl120to180-line nad-winding" cx="-609.26" cy="-1193.64" r="20.00"/>
             </g>
         </g>
         <g id="92">
@@ -1891,12 +1883,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180-line">
-                    <circle class="nad-winding" cx="-1079.94" cy="313.75" r="20.00"/>
-                </g>
-                <g class="nad-vl120to180-line">
-                    <circle class="nad-winding" cx="-1059.94" cy="313.48" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180-line nad-winding" cx="-1079.94" cy="313.75" r="20.00"/>
+                <circle class="nad-vl120to180-line nad-winding" cx="-1059.94" cy="313.48" r="20.00"/>
             </g>
         </g>
         <g id="102">
@@ -1988,12 +1976,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180-line">
-                    <circle class="nad-winding" cx="-13.84" cy="1575.97" r="20.00"/>
-                </g>
-                <g class="nad-vl120to180-line">
-                    <circle class="nad-winding" cx="-18.13" cy="1556.44" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180-line nad-winding" cx="-13.84" cy="1575.97" r="20.00"/>
+                <circle class="nad-vl120to180-line nad-winding" cx="-18.13" cy="1556.44" r="20.00"/>
             </g>
         </g>
     </g>

--- a/network-area-diagram/src/test/resources/IEEE_118_bus_partial.svg
+++ b/network-area-diagram/src/test/resources/IEEE_118_bus_partial.svg
@@ -319,8 +319,8 @@
         <g id="42">
             <desc>L40-42-1</desc>
             <g id="42.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-385.29,177.56 -388.07,40.20"/>
-                <g class="nad-edge-infos" transform="translate(-385.94,145.07)">
+                <polyline class="nad-edge-path nad-stretchable" points="-385.29,177.56 -388.07,40.20"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-385.94,145.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-1.16)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -341,8 +341,8 @@
         <g id="45">
             <desc>L41-42-1</desc>
             <g id="45.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-409.97,194.13 -644.22,92.70"/>
-                <g class="nad-edge-infos" transform="translate(-439.79,181.21)">
+                <polyline class="nad-edge-path nad-stretchable" points="-409.97,194.13 -644.22,92.70"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-439.79,181.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-66.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -363,8 +363,8 @@
         <g id="46">
             <desc>L42-49-1</desc>
             <g id="46.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-367.20,226.24 -333.73,266.69 -135.64,340.34"/>
-                <g class="nad-edge-infos" transform="translate(-305.61,277.15)">
+                <polyline class="nad-edge-path nad-stretchable" points="-367.20,226.24 -333.73,266.69 -135.64,340.34"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-305.61,277.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(110.39)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -382,8 +382,8 @@
                 </g>
             </g>
             <g id="46.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="114.21,405.23 62.45,413.99 -135.64,340.34"/>
-                <g class="nad-edge-infos" transform="translate(34.33,403.53)">
+                <polyline class="nad-edge-path nad-stretchable" points="114.21,405.23 62.45,413.99 -135.64,340.34"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(34.33,403.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-69.61)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -404,8 +404,8 @@
         <g id="47">
             <desc>L42-49-2</desc>
             <g id="47.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-357.61,200.47 -305.85,191.71 -107.76,265.35"/>
-                <g class="nad-edge-infos" transform="translate(-277.73,202.16)">
+                <polyline class="nad-edge-path nad-stretchable" points="-357.61,200.47 -305.85,191.71 -107.76,265.35"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-277.73,202.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(110.39)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -423,8 +423,8 @@
                 </g>
             </g>
             <g id="47.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="123.80,379.45 90.33,339.00 -107.76,265.35"/>
-                <g class="nad-edge-infos" transform="translate(62.21,328.55)">
+                <polyline class="nad-edge-path nad-stretchable" points="123.80,379.45 90.33,339.00 -107.76,265.35"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(62.21,328.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-69.61)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -445,8 +445,8 @@
         <g id="50">
             <desc>L44-45-1</desc>
             <g id="50.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="421.53,544.11 468.94,399.99"/>
-                <g class="nad-edge-infos" transform="translate(431.69,513.23)">
+                <polyline class="nad-edge-path nad-stretchable" points="421.53,544.11 468.94,399.99"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(431.69,513.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(18.21)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -467,8 +467,8 @@
         <g id="53">
             <desc>L45-46-1</desc>
             <g id="53.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="407.77,597.24 376.45,760.94"/>
-                <g class="nad-edge-infos" transform="translate(401.67,629.16)">
+                <polyline class="nad-edge-path nad-stretchable" points="407.77,597.24 376.45,760.94"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(401.67,629.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-169.17)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -489,8 +489,8 @@
         <g id="54">
             <desc>L45-49-1</desc>
             <g id="54.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="389.62,555.66 277.13,485.43"/>
-                <g class="nad-edge-infos" transform="translate(362.05,538.45)">
+                <polyline class="nad-edge-path nad-stretchable" points="389.62,555.66 277.13,485.43"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(362.05,538.45)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-58.02)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -508,8 +508,8 @@
                 </g>
             </g>
             <g id="54.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="164.65,415.20 277.13,485.43"/>
-                <g class="nad-edge-infos" transform="translate(192.22,432.42)">
+                <polyline class="nad-edge-path nad-stretchable" points="164.65,415.20 277.13,485.43"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(192.22,432.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(121.98)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -530,8 +530,8 @@
         <g id="55">
             <desc>L46-47-1</desc>
             <g id="55.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="4.12,895.75 158.48,921.45"/>
-                <g class="nad-edge-infos" transform="translate(36.17,901.09)">
+                <polyline class="nad-edge-path nad-stretchable" points="4.12,895.75 158.48,921.45"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(36.17,901.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(99.45)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -552,8 +552,8 @@
         <g id="56">
             <desc>L47-49-1</desc>
             <g id="56.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-14.28,865.16 59.16,645.94"/>
-                <g class="nad-edge-infos" transform="translate(-3.95,834.34)">
+                <polyline class="nad-edge-path nad-stretchable" points="-14.28,865.16 59.16,645.94"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-3.95,834.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(18.52)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -571,8 +571,8 @@
                 </g>
             </g>
             <g id="56.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="132.59,426.72 59.16,645.94"/>
-                <g class="nad-edge-infos" transform="translate(122.27,457.53)">
+                <polyline class="nad-edge-path nad-stretchable" points="132.59,426.72 59.16,645.94"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(122.27,457.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-161.48)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -593,8 +593,8 @@
         <g id="57">
             <desc>L47-69-1</desc>
             <g id="57.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-26.14,918.56 -47.18,1102.56"/>
-                <g class="nad-edge-infos" transform="translate(-29.83,950.85)">
+                <polyline class="nad-edge-path nad-stretchable" points="-26.14,918.56 -47.18,1102.56"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-29.83,950.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-173.47)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -612,8 +612,8 @@
                 </g>
             </g>
             <g id="57.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-68.23,1286.57 -47.18,1102.56"/>
-                <g class="nad-edge-infos" transform="translate(-64.54,1254.28)">
+                <polyline class="nad-edge-path nad-stretchable" points="-68.23,1286.57 -47.18,1102.56"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-64.54,1254.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(6.53)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -634,8 +634,8 @@
         <g id="58">
             <desc>L46-48-1</desc>
             <g id="58.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="612.80,872.34 489.59,908.16"/>
-                <g class="nad-edge-infos" transform="translate(581.59,881.41)">
+                <polyline class="nad-edge-path nad-stretchable" points="612.80,872.34 489.59,908.16"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(581.59,881.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-106.21)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -656,8 +656,8 @@
         <g id="59">
             <desc>L48-49-1</desc>
             <g id="59.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="619.09,845.91 390.27,632.65"/>
-                <g class="nad-edge-infos" transform="translate(595.31,823.75)">
+                <polyline class="nad-edge-path nad-stretchable" points="619.09,845.91 390.27,632.65"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(595.31,823.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-47.02)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -675,8 +675,8 @@
                 </g>
             </g>
             <g id="59.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="161.44,419.39 390.27,632.65"/>
-                <g class="nad-edge-infos" transform="translate(185.22,441.55)">
+                <polyline class="nad-edge-path nad-stretchable" points="161.44,419.39 390.27,632.65"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(185.22,441.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(132.98)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -697,8 +697,8 @@
         <g id="60">
             <desc>L49-50-1</desc>
             <g id="60.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="168.83,400.36 516.02,396.79"/>
-                <g class="nad-edge-infos" transform="translate(201.32,400.02)">
+                <polyline class="nad-edge-path nad-stretchable" points="168.83,400.36 516.02,396.79"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(201.32,400.02)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(89.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -716,8 +716,8 @@
                 </g>
             </g>
             <g id="60.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="863.22,393.22 516.02,396.79"/>
-                <g class="nad-edge-infos" transform="translate(830.72,393.55)">
+                <polyline class="nad-edge-path nad-stretchable" points="863.22,393.22 516.02,396.79"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(830.72,393.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-90.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -738,8 +738,8 @@
         <g id="61">
             <desc>L49-51-1</desc>
             <g id="61.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="161.36,381.80 459.86,101.18"/>
-                <g class="nad-edge-infos" transform="translate(185.04,359.54)">
+                <polyline class="nad-edge-path nad-stretchable" points="161.36,381.80 459.86,101.18"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(185.04,359.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(46.77)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -757,8 +757,8 @@
                 </g>
             </g>
             <g id="61.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="758.35,-179.45 459.86,101.18"/>
-                <g class="nad-edge-infos" transform="translate(734.67,-157.18)">
+                <polyline class="nad-edge-path nad-stretchable" points="758.35,-179.45 459.86,101.18"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(734.67,-157.18)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-133.23)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -779,8 +779,8 @@
         <g id="62">
             <desc>L49-54-1</desc>
             <g id="62.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="158.77,379.38 192.07,338.79 254.64,-40.45"/>
-                <g class="nad-edge-infos" transform="translate(196.95,309.19)">
+                <polyline class="nad-edge-path nad-stretchable" points="158.77,379.38 192.07,338.79 254.64,-40.45"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(196.95,309.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(9.37)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -798,8 +798,8 @@
                 </g>
             </g>
             <g id="62.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="298.70,-468.82 317.20,-419.69 254.64,-40.45"/>
-                <g class="nad-edge-infos" transform="translate(312.32,-390.09)">
+                <polyline class="nad-edge-path nad-stretchable" points="298.70,-468.82 317.20,-419.69 254.64,-40.45"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(312.32,-390.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-170.63)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -820,8 +820,8 @@
         <g id="63">
             <desc>L49-54-2</desc>
             <g id="63.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="131.64,374.90 113.14,325.77 175.70,-53.47"/>
-                <g class="nad-edge-infos" transform="translate(118.02,296.17)">
+                <polyline class="nad-edge-path nad-stretchable" points="131.64,374.90 113.14,325.77 175.70,-53.47"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(118.02,296.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(9.37)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -839,8 +839,8 @@
                 </g>
             </g>
             <g id="63.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="271.57,-473.30 238.27,-432.71 175.70,-53.47"/>
-                <g class="nad-edge-infos" transform="translate(233.38,-403.11)">
+                <polyline class="nad-edge-path nad-stretchable" points="271.57,-473.30 238.27,-432.71 175.70,-53.47"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(233.38,-403.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-170.63)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -861,8 +861,8 @@
         <g id="64">
             <desc>L49-66-1</desc>
             <g id="64.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="118.94,384.67 76.20,354.19 -325.61,315.52"/>
-                <g class="nad-edge-infos" transform="translate(46.33,351.31)">
+                <polyline class="nad-edge-path nad-stretchable" points="118.94,384.67 76.20,354.19 -325.61,315.52"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(46.33,351.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-84.50)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -880,8 +880,8 @@
                 </g>
             </g>
             <g id="64.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-775.19,298.62 -727.42,276.85 -325.61,315.52"/>
-                <g class="nad-edge-infos" transform="translate(-697.56,279.72)">
+                <polyline class="nad-edge-path nad-stretchable" points="-775.19,298.62 -727.42,276.85 -325.61,315.52"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-697.56,279.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(95.50)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -902,8 +902,8 @@
         <g id="65">
             <desc>L49-66-2</desc>
             <g id="65.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="116.30,412.05 68.53,433.82 -333.28,395.15"/>
-                <g class="nad-edge-infos" transform="translate(38.67,430.95)">
+                <polyline class="nad-edge-path nad-stretchable" points="116.30,412.05 68.53,433.82 -333.28,395.15"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(38.67,430.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-84.50)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -921,8 +921,8 @@
                 </g>
             </g>
             <g id="65.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-777.83,326.00 -735.08,356.48 -333.28,395.15"/>
-                <g class="nad-edge-infos" transform="translate(-705.22,359.36)">
+                <polyline class="nad-edge-path nad-stretchable" points="-777.83,326.00 -735.08,356.48 -333.28,395.15"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-705.22,359.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(95.50)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -943,8 +943,8 @@
         <g id="66">
             <desc>L49-69-1</desc>
             <g id="66.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="135.09,427.42 34.99,857.26"/>
-                <g class="nad-edge-infos" transform="translate(127.72,459.08)">
+                <polyline class="nad-edge-path nad-stretchable" points="135.09,427.42 34.99,857.26"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(127.72,459.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-166.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -962,8 +962,8 @@
                 </g>
             </g>
             <g id="66.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-65.12,1287.11 34.99,857.26"/>
-                <g class="nad-edge-infos" transform="translate(-57.75,1255.45)">
+                <polyline class="nad-edge-path nad-stretchable" points="-65.12,1287.11 34.99,857.26"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-57.75,1255.45)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(13.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -984,8 +984,8 @@
         <g id="67">
             <desc>L50-57-1</desc>
             <g id="67.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="904.12,368.92 994.73,206.57"/>
-                <g class="nad-edge-infos" transform="translate(919.96,340.54)">
+                <polyline class="nad-edge-path nad-stretchable" points="904.12,368.92 994.73,206.57"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(919.96,340.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(29.17)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1003,8 +1003,8 @@
                 </g>
             </g>
             <g id="67.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1085.34,44.21 994.73,206.57"/>
-                <g class="nad-edge-infos" transform="translate(1069.50,72.59)">
+                <polyline class="nad-edge-path nad-stretchable" points="1085.34,44.21 994.73,206.57"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1069.50,72.59)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-150.83)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1025,8 +1025,8 @@
         <g id="68">
             <desc>L51-52-1</desc>
             <g id="68.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="792.26,-222.03 945.28,-483.87"/>
-                <g class="nad-edge-infos" transform="translate(808.66,-250.09)">
+                <polyline class="nad-edge-path nad-stretchable" points="792.26,-222.03 945.28,-483.87"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(808.66,-250.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(30.30)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1044,8 +1044,8 @@
                 </g>
             </g>
             <g id="68.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1098.30,-745.71 945.28,-483.87"/>
-                <g class="nad-edge-infos" transform="translate(1081.90,-717.65)">
+                <polyline class="nad-edge-path nad-stretchable" points="1098.30,-745.71 945.28,-483.87"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1081.90,-717.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-149.70)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1066,8 +1066,8 @@
         <g id="69">
             <desc>L51-58-1</desc>
             <g id="69.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="800.92,-214.05 928.58,-303.35"/>
-                <g class="nad-edge-infos" transform="translate(827.55,-232.67)">
+                <polyline class="nad-edge-path nad-stretchable" points="800.92,-214.05 928.58,-303.35"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(827.55,-232.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(55.03)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1085,8 +1085,8 @@
                 </g>
             </g>
             <g id="69.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1056.24,-392.65 928.58,-303.35"/>
-                <g class="nad-edge-infos" transform="translate(1029.61,-374.02)">
+                <polyline class="nad-edge-path nad-stretchable" points="1056.24,-392.65 928.58,-303.35"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1029.61,-374.02)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-124.97)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1107,8 +1107,8 @@
         <g id="70">
             <desc>L52-53-1</desc>
             <g id="70.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1088.20,-782.92 945.06,-863.37"/>
-                <g class="nad-edge-infos" transform="translate(1059.86,-798.85)">
+                <polyline class="nad-edge-path nad-stretchable" points="1088.20,-782.92 945.06,-863.37"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1059.86,-798.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-60.66)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1126,8 +1126,8 @@
                 </g>
             </g>
             <g id="70.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="801.92,-943.81 945.06,-863.37"/>
-                <g class="nad-edge-infos" transform="translate(830.26,-927.89)">
+                <polyline class="nad-edge-path nad-stretchable" points="801.92,-943.81 945.06,-863.37"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(830.26,-927.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(119.34)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1148,8 +1148,8 @@
         <g id="71">
             <desc>L53-54-1</desc>
             <g id="71.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="757.98,-938.38 533.48,-725.92"/>
-                <g class="nad-edge-infos" transform="translate(734.37,-916.04)">
+                <polyline class="nad-edge-path nad-stretchable" points="757.98,-938.38 533.48,-725.92"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(734.37,-916.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-133.42)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1167,8 +1167,8 @@
                 </g>
             </g>
             <g id="71.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="308.98,-513.46 533.48,-725.92"/>
-                <g class="nad-edge-infos" transform="translate(332.59,-535.80)">
+                <polyline class="nad-edge-path nad-stretchable" points="308.98,-513.46 533.48,-725.92"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(332.59,-535.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(46.58)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1189,8 +1189,8 @@
         <g id="72">
             <desc>L54-55-1</desc>
             <g id="72.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="291.97,-521.90 308.41,-674.00"/>
-                <g class="nad-edge-infos" transform="translate(295.46,-554.21)">
+                <polyline class="nad-edge-path nad-stretchable" points="291.97,-521.90 308.41,-674.00"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(295.46,-554.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(6.17)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1208,8 +1208,8 @@
                 </g>
             </g>
             <g id="72.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="324.86,-826.11 308.41,-674.00"/>
-                <g class="nad-edge-infos" transform="translate(321.36,-793.79)">
+                <polyline class="nad-edge-path nad-stretchable" points="324.86,-826.11 308.41,-674.00"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(321.36,-793.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-173.83)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1230,8 +1230,8 @@
         <g id="73">
             <desc>L54-56-1</desc>
             <g id="73.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="316.19,-498.73 450.52,-519.37"/>
-                <g class="nad-edge-infos" transform="translate(348.31,-503.67)">
+                <polyline class="nad-edge-path nad-stretchable" points="316.19,-498.73 450.52,-519.37"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(348.31,-503.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(81.27)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1249,8 +1249,8 @@
                 </g>
             </g>
             <g id="73.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="584.84,-540.01 450.52,-519.37"/>
-                <g class="nad-edge-infos" transform="translate(552.72,-535.07)">
+                <polyline class="nad-edge-path nad-stretchable" points="584.84,-540.01 450.52,-519.37"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(552.72,-535.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-98.73)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1271,8 +1271,8 @@
         <g id="74">
             <desc>L54-59-1</desc>
             <g id="74.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="271.03,-515.37 126.54,-682.60"/>
-                <g class="nad-edge-infos" transform="translate(249.78,-539.96)">
+                <polyline class="nad-edge-path nad-stretchable" points="271.03,-515.37 126.54,-682.60"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(249.78,-539.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-40.83)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1290,8 +1290,8 @@
                 </g>
             </g>
             <g id="74.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-17.96,-849.83 126.54,-682.60"/>
-                <g class="nad-edge-infos" transform="translate(3.29,-825.24)">
+                <polyline class="nad-edge-path nad-stretchable" points="-17.96,-849.83 126.54,-682.60"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(3.29,-825.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(139.17)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1312,8 +1312,8 @@
         <g id="75">
             <desc>L55-56-1</desc>
             <g id="75.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="346.42,-833.20 469.92,-698.81"/>
-                <g class="nad-edge-infos" transform="translate(368.41,-809.27)">
+                <polyline class="nad-edge-path nad-stretchable" points="346.42,-833.20 469.92,-698.81"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(368.41,-809.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(137.42)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1331,8 +1331,8 @@
                 </g>
             </g>
             <g id="75.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="593.42,-564.43 469.92,-698.81"/>
-                <g class="nad-edge-infos" transform="translate(571.42,-588.36)">
+                <polyline class="nad-edge-path nad-stretchable" points="593.42,-564.43 469.92,-698.81"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(571.42,-588.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-42.58)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1353,8 +1353,8 @@
         <g id="76">
             <desc>L55-59-1</desc>
             <g id="76.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="300.35,-854.75 145.94,-862.04"/>
-                <g class="nad-edge-infos" transform="translate(267.88,-856.28)">
+                <polyline class="nad-edge-path nad-stretchable" points="300.35,-854.75 145.94,-862.04"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(267.88,-856.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-87.29)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1372,8 +1372,8 @@
                 </g>
             </g>
             <g id="76.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-8.47,-869.34 145.94,-862.04"/>
-                <g class="nad-edge-infos" transform="translate(23.99,-867.80)">
+                <polyline class="nad-edge-path nad-stretchable" points="-8.47,-869.34 145.94,-862.04"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(23.99,-867.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(92.71)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1394,8 +1394,8 @@
         <g id="77">
             <desc>L56-57-1</desc>
             <g id="77.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="629.98,-523.36 855.38,-261.99"/>
-                <g class="nad-edge-infos" transform="translate(651.21,-498.74)">
+                <polyline class="nad-edge-path nad-stretchable" points="629.98,-523.36 855.38,-261.99"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(651.21,-498.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(139.23)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1413,8 +1413,8 @@
                 </g>
             </g>
             <g id="77.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1080.78,-0.63 855.38,-261.99"/>
-                <g class="nad-edge-infos" transform="translate(1059.56,-25.24)">
+                <polyline class="nad-edge-path nad-stretchable" points="1080.78,-0.63 855.38,-261.99"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1059.56,-25.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-40.77)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1435,8 +1435,8 @@
         <g id="78">
             <desc>L56-58-1</desc>
             <g id="78.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="638.43,-536.50 845.40,-476.30"/>
-                <g class="nad-edge-infos" transform="translate(669.64,-527.42)">
+                <polyline class="nad-edge-path nad-stretchable" points="638.43,-536.50 845.40,-476.30"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(669.64,-527.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(106.22)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1454,8 +1454,8 @@
                 </g>
             </g>
             <g id="78.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1052.37,-416.09 845.40,-476.30"/>
-                <g class="nad-edge-infos" transform="translate(1021.16,-425.17)">
+                <polyline class="nad-edge-path nad-stretchable" points="1052.37,-416.09 845.40,-476.30"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1021.16,-425.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-73.78)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1476,8 +1476,8 @@
         <g id="79">
             <desc>L56-59-1</desc>
             <g id="79.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="596.94,-567.18 568.15,-611.08 306.04,-743.13"/>
-                <g class="nad-edge-infos" transform="translate(541.36,-624.57)">
+                <polyline class="nad-edge-path nad-stretchable" points="596.94,-567.18 568.15,-611.08 306.04,-743.13"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(541.36,-624.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-63.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1495,8 +1495,8 @@
                 </g>
             </g>
             <g id="79.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-8.48,-872.20 43.93,-875.19 306.04,-743.13"/>
-                <g class="nad-edge-infos" transform="translate(70.72,-861.69)">
+                <polyline class="nad-edge-path nad-stretchable" points="-8.48,-872.20 43.93,-875.19 306.04,-743.13"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(70.72,-861.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(116.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1517,8 +1517,8 @@
         <g id="80">
             <desc>L56-59-2</desc>
             <g id="80.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="584.57,-542.62 532.15,-539.63 270.04,-671.69"/>
-                <g class="nad-edge-infos" transform="translate(505.36,-553.13)">
+                <polyline class="nad-edge-path nad-stretchable" points="584.57,-542.62 532.15,-539.63 270.04,-671.69"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(505.36,-553.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-63.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1536,8 +1536,8 @@
                 </g>
             </g>
             <g id="80.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-20.86,-847.64 7.94,-803.74 270.04,-671.69"/>
-                <g class="nad-edge-infos" transform="translate(34.73,-790.24)">
+                <polyline class="nad-edge-path nad-stretchable" points="-20.86,-847.64 7.94,-803.74 270.04,-671.69"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(34.73,-790.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(116.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1558,8 +1558,8 @@
         <g id="81">
             <desc>L59-60-1</desc>
             <g id="81.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-61.97,-861.77 -257.17,-795.29"/>
-                <g class="nad-edge-infos" transform="translate(-92.74,-851.29)">
+                <polyline class="nad-edge-path nad-stretchable" points="-61.97,-861.77 -257.17,-795.29"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-92.74,-851.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-108.81)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1577,8 +1577,8 @@
                 </g>
             </g>
             <g id="81.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-452.37,-728.81 -257.17,-795.29"/>
-                <g class="nad-edge-infos" transform="translate(-421.61,-739.28)">
+                <polyline class="nad-edge-path nad-stretchable" points="-452.37,-728.81 -257.17,-795.29"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-421.61,-739.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(71.19)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1599,8 +1599,8 @@
         <g id="82">
             <desc>L59-61-1</desc>
             <g id="82.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-62.90,-876.05 -322.82,-928.23"/>
-                <g class="nad-edge-infos" transform="translate(-94.77,-882.45)">
+                <polyline class="nad-edge-path nad-stretchable" points="-62.90,-876.05 -322.82,-928.23"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-94.77,-882.45)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-78.65)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1618,8 +1618,8 @@
                 </g>
             </g>
             <g id="82.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-582.74,-980.40 -322.82,-928.23"/>
-                <g class="nad-edge-infos" transform="translate(-550.87,-974.01)">
+                <polyline class="nad-edge-path nad-stretchable" points="-582.74,-980.40 -322.82,-928.23"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-550.87,-974.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(101.35)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1640,8 +1640,8 @@
         <g id="83">
             <desc>T63-59-1</desc>
             <g id="83.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-202.79,-1343.96 -133.91,-1148.56"/>
-                <g class="nad-edge-infos" transform="translate(-191.98,-1313.31)">
+                <polyline class="nad-edge-path nad-stretchable" points="-202.79,-1343.96 -133.91,-1148.56"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-191.98,-1313.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(160.58)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1657,11 +1657,10 @@
                         <text transform="rotate(70.58)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-127.26" cy="-1129.70" r="20.00"/>
             </g>
             <g id="83.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-45.08,-896.57 -113.96,-1091.97"/>
-                <g class="nad-edge-infos" transform="translate(-55.89,-927.22)">
+                <polyline class="nad-edge-path nad-stretchable" points="-45.08,-896.57 -113.96,-1091.97"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-55.89,-927.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-19.42)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1677,14 +1676,21 @@
                         <text transform="rotate(-289.42)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-120.61" cy="-1110.84" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180-line">
+                    <circle class="nad-winding" cx="-127.26" cy="-1129.70" r="20.00"/>
+                </g>
+                <g class="nad-vl120to180-line">
+                    <circle class="nad-winding" cx="-120.61" cy="-1110.84" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="84">
             <desc>L60-61-1</desc>
             <g id="84.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-490.58,-744.60 -544.05,-852.88"/>
-                <g class="nad-edge-infos" transform="translate(-504.97,-773.74)">
+                <polyline class="nad-edge-path nad-stretchable" points="-490.58,-744.60 -544.05,-852.88"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-504.97,-773.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-26.28)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1702,8 +1708,8 @@
                 </g>
             </g>
             <g id="84.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-597.52,-961.16 -544.05,-852.88"/>
-                <g class="nad-edge-infos" transform="translate(-583.13,-932.02)">
+                <polyline class="nad-edge-path nad-stretchable" points="-597.52,-961.16 -544.05,-852.88"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-583.13,-932.02)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(153.72)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1724,8 +1730,8 @@
         <g id="87">
             <desc>L60-62-1</desc>
             <g id="87.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-500.70,-703.84 -644.79,-599.82"/>
-                <g class="nad-edge-infos" transform="translate(-527.05,-684.82)">
+                <polyline class="nad-edge-path nad-stretchable" points="-500.70,-703.84 -644.79,-599.82"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-527.05,-684.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-125.83)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1746,8 +1752,8 @@
         <g id="88">
             <desc>L61-62-1</desc>
             <g id="88.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-619.87,-960.27 -710.44,-732.76"/>
-                <g class="nad-edge-infos" transform="translate(-631.89,-930.07)">
+                <polyline class="nad-edge-path nad-stretchable" points="-619.87,-960.27 -710.44,-732.76"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-631.89,-930.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-158.29)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1767,12 +1773,10 @@
         </g>
         <g id="91">
             <desc>T64-61-1</desc>
-            <g id="91.1" class="nad-vl120to180-line">
-                <circle class="nad-winding" cx="-609.22" cy="-1213.64" r="20.00"/>
-            </g>
+            <g id="91.1" class="nad-vl120to180-line"></g>
             <g id="91.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-609.64,-1013.32 -609.31,-1173.64"/>
-                <g class="nad-edge-infos" transform="translate(-609.57,-1045.82)">
+                <polyline class="nad-edge-path nad-stretchable" points="-609.64,-1013.32 -609.31,-1173.64"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-609.57,-1045.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(0.12)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1788,14 +1792,21 @@
                         <text transform="rotate(-89.88)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-609.26" cy="-1193.64" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180-line">
+                    <circle class="nad-winding" cx="-609.22" cy="-1213.64" r="20.00"/>
+                </g>
+                <g class="nad-vl120to180-line">
+                    <circle class="nad-winding" cx="-609.26" cy="-1193.64" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="92">
             <desc>L63-64-1</desc>
             <g id="92.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-239.20,-1373.44 -410.36,-1395.68"/>
-                <g class="nad-edge-infos" transform="translate(-271.43,-1377.63)">
+                <polyline class="nad-edge-path nad-stretchable" points="-239.20,-1373.44 -410.36,-1395.68"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-271.43,-1377.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-82.60)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1816,8 +1827,8 @@
         <g id="93">
             <desc>L62-66-1</desc>
             <g id="93.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-800.60,282.53 -805.70,-84.84"/>
-                <g class="nad-edge-infos" transform="translate(-801.05,250.04)">
+                <polyline class="nad-edge-path nad-stretchable" points="-800.60,282.53 -805.70,-84.84"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-801.05,250.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-0.80)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1838,8 +1849,8 @@
         <g id="96">
             <desc>L66-67-1</desc>
             <g id="96.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-816.12,332.47 -940.23,507.63"/>
-                <g class="nad-edge-infos" transform="translate(-834.91,358.99)">
+                <polyline class="nad-edge-path nad-stretchable" points="-816.12,332.47 -940.23,507.63"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-834.91,358.99)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-144.68)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1859,12 +1870,10 @@
         </g>
         <g id="99">
             <desc>T65-66-1</desc>
-            <g id="99.1" class="nad-vl120to180-line">
-                <circle class="nad-winding" cx="-1079.94" cy="313.75" r="20.00"/>
-            </g>
+            <g id="99.1" class="nad-vl120to180-line"></g>
             <g id="99.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-827.71,310.40 -1039.95,313.21"/>
-                <g class="nad-edge-infos" transform="translate(-860.21,310.83)">
+                <polyline class="nad-edge-path nad-stretchable" points="-827.71,310.40 -1039.95,313.21"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-860.21,310.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-90.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1880,14 +1889,21 @@
                         <text transform="rotate(-0.76)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-1059.94" cy="313.48" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180-line">
+                    <circle class="nad-winding" cx="-1079.94" cy="313.75" r="20.00"/>
+                </g>
+                <g class="nad-vl120to180-line">
+                    <circle class="nad-winding" cx="-1059.94" cy="313.48" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="102">
             <desc>L69-70-1</desc>
             <g id="102.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-47.49,1327.55 151.41,1441.36"/>
-                <g class="nad-edge-infos" transform="translate(-19.28,1343.69)">
+                <polyline class="nad-edge-path nad-stretchable" points="-47.49,1327.55 151.41,1441.36"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-19.28,1343.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(119.78)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1908,8 +1924,8 @@
         <g id="105">
             <desc>L69-75-1</desc>
             <g id="105.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-87.47,1336.18 -224.71,1526.05"/>
-                <g class="nad-edge-infos" transform="translate(-106.50,1362.52)">
+                <polyline class="nad-edge-path nad-stretchable" points="-87.47,1336.18 -224.71,1526.05"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-106.50,1362.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-144.14)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1930,8 +1946,8 @@
         <g id="108">
             <desc>L69-77-1</desc>
             <g id="108.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-98.80,1315.68 -305.44,1329.15"/>
-                <g class="nad-edge-infos" transform="translate(-131.23,1317.79)">
+                <polyline class="nad-edge-path nad-stretchable" points="-98.80,1315.68 -305.44,1329.15"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-131.23,1317.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-93.73)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1951,12 +1967,10 @@
         </g>
         <g id="111">
             <desc>T68-69-1</desc>
-            <g id="111.1" class="nad-vl120to180-line">
-                <circle class="nad-winding" cx="-13.84" cy="1575.97" r="20.00"/>
-            </g>
+            <g id="111.1" class="nad-vl120to180-line"></g>
             <g id="111.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-65.46,1340.75 -22.41,1536.90"/>
-                <g class="nad-edge-infos" transform="translate(-58.49,1372.50)">
+                <polyline class="nad-edge-path nad-stretchable" points="-65.46,1340.75 -22.41,1536.90"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-58.49,1372.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(167.62)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1972,7 +1986,14 @@
                         <text transform="rotate(77.62)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-18.13" cy="1556.44" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180-line">
+                    <circle class="nad-winding" cx="-13.84" cy="1575.97" r="20.00"/>
+                </g>
+                <g class="nad-vl120to180-line">
+                    <circle class="nad-winding" cx="-18.13" cy="1556.44" r="20.00"/>
+                </g>
             </g>
         </g>
     </g>

--- a/network-area-diagram/src/test/resources/IEEE_118_bus_partial_non_connected.svg
+++ b/network-area-diagram/src/test/resources/IEEE_118_bus_partial_non_connected.svg
@@ -695,12 +695,8 @@
             </g>
             <g id="51.2" class="nad-vl120to180-line"></g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180-line">
-                    <circle class="nad-winding" cx="-18.31" cy="-385.35" r="20.00"/>
-                </g>
-                <g class="nad-vl120to180-line">
-                    <circle class="nad-winding" cx="-28.38" cy="-368.07" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180-line nad-winding" cx="-18.31" cy="-385.35" r="20.00"/>
+                <circle class="nad-vl120to180-line nad-winding" cx="-28.38" cy="-368.07" r="20.00"/>
             </g>
         </g>
         <g id="52">
@@ -939,12 +935,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180-line">
-                    <circle class="nad-winding" cx="742.71" cy="-307.97" r="20.00"/>
-                </g>
-                <g class="nad-vl120to180-line">
-                    <circle class="nad-winding" cx="760.56" cy="-298.97" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180-line nad-winding" cx="742.71" cy="-307.97" r="20.00"/>
+                <circle class="nad-vl120to180-line nad-winding" cx="760.56" cy="-298.97" r="20.00"/>
             </g>
         </g>
         <g id="73">
@@ -1055,12 +1047,8 @@
             </g>
             <g id="82.2" class="nad-vl120to180-line"></g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180-line">
-                    <circle class="nad-winding" cx="-512.41" cy="-820.05" r="20.00"/>
-                </g>
-                <g class="nad-vl120to180-line">
-                    <circle class="nad-winding" cx="-529.76" cy="-810.11" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180-line nad-winding" cx="-512.41" cy="-820.05" r="20.00"/>
+                <circle class="nad-vl120to180-line nad-winding" cx="-529.76" cy="-810.11" r="20.00"/>
             </g>
         </g>
     </g>

--- a/network-area-diagram/src/test/resources/IEEE_118_bus_partial_non_connected.svg
+++ b/network-area-diagram/src/test/resources/IEEE_118_bus_partial_non_connected.svg
@@ -250,8 +250,8 @@
         <g id="22">
             <desc>L17-113-1</desc>
             <g id="22.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-180.33,380.11 -192.18,171.78"/>
-                <g class="nad-edge-infos" transform="translate(-182.17,347.66)">
+                <polyline class="nad-edge-path nad-stretchable" points="-180.33,380.11 -192.18,171.78"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-182.17,347.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-3.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -272,8 +272,8 @@
         <g id="23">
             <desc>L32-113-1</desc>
             <g id="23.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-386.91,829.44 -288.92,630.83"/>
-                <g class="nad-edge-infos" transform="translate(-372.53,800.29)">
+                <polyline class="nad-edge-path nad-stretchable" points="-386.91,829.44 -288.92,630.83"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-372.53,800.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(26.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -291,8 +291,8 @@
                 </g>
             </g>
             <g id="23.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-190.94,432.22 -288.92,630.83"/>
-                <g class="nad-edge-infos" transform="translate(-205.31,461.37)">
+                <polyline class="nad-edge-path nad-stretchable" points="-190.94,432.22 -288.92,630.83"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-205.31,461.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-153.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -313,8 +313,8 @@
         <g id="24">
             <desc>L32-114-1</desc>
             <g id="24.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-410.18,879.26 -520.47,1129.28"/>
-                <g class="nad-edge-infos" transform="translate(-423.30,909.00)">
+                <polyline class="nad-edge-path nad-stretchable" points="-410.18,879.26 -520.47,1129.28"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-423.30,909.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-156.20)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -332,8 +332,8 @@
                 </g>
             </g>
             <g id="24.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-630.77,1379.31 -520.47,1129.28"/>
-                <g class="nad-edge-infos" transform="translate(-617.65,1349.57)">
+                <polyline class="nad-edge-path nad-stretchable" points="-630.77,1379.31 -520.47,1129.28"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-617.65,1349.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(23.80)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -354,8 +354,8 @@
         <g id="27">
             <desc>L114-115-1</desc>
             <g id="27.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-669.14,1407.94 -816.46,1426.66"/>
-                <g class="nad-edge-infos" transform="translate(-701.39,1412.04)">
+                <polyline class="nad-edge-path nad-stretchable" points="-669.14,1407.94 -816.46,1426.66"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-701.39,1412.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-97.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -376,8 +376,8 @@
         <g id="30">
             <desc>L22-23-1</desc>
             <g id="30.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="107.18,1276.53 191.93,1461.58"/>
-                <g class="nad-edge-infos" transform="translate(120.71,1306.08)">
+                <polyline class="nad-edge-path nad-stretchable" points="107.18,1276.53 191.93,1461.58"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(120.71,1306.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.39)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -398,8 +398,8 @@
         <g id="33">
             <desc>L23-24-1</desc>
             <g id="33.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="123.21,1250.49 317.78,1243.13"/>
-                <g class="nad-edge-infos" transform="translate(155.69,1249.26)">
+                <polyline class="nad-edge-path nad-stretchable" points="123.21,1250.49 317.78,1243.13"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(155.69,1249.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(87.83)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -420,8 +420,8 @@
         <g id="36">
             <desc>L23-25-1</desc>
             <g id="36.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="68.37,1254.27 -92.86,1270.43"/>
-                <g class="nad-edge-infos" transform="translate(36.03,1257.51)">
+                <polyline class="nad-edge-path nad-stretchable" points="68.37,1254.27 -92.86,1270.43"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(36.03,1257.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-95.72)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -442,8 +442,8 @@
         <g id="37">
             <desc>L23-32-1</desc>
             <g id="37.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="74.29,1234.30 -151.68,1052.81"/>
-                <g class="nad-edge-infos" transform="translate(48.95,1213.95)">
+                <polyline class="nad-edge-path nad-stretchable" points="74.29,1234.30 -151.68,1052.81"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(48.95,1213.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-51.23)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -461,8 +461,8 @@
                 </g>
             </g>
             <g id="37.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-377.64,871.32 -151.68,1052.81"/>
-                <g class="nad-edge-infos" transform="translate(-352.30,891.67)">
+                <polyline class="nad-edge-path nad-stretchable" points="-377.64,871.32 -151.68,1052.81"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-352.30,891.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(128.77)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -483,8 +483,8 @@
         <g id="38">
             <desc>L25-27-1</desc>
             <g id="38.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-752.12,1083.54 -529.38,1180.93"/>
-                <g class="nad-edge-infos" transform="translate(-722.34,1096.56)">
+                <polyline class="nad-edge-path nad-stretchable" points="-752.12,1083.54 -529.38,1180.93"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-722.34,1096.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(113.62)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -505,8 +505,8 @@
         <g id="41">
             <desc>L27-28-1</desc>
             <g id="41.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-803.44,1063.94 -995.33,1000.90"/>
-                <g class="nad-edge-infos" transform="translate(-834.31,1053.80)">
+                <polyline class="nad-edge-path nad-stretchable" points="-803.44,1063.94 -995.33,1000.90"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-834.31,1053.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-71.81)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -527,8 +527,8 @@
         <g id="42">
             <desc>L27-32-1</desc>
             <g id="42.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-753.50,1058.77 -588.20,963.31"/>
-                <g class="nad-edge-infos" transform="translate(-725.35,1042.52)">
+                <polyline class="nad-edge-path nad-stretchable" points="-753.50,1058.77 -588.20,963.31"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-725.35,1042.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(59.99)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -546,8 +546,8 @@
                 </g>
             </g>
             <g id="42.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-422.89,867.85 -588.20,963.31"/>
-                <g class="nad-edge-infos" transform="translate(-451.04,884.10)">
+                <polyline class="nad-edge-path nad-stretchable" points="-422.89,867.85 -588.20,963.31"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-451.04,884.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-120.01)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -568,8 +568,8 @@
         <g id="43">
             <desc>L27-115-1</desc>
             <g id="43.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-790.89,1096.44 -884.19,1260.69"/>
-                <g class="nad-edge-infos" transform="translate(-806.94,1124.70)">
+                <polyline class="nad-edge-path nad-stretchable" points="-790.89,1096.44 -884.19,1260.69"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-806.94,1124.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-150.40)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -590,8 +590,8 @@
         <g id="46">
             <desc>L8-30-1</desc>
             <g id="46.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="161.47,-716.79 181.09,-925.10"/>
-                <g class="nad-edge-infos" transform="translate(164.52,-749.14)">
+                <polyline class="nad-edge-path nad-stretchable" points="161.47,-716.79 181.09,-925.10"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(164.52,-749.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(5.38)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -612,8 +612,8 @@
         <g id="49">
             <desc>L26-30-1</desc>
             <g id="49.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="181.89,-704.48 366.84,-825.70"/>
-                <g class="nad-edge-infos" transform="translate(209.07,-722.30)">
+                <polyline class="nad-edge-path nad-stretchable" points="181.89,-704.48 366.84,-825.70"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(209.07,-722.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(56.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -634,8 +634,8 @@
         <g id="50">
             <desc>L30-38-1</desc>
             <g id="50.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="179.59,-671.30 276.28,-586.74"/>
-                <g class="nad-edge-infos" transform="translate(204.05,-649.91)">
+                <polyline class="nad-edge-path nad-stretchable" points="179.59,-671.30 276.28,-586.74"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(204.05,-649.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(131.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -653,8 +653,8 @@
                 </g>
             </g>
             <g id="50.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="372.96,-502.17 276.28,-586.74"/>
-                <g class="nad-edge-infos" transform="translate(348.50,-523.57)">
+                <polyline class="nad-edge-path nad-stretchable" points="372.96,-502.17 276.28,-586.74"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(348.50,-523.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-48.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -675,8 +675,8 @@
         <g id="51">
             <desc>T30-17-1</desc>
             <g id="51.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="145.05,-665.65 -8.24,-402.63"/>
-                <g class="nad-edge-infos" transform="translate(128.68,-637.57)">
+                <polyline class="nad-edge-path nad-stretchable" points="145.05,-665.65 -8.24,-402.63"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(128.68,-637.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-149.77)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -692,17 +692,22 @@
                         <text transform="rotate(-59.77)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-18.31" cy="-385.35" r="20.00"/>
             </g>
-            <g id="51.2" class="nad-vl120to180-line">
-                <circle class="nad-winding" cx="-28.38" cy="-368.07" r="20.00"/>
+            <g id="51.2" class="nad-vl120to180-line"></g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180-line">
+                    <circle class="nad-winding" cx="-18.31" cy="-385.35" r="20.00"/>
+                </g>
+                <g class="nad-vl120to180-line">
+                    <circle class="nad-winding" cx="-28.38" cy="-368.07" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="52">
             <desc>L17-31-1</desc>
             <g id="52.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-588.38,270.66 -407.34,112.38"/>
-                <g class="nad-edge-infos" transform="translate(-563.92,249.27)">
+                <polyline class="nad-edge-path nad-stretchable" points="-588.38,270.66 -407.34,112.38"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-563.92,249.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.84)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -723,8 +728,8 @@
         <g id="55">
             <desc>L29-31-1</desc>
             <g id="55.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-635.05,279.68 -821.49,214.53"/>
-                <g class="nad-edge-infos" transform="translate(-665.73,268.96)">
+                <polyline class="nad-edge-path nad-stretchable" points="-635.05,279.68 -821.49,214.53"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-665.73,268.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-70.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -745,8 +750,8 @@
         <g id="56">
             <desc>L31-32-1</desc>
             <g id="56.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-599.51,314.54 -504.08,571.43"/>
-                <g class="nad-edge-infos" transform="translate(-588.19,345.00)">
+                <polyline class="nad-edge-path nad-stretchable" points="-599.51,314.54 -504.08,571.43"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-588.19,345.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(159.62)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -764,8 +769,8 @@
                 </g>
             </g>
             <g id="56.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-408.66,828.32 -504.08,571.43"/>
-                <g class="nad-edge-infos" transform="translate(-419.97,797.85)">
+                <polyline class="nad-edge-path nad-stretchable" points="-408.66,828.32 -504.08,571.43"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-419.97,797.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-20.38)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -786,8 +791,8 @@
         <g id="59">
             <desc>L35-37-1</desc>
             <g id="59.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1102.38,-96.34 1048.86,100.04"/>
-                <g class="nad-edge-infos" transform="translate(1093.84,-64.99)">
+                <polyline class="nad-edge-path nad-stretchable" points="1102.38,-96.34 1048.86,100.04"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1093.84,-64.99)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-164.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -808,8 +813,8 @@
         <g id="62">
             <desc>L33-37-1</desc>
             <g id="62.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1126.57,-101.23 1267.79,79.00"/>
-                <g class="nad-edge-infos" transform="translate(1146.62,-75.65)">
+                <polyline class="nad-edge-path nad-stretchable" points="1126.57,-101.23 1267.79,79.00"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1146.62,-75.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(141.92)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -830,8 +835,8 @@
         <g id="65">
             <desc>L34-37-1</desc>
             <g id="65.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1082.13,-121.85 940.03,-116.57"/>
-                <g class="nad-edge-infos" transform="translate(1049.65,-120.65)">
+                <polyline class="nad-edge-path nad-stretchable" points="1082.13,-121.85 940.03,-116.57"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1049.65,-120.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-92.13)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -852,8 +857,8 @@
         <g id="68">
             <desc>L37-39-1</desc>
             <g id="68.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1122.48,-147.18 1215.57,-323.09"/>
-                <g class="nad-edge-infos" transform="translate(1137.68,-175.91)">
+                <polyline class="nad-edge-path nad-stretchable" points="1122.48,-147.18 1215.57,-323.09"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1137.68,-175.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(27.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -874,8 +879,8 @@
         <g id="71">
             <desc>L37-40-1</desc>
             <g id="71.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1137.10,-123.74 1350.67,-130.46"/>
-                <g class="nad-edge-infos" transform="translate(1169.58,-124.76)">
+                <polyline class="nad-edge-path nad-stretchable" points="1137.10,-123.74 1350.67,-130.46"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1169.58,-124.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(88.20)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -896,8 +901,8 @@
         <g id="72">
             <desc>T38-37-1</desc>
             <g id="72.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="418.21,-471.68 724.85,-316.98"/>
-                <g class="nad-edge-infos" transform="translate(447.23,-457.04)">
+                <polyline class="nad-edge-path nad-stretchable" points="418.21,-471.68 724.85,-316.98"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(447.23,-457.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(116.77)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -913,11 +918,10 @@
                         <text transform="rotate(26.77)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="742.71" cy="-307.97" r="20.00"/>
             </g>
             <g id="72.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="1085.06,-135.26 778.42,-289.96"/>
-                <g class="nad-edge-infos" transform="translate(1056.04,-149.90)">
+                <polyline class="nad-edge-path nad-stretchable" points="1085.06,-135.26 778.42,-289.96"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1056.04,-149.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-63.23)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -933,14 +937,21 @@
                         <text transform="rotate(-333.23)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="760.56" cy="-298.97" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180-line">
+                    <circle class="nad-winding" cx="742.71" cy="-307.97" r="20.00"/>
+                </g>
+                <g class="nad-vl120to180-line">
+                    <circle class="nad-winding" cx="760.56" cy="-298.97" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="73">
             <desc>L38-65-1</desc>
             <g id="73.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="370.08,-498.21 29.13,-702.76"/>
-                <g class="nad-edge-infos" transform="translate(342.21,-514.93)">
+                <polyline class="nad-edge-path nad-stretchable" points="370.08,-498.21 29.13,-702.76"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(342.21,-514.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-59.04)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -958,8 +969,8 @@
                 </g>
             </g>
             <g id="73.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-311.82,-907.30 29.13,-702.76"/>
-                <g class="nad-edge-infos" transform="translate(-283.95,-890.58)">
+                <polyline class="nad-edge-path nad-stretchable" points="-311.82,-907.30 29.13,-702.76"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-283.95,-890.58)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(120.96)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -980,8 +991,8 @@
         <g id="76">
             <desc>L64-65-1</desc>
             <g id="76.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-336.28,-948.94 -342.74,-1151.32"/>
-                <g class="nad-edge-infos" transform="translate(-337.32,-981.42)">
+                <polyline class="nad-edge-path nad-stretchable" points="-336.28,-948.94 -342.74,-1151.32"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-337.32,-981.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-1.83)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1002,8 +1013,8 @@
         <g id="79">
             <desc>L65-68-1</desc>
             <g id="79.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-359.51,-934.69 -551.17,-1039.95"/>
-                <g class="nad-edge-infos" transform="translate(-388.00,-950.33)">
+                <polyline class="nad-edge-path nad-stretchable" points="-359.51,-934.69 -551.17,-1039.95"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-388.00,-950.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-61.22)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1024,8 +1035,8 @@
         <g id="82">
             <desc>T65-66-1</desc>
             <g id="82.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path" points="-359.27,-907.78 -495.05,-829.99"/>
-                <g class="nad-edge-infos" transform="translate(-387.47,-891.63)">
+                <polyline class="nad-edge-path nad-stretchable" points="-359.27,-907.78 -495.05,-829.99"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-387.47,-891.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-119.81)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1041,10 +1052,15 @@
                         <text transform="rotate(-29.81)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-512.41" cy="-820.05" r="20.00"/>
             </g>
-            <g id="82.2" class="nad-vl120to180-line">
-                <circle class="nad-winding" cx="-529.76" cy="-810.11" r="20.00"/>
+            <g id="82.2" class="nad-vl120to180-line"></g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180-line">
+                    <circle class="nad-winding" cx="-512.41" cy="-820.05" r="20.00"/>
+                </g>
+                <g class="nad-vl120to180-line">
+                    <circle class="nad-winding" cx="-529.76" cy="-810.11" r="20.00"/>
+                </g>
             </g>
         </g>
     </g>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus.svg
@@ -819,12 +819,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180">
-                    <circle class="nad-winding" cx="388.28" cy="351.58" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30">
-                    <circle class="nad-winding" cx="386.73" cy="371.52" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180 nad-winding" cx="388.28" cy="351.58" r="20.00"/>
+                <circle class="nad-vl0to30 nad-winding" cx="386.73" cy="371.52" r="20.00"/>
             </g>
         </g>
         <g id="44">
@@ -868,12 +864,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180">
-                    <circle class="nad-winding" cx="199.35" cy="264.40" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30">
-                    <circle class="nad-winding" cx="182.84" cy="275.68" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180 nad-winding" cx="199.35" cy="264.40" r="20.00"/>
+                <circle class="nad-vl0to30 nad-winding" cx="182.84" cy="275.68" r="20.00"/>
             </g>
         </g>
         <g id="45">
@@ -917,12 +909,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180">
-                    <circle class="nad-winding" cx="-45.49" cy="-363.85" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30">
-                    <circle class="nad-winding" cx="-65.47" cy="-364.87" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180 nad-winding" cx="-45.49" cy="-363.85" r="20.00"/>
+                <circle class="nad-vl0to30 nad-winding" cx="-65.47" cy="-364.87" r="20.00"/>
             </g>
         </g>
         <g id="46">

--- a/network-area-diagram/src/test/resources/IEEE_14_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus.svg
@@ -166,8 +166,8 @@
         <g id="28">
             <desc>L1-2-1</desc>
             <g id="28.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="522.21,-617.54 556.53,-452.92"/>
-                <g class="nad-edge-infos" transform="translate(528.85,-585.72)">
+                <polyline class="nad-edge-path nad-stretchable" points="522.21,-617.54 556.53,-452.92"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(528.85,-585.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(168.22)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -185,8 +185,8 @@
                 </g>
             </g>
             <g id="28.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="590.85,-288.31 556.53,-452.92"/>
-                <g class="nad-edge-infos" transform="translate(584.22,-320.13)">
+                <polyline class="nad-edge-path nad-stretchable" points="590.85,-288.31 556.53,-452.92"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(584.22,-320.13)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-11.78)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -207,8 +207,8 @@
         <g id="29">
             <desc>L1-5-1</desc>
             <g id="29.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="499.00,-624.45 371.07,-496.24"/>
-                <g class="nad-edge-infos" transform="translate(476.04,-601.44)">
+                <polyline class="nad-edge-path nad-stretchable" points="499.00,-624.45 371.07,-496.24"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(476.04,-601.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-135.06)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -226,8 +226,8 @@
                 </g>
             </g>
             <g id="29.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="243.15,-368.02 371.07,-496.24"/>
-                <g class="nad-edge-infos" transform="translate(266.10,-391.03)">
+                <polyline class="nad-edge-path nad-stretchable" points="243.15,-368.02 371.07,-496.24"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(266.10,-391.03)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(44.94)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -248,8 +248,8 @@
         <g id="30">
             <desc>L9-10-1</desc>
             <g id="30.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-48.76,421.74 -271.14,466.56"/>
-                <g class="nad-edge-infos" transform="translate(-80.62,428.16)">
+                <polyline class="nad-edge-path nad-stretchable" points="-48.76,421.74 -271.14,466.56"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-80.62,428.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-101.40)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -267,8 +267,8 @@
                 </g>
             </g>
             <g id="30.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-493.51,511.39 -271.14,466.56"/>
-                <g class="nad-edge-infos" transform="translate(-461.65,504.96)">
+                <polyline class="nad-edge-path nad-stretchable" points="-493.51,511.39 -271.14,466.56"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-461.65,504.96)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(78.60)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -289,8 +289,8 @@
         <g id="31">
             <desc>L10-11-1</desc>
             <g id="31.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-530.08,493.70 -619.73,317.52"/>
-                <g class="nad-edge-infos" transform="translate(-544.82,464.73)">
+                <polyline class="nad-edge-path nad-stretchable" points="-530.08,493.70 -619.73,317.52"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-544.82,464.73)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-26.97)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -308,8 +308,8 @@
                 </g>
             </g>
             <g id="31.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-709.39,141.34 -619.73,317.52"/>
-                <g class="nad-edge-infos" transform="translate(-694.65,170.30)">
+                <polyline class="nad-edge-path nad-stretchable" points="-709.39,141.34 -619.73,317.52"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-694.65,170.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(153.03)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -330,8 +330,8 @@
         <g id="32">
             <desc>L6-11-1</desc>
             <g id="32.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-351.70,-358.58 -528.52,-130.07"/>
-                <g class="nad-edge-infos" transform="translate(-371.59,-332.88)">
+                <polyline class="nad-edge-path nad-stretchable" points="-351.70,-358.58 -528.52,-130.07"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-371.59,-332.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-142.27)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -349,8 +349,8 @@
                 </g>
             </g>
             <g id="32.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-705.35,98.44 -528.52,-130.07"/>
-                <g class="nad-edge-infos" transform="translate(-685.46,72.74)">
+                <polyline class="nad-edge-path nad-stretchable" points="-705.35,98.44 -528.52,-130.07"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-685.46,72.74)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(37.73)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -371,8 +371,8 @@
         <g id="33">
             <desc>L6-12-1</desc>
             <g id="33.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-354.60,-396.29 -485.88,-520.79"/>
-                <g class="nad-edge-infos" transform="translate(-378.18,-418.66)">
+                <polyline class="nad-edge-path nad-stretchable" points="-354.60,-396.29 -485.88,-520.79"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-378.18,-418.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-46.52)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -390,8 +390,8 @@
                 </g>
             </g>
             <g id="33.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-617.16,-645.28 -485.88,-520.79"/>
-                <g class="nad-edge-infos" transform="translate(-593.57,-622.92)">
+                <polyline class="nad-edge-path nad-stretchable" points="-617.16,-645.28 -485.88,-520.79"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-593.57,-622.92)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(133.48)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -412,8 +412,8 @@
         <g id="34">
             <desc>L12-13-1</desc>
             <g id="34.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-635.28,-637.33 -632.92,-480.33"/>
-                <g class="nad-edge-infos" transform="translate(-634.79,-604.84)">
+                <polyline class="nad-edge-path nad-stretchable" points="-635.28,-637.33 -632.92,-480.33"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-634.79,-604.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(179.14)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -431,8 +431,8 @@
                 </g>
             </g>
             <g id="34.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-630.57,-323.32 -632.92,-480.33"/>
-                <g class="nad-edge-infos" transform="translate(-631.05,-355.82)">
+                <polyline class="nad-edge-path nad-stretchable" points="-630.57,-323.32 -632.92,-480.33"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-631.05,-355.82)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-0.86)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -453,8 +453,8 @@
         <g id="35">
             <desc>L6-13-1</desc>
             <g id="35.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-360.68,-371.98 -483.14,-338.29"/>
-                <g class="nad-edge-infos" transform="translate(-392.02,-363.36)">
+                <polyline class="nad-edge-path nad-stretchable" points="-360.68,-371.98 -483.14,-338.29"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-392.02,-363.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-105.38)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -472,8 +472,8 @@
                 </g>
             </g>
             <g id="35.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-605.60,-304.59 -483.14,-338.29"/>
-                <g class="nad-edge-infos" transform="translate(-574.26,-313.21)">
+                <polyline class="nad-edge-path nad-stretchable" points="-605.60,-304.59 -483.14,-338.29"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-574.26,-313.21)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(74.62)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -494,8 +494,8 @@
         <g id="36">
             <desc>L13-14-1</desc>
             <g id="36.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-613.96,-278.15 -469.33,-102.81"/>
-                <g class="nad-edge-infos" transform="translate(-593.28,-253.08)">
+                <polyline class="nad-edge-path nad-stretchable" points="-613.96,-278.15 -469.33,-102.81"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-593.28,-253.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(140.48)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -513,8 +513,8 @@
                 </g>
             </g>
             <g id="36.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-324.70,72.53 -469.33,-102.81"/>
-                <g class="nad-edge-infos" transform="translate(-345.38,47.46)">
+                <polyline class="nad-edge-path nad-stretchable" points="-324.70,72.53 -469.33,-102.81"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-345.38,47.46)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-39.52)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -535,8 +535,8 @@
         <g id="37">
             <desc>L9-14-1</desc>
             <g id="37.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-40.58,397.53 -166.12,254.45"/>
-                <g class="nad-edge-infos" transform="translate(-62.02,373.10)">
+                <polyline class="nad-edge-path nad-stretchable" points="-40.58,397.53 -166.12,254.45"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-62.02,373.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-41.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -554,8 +554,8 @@
                 </g>
             </g>
             <g id="37.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-291.66,111.37 -166.12,254.45"/>
-                <g class="nad-edge-infos" transform="translate(-270.22,135.80)">
+                <polyline class="nad-edge-path nad-stretchable" points="-291.66,111.37 -166.12,254.45"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-270.22,135.80)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(138.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -576,8 +576,8 @@
         <g id="38">
             <desc>L2-3-1</desc>
             <g id="38.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="612.02,-243.46 711.96,-118.97"/>
-                <g class="nad-edge-infos" transform="translate(632.36,-218.12)">
+                <polyline class="nad-edge-path nad-stretchable" points="612.02,-243.46 711.96,-118.97"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(632.36,-218.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(141.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -595,8 +595,8 @@
                 </g>
             </g>
             <g id="38.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="811.91,5.53 711.96,-118.97"/>
-                <g class="nad-edge-infos" transform="translate(791.57,-19.81)">
+                <polyline class="nad-edge-path nad-stretchable" points="811.91,5.53 711.96,-118.97"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(791.57,-19.81)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-38.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -617,8 +617,8 @@
         <g id="39">
             <desc>L2-4-1</desc>
             <g id="39.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="584.80,-240.46 501.00,-69.99"/>
-                <g class="nad-edge-infos" transform="translate(570.47,-211.30)">
+                <polyline class="nad-edge-path nad-stretchable" points="584.80,-240.46 501.00,-69.99"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(570.47,-211.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-153.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -636,8 +636,8 @@
                 </g>
             </g>
             <g id="39.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="417.20,100.49 501.00,-69.99"/>
-                <g class="nad-edge-infos" transform="translate(431.54,71.32)">
+                <polyline class="nad-edge-path nad-stretchable" points="417.20,100.49 501.00,-69.99"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(431.54,71.32)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(26.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -658,8 +658,8 @@
         <g id="40">
             <desc>L2-5-1</desc>
             <g id="40.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="571.22,-269.15 410.59,-306.66"/>
-                <g class="nad-edge-infos" transform="translate(539.57,-276.54)">
+                <polyline class="nad-edge-path nad-stretchable" points="571.22,-269.15 410.59,-306.66"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(539.57,-276.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-76.85)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -677,8 +677,8 @@
                 </g>
             </g>
             <g id="40.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="249.97,-344.17 410.59,-306.66"/>
-                <g class="nad-edge-infos" transform="translate(281.62,-336.78)">
+                <polyline class="nad-edge-path nad-stretchable" points="249.97,-344.17 410.59,-306.66"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(281.62,-336.78)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(103.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -699,8 +699,8 @@
         <g id="41">
             <desc>L3-4-1</desc>
             <g id="41.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="803.04,31.18 616.91,74.40"/>
-                <g class="nad-edge-infos" transform="translate(771.38,38.53)">
+                <polyline class="nad-edge-path nad-stretchable" points="803.04,31.18 616.91,74.40"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(771.38,38.53)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-103.07)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -718,8 +718,8 @@
                 </g>
             </g>
             <g id="41.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="430.79,117.61 616.91,74.40"/>
-                <g class="nad-edge-infos" transform="translate(462.45,110.26)">
+                <polyline class="nad-edge-path nad-stretchable" points="430.79,117.61 616.91,74.40"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(462.45,110.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(76.93)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -740,8 +740,8 @@
         <g id="42">
             <desc>L4-5-1</desc>
             <g id="42.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="396.85,99.55 315.54,-113.30"/>
-                <g class="nad-edge-infos" transform="translate(385.26,69.19)">
+                <polyline class="nad-edge-path nad-stretchable" points="396.85,99.55 315.54,-113.30"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(385.26,69.19)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-20.91)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -759,8 +759,8 @@
                 </g>
             </g>
             <g id="42.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="234.24,-326.15 315.54,-113.30"/>
-                <g class="nad-edge-infos" transform="translate(245.83,-295.79)">
+                <polyline class="nad-edge-path nad-stretchable" points="234.24,-326.15 315.54,-113.30"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(245.83,-295.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(159.09)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -781,8 +781,8 @@
         <g id="43">
             <desc>T4-7-1</desc>
             <g id="43.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="403.98,148.80 389.82,331.64"/>
-                <g class="nad-edge-infos" transform="translate(401.47,181.20)">
+                <polyline class="nad-edge-path nad-stretchable" points="403.98,148.80 389.82,331.64"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(401.47,181.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-175.57)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -798,11 +798,10 @@
                         <text transform="rotate(-85.57)" x="-19.00" style="text-anchor:end">21</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="388.28" cy="351.58" r="20.00"/>
             </g>
             <g id="43.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="371.03,574.29 385.19,391.46"/>
-                <g class="nad-edge-infos" transform="translate(373.54,541.89)">
+                <polyline class="nad-edge-path nad-stretchable" points="371.03,574.29 385.19,391.46"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(373.54,541.89)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(4.43)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -818,14 +817,21 @@
                         <text transform="rotate(-85.57)" x="19.00">-18</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="386.73" cy="371.52" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180">
+                    <circle class="nad-winding" cx="388.28" cy="351.58" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30">
+                    <circle class="nad-winding" cx="386.73" cy="371.52" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="44">
             <desc>T4-9-1</desc>
             <g id="44.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="384.89,137.75 215.87,253.12"/>
-                <g class="nad-edge-infos" transform="translate(358.05,156.07)">
+                <polyline class="nad-edge-path nad-stretchable" points="384.89,137.75 215.87,253.12"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(358.05,156.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-124.32)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -841,11 +847,10 @@
                         <text transform="rotate(-34.32)" x="-19.00" style="text-anchor:end">-13</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="199.35" cy="264.40" r="20.00"/>
             </g>
             <g id="44.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-2.70,402.32 166.32,286.95"/>
-                <g class="nad-edge-infos" transform="translate(24.14,384.00)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2.70,402.32 166.32,286.95"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(24.14,384.00)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(55.68)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -861,14 +866,21 @@
                         <text transform="rotate(-34.32)" x="19.00">16</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="182.84" cy="275.68" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180">
+                    <circle class="nad-winding" cx="199.35" cy="264.40" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30">
+                    <circle class="nad-winding" cx="182.84" cy="275.68" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="45">
             <desc>T5-6-1</desc>
             <g id="45.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="199.67,-351.28 -25.52,-362.82"/>
-                <g class="nad-edge-infos" transform="translate(167.21,-352.94)">
+                <polyline class="nad-edge-path nad-stretchable" points="199.67,-351.28 -25.52,-362.82"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(167.21,-352.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-87.06)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -884,11 +896,10 @@
                         <text transform="rotate(-357.06)" x="-19.00" style="text-anchor:end">9</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-45.49" cy="-363.85" r="20.00"/>
             </g>
             <g id="45.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-310.63,-377.44 -85.44,-365.90"/>
-                <g class="nad-edge-infos" transform="translate(-278.17,-375.78)">
+                <polyline class="nad-edge-path nad-stretchable" points="-310.63,-377.44 -85.44,-365.90"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-278.17,-375.78)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(92.94)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -904,14 +915,21 @@
                         <text transform="rotate(2.94)" x="19.00">-6</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-65.47" cy="-364.87" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180">
+                    <circle class="nad-winding" cx="-45.49" cy="-363.85" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30">
+                    <circle class="nad-winding" cx="-65.47" cy="-364.87" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="46">
             <desc>L7-8-1</desc>
             <g id="46.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="381.02,622.24 468.84,787.59"/>
-                <g class="nad-edge-infos" transform="translate(396.27,650.94)">
+                <polyline class="nad-edge-path nad-stretchable" points="381.02,622.24 468.84,787.59"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(396.27,650.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(152.03)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -929,8 +947,8 @@
                 </g>
             </g>
             <g id="46.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="556.67,952.94 468.84,787.59"/>
-                <g class="nad-edge-infos" transform="translate(541.42,924.23)">
+                <polyline class="nad-edge-path nad-stretchable" points="556.67,952.94 468.84,787.59"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(541.42,924.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-27.97)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -951,8 +969,8 @@
         <g id="47">
             <desc>L7-9-1</desc>
             <g id="47.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="345.94,588.95 172.65,508.21"/>
-                <g class="nad-edge-infos" transform="translate(316.48,575.22)">
+                <polyline class="nad-edge-path nad-stretchable" points="345.94,588.95 172.65,508.21"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(316.48,575.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-65.02)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -970,8 +988,8 @@
                 </g>
             </g>
             <g id="47.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-0.65,427.47 172.65,508.21"/>
-                <g class="nad-edge-infos" transform="translate(28.81,441.19)">
+                <polyline class="nad-edge-path nad-stretchable" points="-0.65,427.47 172.65,508.21"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(28.81,441.19)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(114.98)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_disconnection.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_disconnection.svg
@@ -165,8 +165,8 @@
         <g id="27">
             <desc>L1-2-1</desc>
             <g id="27.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="522.21,-617.54 556.53,-452.92"/>
-                <g class="nad-edge-infos" transform="translate(528.85,-585.72)">
+                <polyline class="nad-edge-path nad-stretchable" points="522.21,-617.54 556.53,-452.92"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(528.85,-585.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(168.22)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -184,8 +184,8 @@
                 </g>
             </g>
             <g id="27.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="590.85,-288.31 556.53,-452.92"/>
-                <g class="nad-edge-infos" transform="translate(584.22,-320.13)">
+                <polyline class="nad-edge-path nad-stretchable" points="590.85,-288.31 556.53,-452.92"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(584.22,-320.13)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-11.78)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -206,8 +206,8 @@
         <g id="28">
             <desc>L1-5-1</desc>
             <g id="28.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="499.00,-624.45 371.07,-496.24"/>
-                <g class="nad-edge-infos" transform="translate(476.04,-601.44)">
+                <polyline class="nad-edge-path nad-stretchable" points="499.00,-624.45 371.07,-496.24"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(476.04,-601.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-135.06)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -225,8 +225,8 @@
                 </g>
             </g>
             <g id="28.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="243.15,-368.02 371.07,-496.24"/>
-                <g class="nad-edge-infos" transform="translate(266.10,-391.03)">
+                <polyline class="nad-edge-path nad-stretchable" points="243.15,-368.02 371.07,-496.24"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(266.10,-391.03)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(44.94)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -247,8 +247,8 @@
         <g id="29">
             <desc>L9-10-1</desc>
             <g id="29.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-48.76,421.74 -271.14,466.56"/>
-                <g class="nad-edge-infos" transform="translate(-80.62,428.16)">
+                <polyline class="nad-edge-path nad-stretchable" points="-48.76,421.74 -271.14,466.56"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-80.62,428.16)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-101.40)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -266,8 +266,8 @@
                 </g>
             </g>
             <g id="29.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-493.51,511.39 -271.14,466.56"/>
-                <g class="nad-edge-infos" transform="translate(-461.65,504.96)">
+                <polyline class="nad-edge-path nad-stretchable" points="-493.51,511.39 -271.14,466.56"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-461.65,504.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(78.60)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -288,8 +288,8 @@
         <g id="30">
             <desc>L10-11-1</desc>
             <g id="30.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-530.08,493.70 -619.73,317.52"/>
-                <g class="nad-edge-infos" transform="translate(-544.82,464.73)">
+                <polyline class="nad-edge-path nad-stretchable" points="-530.08,493.70 -619.73,317.52"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-544.82,464.73)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-26.97)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -307,8 +307,8 @@
                 </g>
             </g>
             <g id="30.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-709.39,141.34 -619.73,317.52"/>
-                <g class="nad-edge-infos" transform="translate(-694.65,170.30)">
+                <polyline class="nad-edge-path nad-stretchable" points="-709.39,141.34 -619.73,317.52"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-694.65,170.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(153.03)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -329,8 +329,8 @@
         <g id="31">
             <desc>L6-11-1</desc>
             <g id="31.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-351.70,-358.58 -528.52,-130.07"/>
-                <g class="nad-edge-infos" transform="translate(-371.59,-332.88)">
+                <polyline class="nad-edge-path nad-stretchable" points="-351.70,-358.58 -528.52,-130.07"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-371.59,-332.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-142.27)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -348,8 +348,8 @@
                 </g>
             </g>
             <g id="31.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-705.35,98.44 -528.52,-130.07"/>
-                <g class="nad-edge-infos" transform="translate(-685.46,72.74)">
+                <polyline class="nad-edge-path nad-stretchable" points="-705.35,98.44 -528.52,-130.07"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-685.46,72.74)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(37.73)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -370,8 +370,8 @@
         <g id="32">
             <desc>L6-12-1</desc>
             <g id="32.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-354.60,-396.29 -485.88,-520.79"/>
-                <g class="nad-edge-infos" transform="translate(-378.18,-418.66)">
+                <polyline class="nad-edge-path nad-stretchable" points="-354.60,-396.29 -485.88,-520.79"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-378.18,-418.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-46.52)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -389,8 +389,8 @@
                 </g>
             </g>
             <g id="32.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-617.16,-645.28 -485.88,-520.79"/>
-                <g class="nad-edge-infos" transform="translate(-593.57,-622.92)">
+                <polyline class="nad-edge-path nad-stretchable" points="-617.16,-645.28 -485.88,-520.79"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-593.57,-622.92)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(133.48)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -411,8 +411,8 @@
         <g id="33">
             <desc>L12-13-1</desc>
             <g id="33.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-635.28,-637.33 -632.92,-480.33"/>
-                <g class="nad-edge-infos" transform="translate(-634.79,-604.84)">
+                <polyline class="nad-edge-path nad-stretchable" points="-635.28,-637.33 -632.92,-480.33"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-634.79,-604.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(179.14)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -430,8 +430,8 @@
                 </g>
             </g>
             <g id="33.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-630.57,-323.32 -632.92,-480.33"/>
-                <g class="nad-edge-infos" transform="translate(-631.05,-355.82)">
+                <polyline class="nad-edge-path nad-stretchable" points="-630.57,-323.32 -632.92,-480.33"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-631.05,-355.82)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-0.86)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -452,8 +452,8 @@
         <g id="34">
             <desc>L6-13-1</desc>
             <g id="34.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-360.68,-371.98 -483.14,-338.29"/>
-                <g class="nad-edge-infos" transform="translate(-392.02,-363.36)">
+                <polyline class="nad-edge-path nad-stretchable" points="-360.68,-371.98 -483.14,-338.29"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-392.02,-363.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-105.38)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -471,8 +471,8 @@
                 </g>
             </g>
             <g id="34.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-605.60,-304.59 -483.14,-338.29"/>
-                <g class="nad-edge-infos" transform="translate(-574.26,-313.21)">
+                <polyline class="nad-edge-path nad-stretchable" points="-605.60,-304.59 -483.14,-338.29"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-574.26,-313.21)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(74.62)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -493,8 +493,8 @@
         <g id="35" class="nad-disconnected">
             <desc>L13-14-1</desc>
             <g id="35.1" class="nad-disconnected nad-vl0to30">
-                <polyline class="nad-edge-path" points="-613.96,-278.15 -473.94,-108.41"/>
-                <g class="nad-edge-infos" transform="translate(-593.28,-253.08)">
+                <polyline class="nad-edge-path nad-stretchable" points="-613.96,-278.15 -473.94,-108.41"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-593.28,-253.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(140.48)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -512,8 +512,8 @@
                 </g>
             </g>
             <g id="35.2" class="nad-disconnected nad-vl0to30">
-                <polyline class="nad-edge-path" points="-333.93,61.34 -473.94,-108.41"/>
-                <g class="nad-edge-infos" transform="translate(-354.61,36.27)">
+                <polyline class="nad-edge-path nad-stretchable" points="-333.93,61.34 -473.94,-108.41"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-354.61,36.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-39.52)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -534,8 +534,8 @@
         <g id="36" class="nad-disconnected">
             <desc>L9-14-1</desc>
             <g id="36.1" class="nad-disconnected nad-vl0to30">
-                <polyline class="nad-edge-path" points="-40.58,397.53 -161.34,259.90"/>
-                <g class="nad-edge-infos" transform="translate(-62.02,373.10)">
+                <polyline class="nad-edge-path nad-stretchable" points="-40.58,397.53 -161.34,259.90"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-62.02,373.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-41.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -553,8 +553,8 @@
                 </g>
             </g>
             <g id="36.2" class="nad-disconnected nad-vl0to30">
-                <polyline class="nad-edge-path" points="-282.09,122.27 -161.34,259.90"/>
-                <g class="nad-edge-infos" transform="translate(-260.66,146.70)">
+                <polyline class="nad-edge-path nad-stretchable" points="-282.09,122.27 -161.34,259.90"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-260.66,146.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(138.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -575,8 +575,8 @@
         <g id="37">
             <desc>L2-3-1</desc>
             <g id="37.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="612.02,-243.46 711.96,-118.97"/>
-                <g class="nad-edge-infos" transform="translate(632.36,-218.12)">
+                <polyline class="nad-edge-path nad-stretchable" points="612.02,-243.46 711.96,-118.97"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(632.36,-218.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(141.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -594,8 +594,8 @@
                 </g>
             </g>
             <g id="37.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="811.91,5.53 711.96,-118.97"/>
-                <g class="nad-edge-infos" transform="translate(791.57,-19.81)">
+                <polyline class="nad-edge-path nad-stretchable" points="811.91,5.53 711.96,-118.97"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(791.57,-19.81)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-38.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -616,8 +616,8 @@
         <g id="38">
             <desc>L2-4-1</desc>
             <g id="38.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="584.80,-240.46 501.00,-69.99"/>
-                <g class="nad-edge-infos" transform="translate(570.47,-211.30)">
+                <polyline class="nad-edge-path nad-stretchable" points="584.80,-240.46 501.00,-69.99"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(570.47,-211.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-153.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -635,8 +635,8 @@
                 </g>
             </g>
             <g id="38.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="417.20,100.49 501.00,-69.99"/>
-                <g class="nad-edge-infos" transform="translate(431.54,71.32)">
+                <polyline class="nad-edge-path nad-stretchable" points="417.20,100.49 501.00,-69.99"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(431.54,71.32)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(26.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -657,8 +657,8 @@
         <g id="39">
             <desc>L2-5-1</desc>
             <g id="39.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="571.22,-269.15 410.59,-306.66"/>
-                <g class="nad-edge-infos" transform="translate(539.57,-276.54)">
+                <polyline class="nad-edge-path nad-stretchable" points="571.22,-269.15 410.59,-306.66"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(539.57,-276.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-76.85)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -676,8 +676,8 @@
                 </g>
             </g>
             <g id="39.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="249.97,-344.17 410.59,-306.66"/>
-                <g class="nad-edge-infos" transform="translate(281.62,-336.78)">
+                <polyline class="nad-edge-path nad-stretchable" points="249.97,-344.17 410.59,-306.66"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(281.62,-336.78)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(103.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -698,8 +698,8 @@
         <g id="40">
             <desc>L3-4-1</desc>
             <g id="40.1" class="nad-disconnected nad-vl120to180">
-                <polyline class="nad-edge-path" points="803.04,31.18 616.91,74.40"/>
-                <g class="nad-edge-infos" transform="translate(771.38,38.53)">
+                <polyline class="nad-edge-path nad-stretchable" points="803.04,31.18 616.91,74.40"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(771.38,38.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-103.07)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -717,8 +717,8 @@
                 </g>
             </g>
             <g id="40.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="430.79,117.61 616.91,74.40"/>
-                <g class="nad-edge-infos" transform="translate(462.45,110.26)">
+                <polyline class="nad-edge-path nad-stretchable" points="430.79,117.61 616.91,74.40"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(462.45,110.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(76.93)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -739,8 +739,8 @@
         <g id="41">
             <desc>L4-5-1</desc>
             <g id="41.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="396.85,99.55 315.54,-113.30"/>
-                <g class="nad-edge-infos" transform="translate(385.26,69.19)">
+                <polyline class="nad-edge-path nad-stretchable" points="396.85,99.55 315.54,-113.30"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(385.26,69.19)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-20.91)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -758,8 +758,8 @@
                 </g>
             </g>
             <g id="41.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="234.24,-326.15 315.54,-113.30"/>
-                <g class="nad-edge-infos" transform="translate(245.83,-295.79)">
+                <polyline class="nad-edge-path nad-stretchable" points="234.24,-326.15 315.54,-113.30"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(245.83,-295.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(159.09)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -780,8 +780,8 @@
         <g id="42">
             <desc>T4-7-1</desc>
             <g id="42.1" class="nad-disconnected nad-vl120to180">
-                <polyline class="nad-edge-path" points="403.98,148.80 389.82,331.64"/>
-                <g class="nad-edge-infos" transform="translate(401.47,181.20)">
+                <polyline class="nad-edge-path nad-stretchable" points="403.98,148.80 389.82,331.64"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(401.47,181.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-175.57)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -797,11 +797,10 @@
                         <text transform="rotate(-85.57)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="388.28" cy="351.58" r="20.00"/>
             </g>
             <g id="42.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="371.03,574.29 385.19,391.46"/>
-                <g class="nad-edge-infos" transform="translate(373.54,541.89)">
+                <polyline class="nad-edge-path nad-stretchable" points="371.03,574.29 385.19,391.46"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(373.54,541.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(4.43)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -817,14 +816,21 @@
                         <text transform="rotate(-85.57)" x="19.00">-0</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="386.73" cy="371.52" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-disconnected nad-vl120to180">
+                    <circle class="nad-winding" cx="388.28" cy="351.58" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30">
+                    <circle class="nad-winding" cx="386.73" cy="371.52" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="43">
             <desc>T4-9-1</desc>
             <g id="43.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="384.89,137.75 215.87,253.12"/>
-                <g class="nad-edge-infos" transform="translate(358.05,156.07)">
+                <polyline class="nad-edge-path nad-stretchable" points="384.89,137.75 215.87,253.12"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(358.05,156.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-124.32)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -840,11 +846,10 @@
                         <text transform="rotate(-34.32)" x="-19.00" style="text-anchor:end">-6</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="199.35" cy="264.40" r="20.00"/>
             </g>
             <g id="43.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-2.70,402.32 166.32,286.95"/>
-                <g class="nad-edge-infos" transform="translate(24.14,384.00)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2.70,402.32 166.32,286.95"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(24.14,384.00)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(55.68)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -860,14 +865,21 @@
                         <text transform="rotate(-34.32)" x="19.00">11</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="182.84" cy="275.68" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180">
+                    <circle class="nad-winding" cx="199.35" cy="264.40" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30">
+                    <circle class="nad-winding" cx="182.84" cy="275.68" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="44">
             <desc>T5-6-1</desc>
             <g id="44.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="199.67,-351.28 -25.52,-362.82"/>
-                <g class="nad-edge-infos" transform="translate(167.21,-352.94)">
+                <polyline class="nad-edge-path nad-stretchable" points="199.67,-351.28 -25.52,-362.82"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(167.21,-352.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-87.06)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -883,11 +895,10 @@
                         <text transform="rotate(-357.06)" x="-19.00" style="text-anchor:end">14</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-45.49" cy="-363.85" r="20.00"/>
             </g>
             <g id="44.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-310.63,-377.44 -85.44,-365.90"/>
-                <g class="nad-edge-infos" transform="translate(-278.17,-375.78)">
+                <polyline class="nad-edge-path nad-stretchable" points="-310.63,-377.44 -85.44,-365.90"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-278.17,-375.78)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(92.94)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -903,14 +914,21 @@
                         <text transform="rotate(2.94)" x="19.00">-10</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-65.47" cy="-364.87" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180">
+                    <circle class="nad-winding" cx="-45.49" cy="-363.85" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30">
+                    <circle class="nad-winding" cx="-65.47" cy="-364.87" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="45">
             <desc>L7-8-1</desc>
             <g id="45.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="381.02,622.24 468.84,787.59"/>
-                <g class="nad-edge-infos" transform="translate(396.27,650.94)">
+                <polyline class="nad-edge-path nad-stretchable" points="381.02,622.24 468.84,787.59"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(396.27,650.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(152.03)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -928,8 +946,8 @@
                 </g>
             </g>
             <g id="45.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="556.67,952.94 468.84,787.59"/>
-                <g class="nad-edge-infos" transform="translate(541.42,924.23)">
+                <polyline class="nad-edge-path nad-stretchable" points="556.67,952.94 468.84,787.59"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(541.42,924.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-27.97)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -950,8 +968,8 @@
         <g id="46">
             <desc>L7-9-1</desc>
             <g id="46.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="345.94,588.95 172.65,508.21"/>
-                <g class="nad-edge-infos" transform="translate(316.48,575.22)">
+                <polyline class="nad-edge-path nad-stretchable" points="345.94,588.95 172.65,508.21"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(316.48,575.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-65.02)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -969,8 +987,8 @@
                 </g>
             </g>
             <g id="46.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-0.65,427.47 172.65,508.21"/>
-                <g class="nad-edge-infos" transform="translate(28.81,441.19)">
+                <polyline class="nad-edge-path nad-stretchable" points="-0.65,427.47 172.65,508.21"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(28.81,441.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(114.98)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_disconnection.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_disconnection.svg
@@ -818,12 +818,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-disconnected nad-vl120to180">
-                    <circle class="nad-winding" cx="388.28" cy="351.58" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30">
-                    <circle class="nad-winding" cx="386.73" cy="371.52" r="20.00"/>
-                </g>
+                <circle class="nad-disconnected nad-vl120to180 nad-winding" cx="388.28" cy="351.58" r="20.00"/>
+                <circle class="nad-vl0to30 nad-winding" cx="386.73" cy="371.52" r="20.00"/>
             </g>
         </g>
         <g id="43">
@@ -867,12 +863,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180">
-                    <circle class="nad-winding" cx="199.35" cy="264.40" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30">
-                    <circle class="nad-winding" cx="182.84" cy="275.68" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180 nad-winding" cx="199.35" cy="264.40" r="20.00"/>
+                <circle class="nad-vl0to30 nad-winding" cx="182.84" cy="275.68" r="20.00"/>
             </g>
         </g>
         <g id="44">
@@ -916,12 +908,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180">
-                    <circle class="nad-winding" cx="-45.49" cy="-363.85" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30">
-                    <circle class="nad-winding" cx="-65.47" cy="-364.87" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180 nad-winding" cx="-45.49" cy="-363.85" r="20.00"/>
+                <circle class="nad-vl0to30 nad-winding" cx="-65.47" cy="-364.87" r="20.00"/>
             </g>
         </g>
         <g id="45">

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_fictitious.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_fictitious.svg
@@ -166,8 +166,8 @@
         <g id="28">
             <desc>L1-2-1</desc>
             <g id="28.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="522.21,-617.54 556.53,-452.92"/>
-                <g class="nad-edge-infos" transform="translate(528.85,-585.72)">
+                <polyline class="nad-edge-path nad-stretchable" points="522.21,-617.54 556.53,-452.92"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(528.85,-585.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(168.22)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -185,8 +185,8 @@
                 </g>
             </g>
             <g id="28.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="590.85,-288.31 556.53,-452.92"/>
-                <g class="nad-edge-infos" transform="translate(584.22,-320.13)">
+                <polyline class="nad-edge-path nad-stretchable" points="590.85,-288.31 556.53,-452.92"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(584.22,-320.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-11.78)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -207,8 +207,8 @@
         <g id="29">
             <desc>L1-5-1</desc>
             <g id="29.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="499.00,-624.45 371.07,-496.24"/>
-                <g class="nad-edge-infos" transform="translate(476.04,-601.44)">
+                <polyline class="nad-edge-path nad-stretchable" points="499.00,-624.45 371.07,-496.24"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(476.04,-601.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-135.06)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -226,8 +226,8 @@
                 </g>
             </g>
             <g id="29.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="243.15,-368.02 371.07,-496.24"/>
-                <g class="nad-edge-infos" transform="translate(266.10,-391.03)">
+                <polyline class="nad-edge-path nad-stretchable" points="243.15,-368.02 371.07,-496.24"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(266.10,-391.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(44.94)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -248,8 +248,8 @@
         <g id="30">
             <desc>L9-10-1</desc>
             <g id="30.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-48.76,421.74 -271.14,466.56"/>
-                <g class="nad-edge-infos" transform="translate(-80.62,428.16)">
+                <polyline class="nad-edge-path nad-stretchable" points="-48.76,421.74 -271.14,466.56"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-80.62,428.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-101.40)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -267,8 +267,8 @@
                 </g>
             </g>
             <g id="30.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-493.51,511.39 -271.14,466.56"/>
-                <g class="nad-edge-infos" transform="translate(-461.65,504.96)">
+                <polyline class="nad-edge-path nad-stretchable" points="-493.51,511.39 -271.14,466.56"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-461.65,504.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(78.60)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -289,8 +289,8 @@
         <g id="31">
             <desc>L10-11-1</desc>
             <g id="31.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-530.08,493.70 -619.73,317.52"/>
-                <g class="nad-edge-infos" transform="translate(-544.82,464.73)">
+                <polyline class="nad-edge-path nad-stretchable" points="-530.08,493.70 -619.73,317.52"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-544.82,464.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-26.97)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -308,8 +308,8 @@
                 </g>
             </g>
             <g id="31.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-709.39,141.34 -619.73,317.52"/>
-                <g class="nad-edge-infos" transform="translate(-694.65,170.30)">
+                <polyline class="nad-edge-path nad-stretchable" points="-709.39,141.34 -619.73,317.52"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-694.65,170.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(153.03)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -330,8 +330,8 @@
         <g id="32">
             <desc>L6-11-1</desc>
             <g id="32.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-351.70,-358.58 -528.52,-130.07"/>
-                <g class="nad-edge-infos" transform="translate(-371.59,-332.88)">
+                <polyline class="nad-edge-path nad-stretchable" points="-351.70,-358.58 -528.52,-130.07"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-371.59,-332.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-142.27)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -349,8 +349,8 @@
                 </g>
             </g>
             <g id="32.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-705.35,98.44 -528.52,-130.07"/>
-                <g class="nad-edge-infos" transform="translate(-685.46,72.74)">
+                <polyline class="nad-edge-path nad-stretchable" points="-705.35,98.44 -528.52,-130.07"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-685.46,72.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(37.73)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -371,8 +371,8 @@
         <g id="33">
             <desc>L6-12-1</desc>
             <g id="33.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-354.60,-396.29 -491.32,-525.95"/>
-                <g class="nad-edge-infos" transform="translate(-378.18,-418.66)">
+                <polyline class="nad-edge-path nad-stretchable" points="-354.60,-396.29 -491.32,-525.95"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-378.18,-418.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-46.52)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -390,8 +390,8 @@
                 </g>
             </g>
             <g id="33.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-628.04,-655.60 -491.32,-525.95"/>
-                <g class="nad-edge-infos" transform="translate(-604.46,-633.24)">
+                <polyline class="nad-edge-path nad-stretchable" points="-628.04,-655.60 -491.32,-525.95"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-604.46,-633.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(133.48)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -412,8 +412,8 @@
         <g id="34">
             <desc>L12-13-1</desc>
             <g id="34.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-635.50,-652.33 -633.03,-487.83"/>
-                <g class="nad-edge-infos" transform="translate(-635.01,-619.83)">
+                <polyline class="nad-edge-path nad-stretchable" points="-635.50,-652.33 -633.03,-487.83"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-635.01,-619.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(179.14)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -431,8 +431,8 @@
                 </g>
             </g>
             <g id="34.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-630.57,-323.32 -633.03,-487.83"/>
-                <g class="nad-edge-infos" transform="translate(-631.05,-355.82)">
+                <polyline class="nad-edge-path nad-stretchable" points="-630.57,-323.32 -633.03,-487.83"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-631.05,-355.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-0.86)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -453,8 +453,8 @@
         <g id="35">
             <desc>L6-13-1</desc>
             <g id="35.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-360.68,-371.98 -483.14,-338.29"/>
-                <g class="nad-edge-infos" transform="translate(-392.02,-363.36)">
+                <polyline class="nad-edge-path nad-stretchable" points="-360.68,-371.98 -483.14,-338.29"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-392.02,-363.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-105.38)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -472,8 +472,8 @@
                 </g>
             </g>
             <g id="35.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-605.60,-304.59 -483.14,-338.29"/>
-                <g class="nad-edge-infos" transform="translate(-574.26,-313.21)">
+                <polyline class="nad-edge-path nad-stretchable" points="-605.60,-304.59 -483.14,-338.29"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-574.26,-313.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(74.62)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -494,8 +494,8 @@
         <g id="36">
             <desc>L13-14-1</desc>
             <g id="36.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-613.96,-278.15 -464.56,-97.03"/>
-                <g class="nad-edge-infos" transform="translate(-593.28,-253.08)">
+                <polyline class="nad-edge-path nad-stretchable" points="-613.96,-278.15 -464.56,-97.03"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-593.28,-253.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(140.48)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -513,8 +513,8 @@
                 </g>
             </g>
             <g id="36.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-315.16,84.10 -464.56,-97.03"/>
-                <g class="nad-edge-infos" transform="translate(-335.84,59.03)">
+                <polyline class="nad-edge-path nad-stretchable" points="-315.16,84.10 -464.56,-97.03"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-335.84,59.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-39.52)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -535,8 +535,8 @@
         <g id="37">
             <desc>L9-14-1</desc>
             <g id="37.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-40.58,397.53 -171.07,248.81"/>
-                <g class="nad-edge-infos" transform="translate(-62.02,373.10)">
+                <polyline class="nad-edge-path nad-stretchable" points="-40.58,397.53 -171.07,248.81"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-62.02,373.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-41.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -554,8 +554,8 @@
                 </g>
             </g>
             <g id="37.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-301.55,100.09 -171.07,248.81"/>
-                <g class="nad-edge-infos" transform="translate(-280.12,124.52)">
+                <polyline class="nad-edge-path nad-stretchable" points="-301.55,100.09 -171.07,248.81"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-280.12,124.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(138.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -576,8 +576,8 @@
         <g id="38">
             <desc>L2-3-1</desc>
             <g id="38.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="612.02,-243.46 711.96,-118.97"/>
-                <g class="nad-edge-infos" transform="translate(632.36,-218.12)">
+                <polyline class="nad-edge-path nad-stretchable" points="612.02,-243.46 711.96,-118.97"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(632.36,-218.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(141.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -595,8 +595,8 @@
                 </g>
             </g>
             <g id="38.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="811.91,5.53 711.96,-118.97"/>
-                <g class="nad-edge-infos" transform="translate(791.57,-19.81)">
+                <polyline class="nad-edge-path nad-stretchable" points="811.91,5.53 711.96,-118.97"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(791.57,-19.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-38.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -617,8 +617,8 @@
         <g id="39">
             <desc>L2-4-1</desc>
             <g id="39.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="584.80,-240.46 501.00,-69.99"/>
-                <g class="nad-edge-infos" transform="translate(570.47,-211.30)">
+                <polyline class="nad-edge-path nad-stretchable" points="584.80,-240.46 501.00,-69.99"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(570.47,-211.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-153.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -636,8 +636,8 @@
                 </g>
             </g>
             <g id="39.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="417.20,100.49 501.00,-69.99"/>
-                <g class="nad-edge-infos" transform="translate(431.54,71.32)">
+                <polyline class="nad-edge-path nad-stretchable" points="417.20,100.49 501.00,-69.99"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(431.54,71.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(26.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -658,8 +658,8 @@
         <g id="40">
             <desc>L2-5-1</desc>
             <g id="40.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="571.22,-269.15 410.59,-306.66"/>
-                <g class="nad-edge-infos" transform="translate(539.57,-276.54)">
+                <polyline class="nad-edge-path nad-stretchable" points="571.22,-269.15 410.59,-306.66"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(539.57,-276.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-76.85)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -677,8 +677,8 @@
                 </g>
             </g>
             <g id="40.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="249.97,-344.17 410.59,-306.66"/>
-                <g class="nad-edge-infos" transform="translate(281.62,-336.78)">
+                <polyline class="nad-edge-path nad-stretchable" points="249.97,-344.17 410.59,-306.66"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(281.62,-336.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(103.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -699,8 +699,8 @@
         <g id="41">
             <desc>L3-4-1</desc>
             <g id="41.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="803.04,31.18 616.91,74.40"/>
-                <g class="nad-edge-infos" transform="translate(771.38,38.53)">
+                <polyline class="nad-edge-path nad-stretchable" points="803.04,31.18 616.91,74.40"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(771.38,38.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-103.07)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -718,8 +718,8 @@
                 </g>
             </g>
             <g id="41.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="430.79,117.61 616.91,74.40"/>
-                <g class="nad-edge-infos" transform="translate(462.45,110.26)">
+                <polyline class="nad-edge-path nad-stretchable" points="430.79,117.61 616.91,74.40"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(462.45,110.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(76.93)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -740,8 +740,8 @@
         <g id="42">
             <desc>L4-5-1</desc>
             <g id="42.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="396.85,99.55 315.54,-113.30"/>
-                <g class="nad-edge-infos" transform="translate(385.26,69.19)">
+                <polyline class="nad-edge-path nad-stretchable" points="396.85,99.55 315.54,-113.30"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(385.26,69.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-20.91)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -759,8 +759,8 @@
                 </g>
             </g>
             <g id="42.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="234.24,-326.15 315.54,-113.30"/>
-                <g class="nad-edge-infos" transform="translate(245.83,-295.79)">
+                <polyline class="nad-edge-path nad-stretchable" points="234.24,-326.15 315.54,-113.30"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(245.83,-295.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(159.09)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -781,8 +781,8 @@
         <g id="43">
             <desc>T4-7-1</desc>
             <g id="43.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="403.98,148.80 389.82,331.64"/>
-                <g class="nad-edge-infos" transform="translate(401.47,181.20)">
+                <polyline class="nad-edge-path nad-stretchable" points="403.98,148.80 389.82,331.64"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(401.47,181.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-175.57)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -798,11 +798,10 @@
                         <text transform="rotate(-85.57)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="388.28" cy="351.58" r="20.00"/>
             </g>
             <g id="43.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="371.03,574.29 385.19,391.46"/>
-                <g class="nad-edge-infos" transform="translate(373.54,541.89)">
+                <polyline class="nad-edge-path nad-stretchable" points="371.03,574.29 385.19,391.46"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(373.54,541.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(4.43)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -818,14 +817,21 @@
                         <text transform="rotate(-85.57)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="386.73" cy="371.52" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180">
+                    <circle class="nad-winding" cx="388.28" cy="351.58" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30">
+                    <circle class="nad-winding" cx="386.73" cy="371.52" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="44">
             <desc>T4-9-1</desc>
             <g id="44.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="384.89,137.75 215.87,253.12"/>
-                <g class="nad-edge-infos" transform="translate(358.05,156.07)">
+                <polyline class="nad-edge-path nad-stretchable" points="384.89,137.75 215.87,253.12"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(358.05,156.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-124.32)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -841,11 +847,10 @@
                         <text transform="rotate(-34.32)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="199.35" cy="264.40" r="20.00"/>
             </g>
             <g id="44.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-2.70,402.32 166.32,286.95"/>
-                <g class="nad-edge-infos" transform="translate(24.14,384.00)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2.70,402.32 166.32,286.95"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(24.14,384.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(55.68)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -861,14 +866,21 @@
                         <text transform="rotate(-34.32)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="182.84" cy="275.68" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180">
+                    <circle class="nad-winding" cx="199.35" cy="264.40" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30">
+                    <circle class="nad-winding" cx="182.84" cy="275.68" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="45">
             <desc>T5-6-1</desc>
             <g id="45.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="199.67,-351.28 -25.52,-362.82"/>
-                <g class="nad-edge-infos" transform="translate(167.21,-352.94)">
+                <polyline class="nad-edge-path nad-stretchable" points="199.67,-351.28 -25.52,-362.82"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(167.21,-352.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-87.06)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -884,11 +896,10 @@
                         <text transform="rotate(-357.06)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-45.49" cy="-363.85" r="20.00"/>
             </g>
             <g id="45.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-310.63,-377.44 -85.44,-365.90"/>
-                <g class="nad-edge-infos" transform="translate(-278.17,-375.78)">
+                <polyline class="nad-edge-path nad-stretchable" points="-310.63,-377.44 -85.44,-365.90"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-278.17,-375.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(92.94)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -904,14 +915,21 @@
                         <text transform="rotate(2.94)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-65.47" cy="-364.87" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180">
+                    <circle class="nad-winding" cx="-45.49" cy="-363.85" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30">
+                    <circle class="nad-winding" cx="-65.47" cy="-364.87" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="46">
             <desc>L7-8-1</desc>
             <g id="46.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="381.02,622.24 468.84,787.59"/>
-                <g class="nad-edge-infos" transform="translate(396.27,650.94)">
+                <polyline class="nad-edge-path nad-stretchable" points="381.02,622.24 468.84,787.59"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(396.27,650.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(152.03)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -929,8 +947,8 @@
                 </g>
             </g>
             <g id="46.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="556.67,952.94 468.84,787.59"/>
-                <g class="nad-edge-infos" transform="translate(541.42,924.23)">
+                <polyline class="nad-edge-path nad-stretchable" points="556.67,952.94 468.84,787.59"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(541.42,924.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-27.97)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -951,8 +969,8 @@
         <g id="47">
             <desc>L7-9-1</desc>
             <g id="47.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="345.94,588.95 172.65,508.21"/>
-                <g class="nad-edge-infos" transform="translate(316.48,575.22)">
+                <polyline class="nad-edge-path nad-stretchable" points="345.94,588.95 172.65,508.21"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(316.48,575.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-65.02)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -970,8 +988,8 @@
                 </g>
             </g>
             <g id="47.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-0.65,427.47 172.65,508.21"/>
-                <g class="nad-edge-infos" transform="translate(28.81,441.19)">
+                <polyline class="nad-edge-path nad-stretchable" points="-0.65,427.47 172.65,508.21"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(28.81,441.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(114.98)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_fictitious.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_fictitious.svg
@@ -819,12 +819,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180">
-                    <circle class="nad-winding" cx="388.28" cy="351.58" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30">
-                    <circle class="nad-winding" cx="386.73" cy="371.52" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180 nad-winding" cx="388.28" cy="351.58" r="20.00"/>
+                <circle class="nad-vl0to30 nad-winding" cx="386.73" cy="371.52" r="20.00"/>
             </g>
         </g>
         <g id="44">
@@ -868,12 +864,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180">
-                    <circle class="nad-winding" cx="199.35" cy="264.40" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30">
-                    <circle class="nad-winding" cx="182.84" cy="275.68" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180 nad-winding" cx="199.35" cy="264.40" r="20.00"/>
+                <circle class="nad-vl0to30 nad-winding" cx="182.84" cy="275.68" r="20.00"/>
             </g>
         </g>
         <g id="45">
@@ -917,12 +909,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180">
-                    <circle class="nad-winding" cx="-45.49" cy="-363.85" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30">
-                    <circle class="nad-winding" cx="-65.47" cy="-364.87" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180 nad-winding" cx="-45.49" cy="-363.85" r="20.00"/>
+                <circle class="nad-vl0to30 nad-winding" cx="-65.47" cy="-364.87" r="20.00"/>
             </g>
         </g>
         <g id="46">

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_text_nodes.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_text_nodes.svg
@@ -166,8 +166,8 @@
         <g id="28">
             <desc>L1-2-1</desc>
             <g id="28.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="974.70,470.51 934.52,257.19"/>
-                <g class="nad-edge-infos" transform="translate(968.69,438.57)">
+                <polyline class="nad-edge-path nad-stretchable" points="974.70,470.51 934.52,257.19"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(968.69,438.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-10.67)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -185,8 +185,8 @@
                 </g>
             </g>
             <g id="28.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="894.33,43.87 934.52,257.19"/>
-                <g class="nad-edge-infos" transform="translate(900.34,75.81)">
+                <polyline class="nad-edge-path nad-stretchable" points="894.33,43.87 934.52,257.19"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(900.34,75.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(169.33)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -207,8 +207,8 @@
         <g id="29">
             <desc>L1-5-1</desc>
             <g id="29.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="961.14,477.79 810.94,331.77"/>
-                <g class="nad-edge-infos" transform="translate(937.84,455.14)">
+                <polyline class="nad-edge-path nad-stretchable" points="961.14,477.79 810.94,331.77"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(937.84,455.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-45.81)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -226,8 +226,8 @@
                 </g>
             </g>
             <g id="29.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="660.74,185.74 810.94,331.77"/>
-                <g class="nad-edge-infos" transform="translate(684.05,208.40)">
+                <polyline class="nad-edge-path nad-stretchable" points="660.74,185.74 810.94,331.77"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(684.05,208.40)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(134.19)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -248,8 +248,8 @@
         <g id="30">
             <desc>L9-10-1</desc>
             <g id="30.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-330.09,463.57 -673.91,246.06"/>
-                <g class="nad-edge-infos" transform="translate(-357.55,446.20)">
+                <polyline class="nad-edge-path nad-stretchable" points="-330.09,463.57 -673.91,246.06"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-357.55,446.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-57.68)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -267,8 +267,8 @@
                 </g>
             </g>
             <g id="30.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-1017.72,28.54 -673.91,246.06"/>
-                <g class="nad-edge-infos" transform="translate(-990.26,45.91)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1017.72,28.54 -673.91,246.06"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-990.26,45.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(122.32)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -289,8 +289,8 @@
         <g id="31">
             <desc>L10-11-1</desc>
             <g id="31.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-1031.40,-9.35 -959.24,-231.81"/>
-                <g class="nad-edge-infos" transform="translate(-1021.38,-40.26)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1031.40,-9.35 -959.24,-231.81"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1021.38,-40.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(17.97)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -308,8 +308,8 @@
                 </g>
             </g>
             <g id="31.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-887.07,-454.28 -959.24,-231.81"/>
-                <g class="nad-edge-infos" transform="translate(-897.10,-423.36)">
+                <polyline class="nad-edge-path nad-stretchable" points="-887.07,-454.28 -959.24,-231.81"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-897.10,-423.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-162.03)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -330,8 +330,8 @@
         <g id="32">
             <desc>L6-11-1</desc>
             <g id="32.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-225.48,-397.99 -539.69,-436.70"/>
-                <g class="nad-edge-infos" transform="translate(-257.74,-401.96)">
+                <polyline class="nad-edge-path nad-stretchable" points="-225.48,-397.99 -539.69,-436.70"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-257.74,-401.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-82.98)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -349,8 +349,8 @@
                 </g>
             </g>
             <g id="32.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-853.90,-475.41 -539.69,-436.70"/>
-                <g class="nad-edge-infos" transform="translate(-821.64,-471.44)">
+                <polyline class="nad-edge-path nad-stretchable" points="-853.90,-475.41 -539.69,-436.70"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-821.64,-471.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(97.02)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -371,8 +371,8 @@
         <g id="33">
             <desc>L6-12-1</desc>
             <g id="33.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-193.19,-419.39 -156.07,-549.82"/>
-                <g class="nad-edge-infos" transform="translate(-184.30,-450.65)">
+                <polyline class="nad-edge-path nad-stretchable" points="-193.19,-419.39 -156.07,-549.82"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-184.30,-450.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(15.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -390,8 +390,8 @@
                 </g>
             </g>
             <g id="33.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-118.95,-680.24 -156.07,-549.82"/>
-                <g class="nad-edge-infos" transform="translate(-127.85,-648.98)">
+                <polyline class="nad-edge-path nad-stretchable" points="-118.95,-680.24 -156.07,-549.82"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-127.85,-648.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-164.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -412,8 +412,8 @@
         <g id="34">
             <desc>L12-13-1</desc>
             <g id="34.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-123.43,-681.99 -255.81,-418.86"/>
-                <g class="nad-edge-infos" transform="translate(-138.03,-652.95)">
+                <polyline class="nad-edge-path nad-stretchable" points="-123.43,-681.99 -255.81,-418.86"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-138.03,-652.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-153.29)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -431,8 +431,8 @@
                 </g>
             </g>
             <g id="34.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-388.20,-155.73 -255.81,-418.86"/>
-                <g class="nad-edge-infos" transform="translate(-373.59,-184.76)">
+                <polyline class="nad-edge-path nad-stretchable" points="-388.20,-155.73 -255.81,-418.86"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-373.59,-184.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(26.71)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -453,8 +453,8 @@
         <g id="35">
             <desc>L6-13-1</desc>
             <g id="35.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-215.63,-374.58 -299.92,-263.91"/>
-                <g class="nad-edge-infos" transform="translate(-235.32,-348.73)">
+                <polyline class="nad-edge-path nad-stretchable" points="-215.63,-374.58 -299.92,-263.91"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-235.32,-348.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-142.71)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -472,8 +472,8 @@
                 </g>
             </g>
             <g id="35.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-384.21,-153.24 -299.92,-263.91"/>
-                <g class="nad-edge-infos" transform="translate(-364.52,-179.09)">
+                <polyline class="nad-edge-path nad-stretchable" points="-384.21,-153.24 -299.92,-263.91"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-364.52,-179.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(37.29)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -494,8 +494,8 @@
         <g id="36">
             <desc>L13-14-1</desc>
             <g id="36.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-411.53,-110.38 -555.78,163.99"/>
-                <g class="nad-edge-infos" transform="translate(-426.65,-81.61)">
+                <polyline class="nad-edge-path nad-stretchable" points="-411.53,-110.38 -555.78,163.99"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-426.65,-81.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-152.27)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -513,8 +513,8 @@
                 </g>
             </g>
             <g id="36.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-700.03,438.37 -555.78,163.99"/>
-                <g class="nad-edge-infos" transform="translate(-684.90,409.60)">
+                <polyline class="nad-edge-path nad-stretchable" points="-700.03,438.37 -555.78,163.99"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-684.90,409.60)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(27.73)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -535,8 +535,8 @@
         <g id="37">
             <desc>L9-14-1</desc>
             <g id="37.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-334.02,476.18 -510.22,469.07"/>
-                <g class="nad-edge-infos" transform="translate(-366.49,474.87)">
+                <polyline class="nad-edge-path nad-stretchable" points="-334.02,476.18 -510.22,469.07"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-366.49,474.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-87.69)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -554,8 +554,8 @@
                 </g>
             </g>
             <g id="37.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-686.41,461.97 -510.22,469.07"/>
-                <g class="nad-edge-infos" transform="translate(-653.94,463.28)">
+                <polyline class="nad-edge-path nad-stretchable" points="-686.41,461.97 -510.22,469.07"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-653.94,463.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(92.31)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -576,8 +576,8 @@
         <g id="38">
             <desc>L2-3-1</desc>
             <g id="38.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="871.83,0.52 712.87,-163.04"/>
-                <g class="nad-edge-infos" transform="translate(849.18,-22.78)">
+                <polyline class="nad-edge-path nad-stretchable" points="871.83,0.52 712.87,-163.04"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(849.18,-22.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-44.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -595,8 +595,8 @@
                 </g>
             </g>
             <g id="38.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="553.90,-326.61 712.87,-163.04"/>
-                <g class="nad-edge-infos" transform="translate(576.56,-303.30)">
+                <polyline class="nad-edge-path nad-stretchable" points="553.90,-326.61 712.87,-163.04"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(576.56,-303.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(135.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -617,8 +617,8 @@
         <g id="39">
             <desc>L2-4-1</desc>
             <g id="39.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="864.87,24.99 623.87,85.21"/>
-                <g class="nad-edge-infos" transform="translate(833.34,32.87)">
+                <polyline class="nad-edge-path nad-stretchable" points="864.87,24.99 623.87,85.21"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(833.34,32.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-104.03)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -636,8 +636,8 @@
                 </g>
             </g>
             <g id="39.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="382.88,145.43 623.87,85.21"/>
-                <g class="nad-edge-infos" transform="translate(414.41,137.55)">
+                <polyline class="nad-edge-path nad-stretchable" points="382.88,145.43 623.87,85.21"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(414.41,137.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(75.97)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -658,8 +658,8 @@
         <g id="40">
             <desc>L2-5-1</desc>
             <g id="40.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="867.77,31.99 766.03,93.39"/>
-                <g class="nad-edge-infos" transform="translate(839.95,48.78)">
+                <polyline class="nad-edge-path nad-stretchable" points="867.77,31.99 766.03,93.39"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(839.95,48.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-121.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -677,8 +677,8 @@
                 </g>
             </g>
             <g id="40.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="664.29,154.79 766.03,93.39"/>
-                <g class="nad-edge-infos" transform="translate(692.12,138.00)">
+                <polyline class="nad-edge-path nad-stretchable" points="664.29,154.79 766.03,93.39"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(692.12,138.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(58.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -699,8 +699,8 @@
         <g id="41">
             <desc>L3-4-1</desc>
             <g id="41.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="527.53,-320.89 447.14,-96.64"/>
-                <g class="nad-edge-infos" transform="translate(516.56,-290.30)">
+                <polyline class="nad-edge-path nad-stretchable" points="527.53,-320.89 447.14,-96.64"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(516.56,-290.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-160.28)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -718,8 +718,8 @@
                 </g>
             </g>
             <g id="41.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="366.74,127.60 447.14,-96.64"/>
-                <g class="nad-edge-infos" transform="translate(377.71,97.01)">
+                <polyline class="nad-edge-path nad-stretchable" points="366.74,127.60 447.14,-96.64"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(377.71,97.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(19.72)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -740,8 +740,8 @@
         <g id="42">
             <desc>L4-5-1</desc>
             <g id="42.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="383.60,153.07 500.30,159.79"/>
-                <g class="nad-edge-infos" transform="translate(416.04,154.94)">
+                <polyline class="nad-edge-path nad-stretchable" points="383.60,153.07 500.30,159.79"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(416.04,154.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(93.29)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -759,8 +759,8 @@
                 </g>
             </g>
             <g id="42.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="617.00,166.50 500.30,159.79"/>
-                <g class="nad-edge-infos" transform="translate(584.56,164.64)">
+                <polyline class="nad-edge-path nad-stretchable" points="617.00,166.50 500.30,159.79"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(584.56,164.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-86.71)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -781,8 +781,8 @@
         <g id="43">
             <desc>T4-7-1</desc>
             <g id="43.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="350.48,175.93 266.82,441.57"/>
-                <g class="nad-edge-infos" transform="translate(340.72,206.93)">
+                <polyline class="nad-edge-path nad-stretchable" points="350.48,175.93 266.82,441.57"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(340.72,206.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-162.52)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -798,11 +798,10 @@
                         <text transform="rotate(-72.52)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="260.81" cy="460.65" r="20.00"/>
             </g>
             <g id="43.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="165.13,764.44 248.80,498.80"/>
-                <g class="nad-edge-infos" transform="translate(174.90,733.44)">
+                <polyline class="nad-edge-path nad-stretchable" points="165.13,764.44 248.80,498.80"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(174.90,733.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(17.48)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -818,14 +817,21 @@
                         <text transform="rotate(-72.52)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="254.80" cy="479.72" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180">
+                    <circle class="nad-winding" cx="260.81" cy="460.65" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30">
+                    <circle class="nad-winding" cx="254.80" cy="479.72" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="44">
             <desc>T4-9-1</desc>
             <g id="44.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="335.23,162.80 51.76,301.24"/>
-                <g class="nad-edge-infos" transform="translate(306.02,177.06)">
+                <polyline class="nad-edge-path nad-stretchable" points="335.23,162.80 51.76,301.24"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(306.02,177.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-116.03)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -841,11 +847,10 @@
                         <text transform="rotate(-26.03)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="33.79" cy="310.02" r="20.00"/>
             </g>
             <g id="44.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-285.63,466.02 -2.16,327.57"/>
-                <g class="nad-edge-infos" transform="translate(-256.42,451.75)">
+                <polyline class="nad-edge-path nad-stretchable" points="-285.63,466.02 -2.16,327.57"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-256.42,451.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(63.97)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -861,14 +866,21 @@
                         <text transform="rotate(-26.03)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="15.81" cy="318.80" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180">
+                    <circle class="nad-winding" cx="33.79" cy="310.02" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30">
+                    <circle class="nad-winding" cx="15.81" cy="318.80" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="45">
             <desc>T5-6-1</desc>
             <g id="45.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="621.26,153.81 246.09,-96.79"/>
-                <g class="nad-edge-infos" transform="translate(594.23,135.75)">
+                <polyline class="nad-edge-path nad-stretchable" points="621.26,153.81 246.09,-96.79"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(594.23,135.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-56.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -884,11 +896,10 @@
                         <text transform="rotate(-326.26)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="229.46" cy="-107.90" r="20.00"/>
             </g>
             <g id="45.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-178.97,-380.70 196.20,-130.11"/>
-                <g class="nad-edge-infos" transform="translate(-151.94,-362.65)">
+                <polyline class="nad-edge-path nad-stretchable" points="-178.97,-380.70 196.20,-130.11"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-151.94,-362.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(123.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -904,14 +915,21 @@
                         <text transform="rotate(33.74)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="212.83" cy="-119.00" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180">
+                    <circle class="nad-winding" cx="229.46" cy="-107.90" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30">
+                    <circle class="nad-winding" cx="212.83" cy="-119.00" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="46">
             <desc>L7-8-1</desc>
             <g id="46.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="171.39,810.13 313.05,1027.61"/>
-                <g class="nad-edge-infos" transform="translate(189.13,837.36)">
+                <polyline class="nad-edge-path nad-stretchable" points="171.39,810.13 313.05,1027.61"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(189.13,837.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(146.92)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -929,8 +947,8 @@
                 </g>
             </g>
             <g id="46.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="454.71,1245.09 313.05,1027.61"/>
-                <g class="nad-edge-infos" transform="translate(436.97,1217.86)">
+                <polyline class="nad-edge-path nad-stretchable" points="454.71,1245.09 313.05,1027.61"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(436.97,1217.86)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-33.08)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -951,8 +969,8 @@
         <g id="47">
             <desc>L7-9-1</desc>
             <g id="47.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="136.28,774.59 -75.53,632.98"/>
-                <g class="nad-edge-infos" transform="translate(109.26,756.53)">
+                <polyline class="nad-edge-path nad-stretchable" points="136.28,774.59 -75.53,632.98"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(109.26,756.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-56.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -970,8 +988,8 @@
                 </g>
             </g>
             <g id="47.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-287.34,491.38 -75.53,632.98"/>
-                <g class="nad-edge-infos" transform="translate(-260.32,509.44)">
+                <polyline class="nad-edge-path nad-stretchable" points="-287.34,491.38 -75.53,632.98"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-260.32,509.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(123.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_text_nodes.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_text_nodes.svg
@@ -819,12 +819,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180">
-                    <circle class="nad-winding" cx="260.81" cy="460.65" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30">
-                    <circle class="nad-winding" cx="254.80" cy="479.72" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180 nad-winding" cx="260.81" cy="460.65" r="20.00"/>
+                <circle class="nad-vl0to30 nad-winding" cx="254.80" cy="479.72" r="20.00"/>
             </g>
         </g>
         <g id="44">
@@ -868,12 +864,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180">
-                    <circle class="nad-winding" cx="33.79" cy="310.02" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30">
-                    <circle class="nad-winding" cx="15.81" cy="318.80" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180 nad-winding" cx="33.79" cy="310.02" r="20.00"/>
+                <circle class="nad-vl0to30 nad-winding" cx="15.81" cy="318.80" r="20.00"/>
             </g>
         </g>
         <g id="45">
@@ -917,12 +909,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180">
-                    <circle class="nad-winding" cx="229.46" cy="-107.90" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30">
-                    <circle class="nad-winding" cx="212.83" cy="-119.00" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180 nad-winding" cx="229.46" cy="-107.90" r="20.00"/>
+                <circle class="nad-vl0to30 nad-winding" cx="212.83" cy="-119.00" r="20.00"/>
             </g>
         </g>
         <g id="46">

--- a/network-area-diagram/src/test/resources/IEEE_14_id_prefixed.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_id_prefixed.svg
@@ -166,8 +166,8 @@
         <g id="test_28">
             <desc>L1-2-1</desc>
             <g id="test_28.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="522.21,-617.54 556.53,-452.92"/>
-                <g class="nad-edge-infos" transform="translate(528.85,-585.72)">
+                <polyline class="nad-edge-path nad-stretchable" points="522.21,-617.54 556.53,-452.92"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(528.85,-585.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(168.22)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -185,8 +185,8 @@
                 </g>
             </g>
             <g id="test_28.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="590.85,-288.31 556.53,-452.92"/>
-                <g class="nad-edge-infos" transform="translate(584.22,-320.13)">
+                <polyline class="nad-edge-path nad-stretchable" points="590.85,-288.31 556.53,-452.92"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(584.22,-320.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-11.78)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -207,8 +207,8 @@
         <g id="test_29">
             <desc>L1-5-1</desc>
             <g id="test_29.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="499.00,-624.45 371.07,-496.24"/>
-                <g class="nad-edge-infos" transform="translate(476.04,-601.44)">
+                <polyline class="nad-edge-path nad-stretchable" points="499.00,-624.45 371.07,-496.24"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(476.04,-601.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-135.06)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -226,8 +226,8 @@
                 </g>
             </g>
             <g id="test_29.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="243.15,-368.02 371.07,-496.24"/>
-                <g class="nad-edge-infos" transform="translate(266.10,-391.03)">
+                <polyline class="nad-edge-path nad-stretchable" points="243.15,-368.02 371.07,-496.24"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(266.10,-391.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(44.94)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -248,8 +248,8 @@
         <g id="test_30">
             <desc>L9-10-1</desc>
             <g id="test_30.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-48.76,421.74 -271.14,466.56"/>
-                <g class="nad-edge-infos" transform="translate(-80.62,428.16)">
+                <polyline class="nad-edge-path nad-stretchable" points="-48.76,421.74 -271.14,466.56"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-80.62,428.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-101.40)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -267,8 +267,8 @@
                 </g>
             </g>
             <g id="test_30.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-493.51,511.39 -271.14,466.56"/>
-                <g class="nad-edge-infos" transform="translate(-461.65,504.96)">
+                <polyline class="nad-edge-path nad-stretchable" points="-493.51,511.39 -271.14,466.56"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-461.65,504.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(78.60)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -289,8 +289,8 @@
         <g id="test_31">
             <desc>L10-11-1</desc>
             <g id="test_31.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-530.08,493.70 -619.73,317.52"/>
-                <g class="nad-edge-infos" transform="translate(-544.82,464.73)">
+                <polyline class="nad-edge-path nad-stretchable" points="-530.08,493.70 -619.73,317.52"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-544.82,464.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-26.97)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -308,8 +308,8 @@
                 </g>
             </g>
             <g id="test_31.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-709.39,141.34 -619.73,317.52"/>
-                <g class="nad-edge-infos" transform="translate(-694.65,170.30)">
+                <polyline class="nad-edge-path nad-stretchable" points="-709.39,141.34 -619.73,317.52"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-694.65,170.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(153.03)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -330,8 +330,8 @@
         <g id="test_32">
             <desc>L6-11-1</desc>
             <g id="test_32.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-351.70,-358.58 -528.52,-130.07"/>
-                <g class="nad-edge-infos" transform="translate(-371.59,-332.88)">
+                <polyline class="nad-edge-path nad-stretchable" points="-351.70,-358.58 -528.52,-130.07"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-371.59,-332.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-142.27)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -349,8 +349,8 @@
                 </g>
             </g>
             <g id="test_32.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-705.35,98.44 -528.52,-130.07"/>
-                <g class="nad-edge-infos" transform="translate(-685.46,72.74)">
+                <polyline class="nad-edge-path nad-stretchable" points="-705.35,98.44 -528.52,-130.07"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-685.46,72.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(37.73)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -371,8 +371,8 @@
         <g id="test_33">
             <desc>L6-12-1</desc>
             <g id="test_33.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-354.60,-396.29 -485.88,-520.79"/>
-                <g class="nad-edge-infos" transform="translate(-378.18,-418.66)">
+                <polyline class="nad-edge-path nad-stretchable" points="-354.60,-396.29 -485.88,-520.79"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-378.18,-418.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-46.52)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -390,8 +390,8 @@
                 </g>
             </g>
             <g id="test_33.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-617.16,-645.28 -485.88,-520.79"/>
-                <g class="nad-edge-infos" transform="translate(-593.57,-622.92)">
+                <polyline class="nad-edge-path nad-stretchable" points="-617.16,-645.28 -485.88,-520.79"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-593.57,-622.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(133.48)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -412,8 +412,8 @@
         <g id="test_34">
             <desc>L12-13-1</desc>
             <g id="test_34.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-635.28,-637.33 -632.92,-480.33"/>
-                <g class="nad-edge-infos" transform="translate(-634.79,-604.84)">
+                <polyline class="nad-edge-path nad-stretchable" points="-635.28,-637.33 -632.92,-480.33"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-634.79,-604.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(179.14)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -431,8 +431,8 @@
                 </g>
             </g>
             <g id="test_34.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-630.57,-323.32 -632.92,-480.33"/>
-                <g class="nad-edge-infos" transform="translate(-631.05,-355.82)">
+                <polyline class="nad-edge-path nad-stretchable" points="-630.57,-323.32 -632.92,-480.33"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-631.05,-355.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-0.86)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -453,8 +453,8 @@
         <g id="test_35">
             <desc>L6-13-1</desc>
             <g id="test_35.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-360.68,-371.98 -483.14,-338.29"/>
-                <g class="nad-edge-infos" transform="translate(-392.02,-363.36)">
+                <polyline class="nad-edge-path nad-stretchable" points="-360.68,-371.98 -483.14,-338.29"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-392.02,-363.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-105.38)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -472,8 +472,8 @@
                 </g>
             </g>
             <g id="test_35.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-605.60,-304.59 -483.14,-338.29"/>
-                <g class="nad-edge-infos" transform="translate(-574.26,-313.21)">
+                <polyline class="nad-edge-path nad-stretchable" points="-605.60,-304.59 -483.14,-338.29"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-574.26,-313.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(74.62)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -494,8 +494,8 @@
         <g id="test_36">
             <desc>L13-14-1</desc>
             <g id="test_36.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-613.96,-278.15 -469.33,-102.81"/>
-                <g class="nad-edge-infos" transform="translate(-593.28,-253.08)">
+                <polyline class="nad-edge-path nad-stretchable" points="-613.96,-278.15 -469.33,-102.81"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-593.28,-253.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(140.48)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -513,8 +513,8 @@
                 </g>
             </g>
             <g id="test_36.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-324.70,72.53 -469.33,-102.81"/>
-                <g class="nad-edge-infos" transform="translate(-345.38,47.46)">
+                <polyline class="nad-edge-path nad-stretchable" points="-324.70,72.53 -469.33,-102.81"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-345.38,47.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-39.52)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -535,8 +535,8 @@
         <g id="test_37">
             <desc>L9-14-1</desc>
             <g id="test_37.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-40.58,397.53 -166.12,254.45"/>
-                <g class="nad-edge-infos" transform="translate(-62.02,373.10)">
+                <polyline class="nad-edge-path nad-stretchable" points="-40.58,397.53 -166.12,254.45"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-62.02,373.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-41.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -554,8 +554,8 @@
                 </g>
             </g>
             <g id="test_37.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-291.66,111.37 -166.12,254.45"/>
-                <g class="nad-edge-infos" transform="translate(-270.22,135.80)">
+                <polyline class="nad-edge-path nad-stretchable" points="-291.66,111.37 -166.12,254.45"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-270.22,135.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(138.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -576,8 +576,8 @@
         <g id="test_38">
             <desc>L2-3-1</desc>
             <g id="test_38.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="612.02,-243.46 711.96,-118.97"/>
-                <g class="nad-edge-infos" transform="translate(632.36,-218.12)">
+                <polyline class="nad-edge-path nad-stretchable" points="612.02,-243.46 711.96,-118.97"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(632.36,-218.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(141.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -595,8 +595,8 @@
                 </g>
             </g>
             <g id="test_38.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="811.91,5.53 711.96,-118.97"/>
-                <g class="nad-edge-infos" transform="translate(791.57,-19.81)">
+                <polyline class="nad-edge-path nad-stretchable" points="811.91,5.53 711.96,-118.97"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(791.57,-19.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-38.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -617,8 +617,8 @@
         <g id="test_39">
             <desc>L2-4-1</desc>
             <g id="test_39.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="584.80,-240.46 501.00,-69.99"/>
-                <g class="nad-edge-infos" transform="translate(570.47,-211.30)">
+                <polyline class="nad-edge-path nad-stretchable" points="584.80,-240.46 501.00,-69.99"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(570.47,-211.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-153.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -636,8 +636,8 @@
                 </g>
             </g>
             <g id="test_39.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="417.20,100.49 501.00,-69.99"/>
-                <g class="nad-edge-infos" transform="translate(431.54,71.32)">
+                <polyline class="nad-edge-path nad-stretchable" points="417.20,100.49 501.00,-69.99"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(431.54,71.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(26.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -658,8 +658,8 @@
         <g id="test_40">
             <desc>L2-5-1</desc>
             <g id="test_40.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="571.22,-269.15 410.59,-306.66"/>
-                <g class="nad-edge-infos" transform="translate(539.57,-276.54)">
+                <polyline class="nad-edge-path nad-stretchable" points="571.22,-269.15 410.59,-306.66"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(539.57,-276.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-76.85)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -677,8 +677,8 @@
                 </g>
             </g>
             <g id="test_40.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="249.97,-344.17 410.59,-306.66"/>
-                <g class="nad-edge-infos" transform="translate(281.62,-336.78)">
+                <polyline class="nad-edge-path nad-stretchable" points="249.97,-344.17 410.59,-306.66"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(281.62,-336.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(103.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -699,8 +699,8 @@
         <g id="test_41">
             <desc>L3-4-1</desc>
             <g id="test_41.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="803.04,31.18 616.91,74.40"/>
-                <g class="nad-edge-infos" transform="translate(771.38,38.53)">
+                <polyline class="nad-edge-path nad-stretchable" points="803.04,31.18 616.91,74.40"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(771.38,38.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-103.07)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -718,8 +718,8 @@
                 </g>
             </g>
             <g id="test_41.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="430.79,117.61 616.91,74.40"/>
-                <g class="nad-edge-infos" transform="translate(462.45,110.26)">
+                <polyline class="nad-edge-path nad-stretchable" points="430.79,117.61 616.91,74.40"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(462.45,110.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(76.93)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -740,8 +740,8 @@
         <g id="test_42">
             <desc>L4-5-1</desc>
             <g id="test_42.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="396.85,99.55 315.54,-113.30"/>
-                <g class="nad-edge-infos" transform="translate(385.26,69.19)">
+                <polyline class="nad-edge-path nad-stretchable" points="396.85,99.55 315.54,-113.30"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(385.26,69.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-20.91)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -759,8 +759,8 @@
                 </g>
             </g>
             <g id="test_42.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="234.24,-326.15 315.54,-113.30"/>
-                <g class="nad-edge-infos" transform="translate(245.83,-295.79)">
+                <polyline class="nad-edge-path nad-stretchable" points="234.24,-326.15 315.54,-113.30"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(245.83,-295.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(159.09)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -781,8 +781,8 @@
         <g id="test_43">
             <desc>T4-7-1</desc>
             <g id="test_43.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="403.98,148.80 389.82,331.64"/>
-                <g class="nad-edge-infos" transform="translate(401.47,181.20)">
+                <polyline class="nad-edge-path nad-stretchable" points="403.98,148.80 389.82,331.64"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(401.47,181.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-175.57)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -798,11 +798,10 @@
                         <text transform="rotate(-85.57)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="388.28" cy="351.58" r="20.00"/>
             </g>
             <g id="test_43.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="371.03,574.29 385.19,391.46"/>
-                <g class="nad-edge-infos" transform="translate(373.54,541.89)">
+                <polyline class="nad-edge-path nad-stretchable" points="371.03,574.29 385.19,391.46"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(373.54,541.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(4.43)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -818,14 +817,21 @@
                         <text transform="rotate(-85.57)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="386.73" cy="371.52" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180">
+                    <circle class="nad-winding" cx="388.28" cy="351.58" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30">
+                    <circle class="nad-winding" cx="386.73" cy="371.52" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="test_44">
             <desc>T4-9-1</desc>
             <g id="test_44.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="384.89,137.75 215.87,253.12"/>
-                <g class="nad-edge-infos" transform="translate(358.05,156.07)">
+                <polyline class="nad-edge-path nad-stretchable" points="384.89,137.75 215.87,253.12"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(358.05,156.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-124.32)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -841,11 +847,10 @@
                         <text transform="rotate(-34.32)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="199.35" cy="264.40" r="20.00"/>
             </g>
             <g id="test_44.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-2.70,402.32 166.32,286.95"/>
-                <g class="nad-edge-infos" transform="translate(24.14,384.00)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2.70,402.32 166.32,286.95"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(24.14,384.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(55.68)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -861,14 +866,21 @@
                         <text transform="rotate(-34.32)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="182.84" cy="275.68" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180">
+                    <circle class="nad-winding" cx="199.35" cy="264.40" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30">
+                    <circle class="nad-winding" cx="182.84" cy="275.68" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="test_45">
             <desc>T5-6-1</desc>
             <g id="test_45.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="199.67,-351.28 -25.52,-362.82"/>
-                <g class="nad-edge-infos" transform="translate(167.21,-352.94)">
+                <polyline class="nad-edge-path nad-stretchable" points="199.67,-351.28 -25.52,-362.82"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(167.21,-352.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-87.06)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -884,11 +896,10 @@
                         <text transform="rotate(-357.06)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-45.49" cy="-363.85" r="20.00"/>
             </g>
             <g id="test_45.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-310.63,-377.44 -85.44,-365.90"/>
-                <g class="nad-edge-infos" transform="translate(-278.17,-375.78)">
+                <polyline class="nad-edge-path nad-stretchable" points="-310.63,-377.44 -85.44,-365.90"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-278.17,-375.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(92.94)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -904,14 +915,21 @@
                         <text transform="rotate(2.94)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-65.47" cy="-364.87" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180">
+                    <circle class="nad-winding" cx="-45.49" cy="-363.85" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30">
+                    <circle class="nad-winding" cx="-65.47" cy="-364.87" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="test_46">
             <desc>L7-8-1</desc>
             <g id="test_46.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="381.02,622.24 468.84,787.59"/>
-                <g class="nad-edge-infos" transform="translate(396.27,650.94)">
+                <polyline class="nad-edge-path nad-stretchable" points="381.02,622.24 468.84,787.59"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(396.27,650.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(152.03)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -929,8 +947,8 @@
                 </g>
             </g>
             <g id="test_46.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="556.67,952.94 468.84,787.59"/>
-                <g class="nad-edge-infos" transform="translate(541.42,924.23)">
+                <polyline class="nad-edge-path nad-stretchable" points="556.67,952.94 468.84,787.59"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(541.42,924.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-27.97)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -951,8 +969,8 @@
         <g id="test_47">
             <desc>L7-9-1</desc>
             <g id="test_47.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="345.94,588.95 172.65,508.21"/>
-                <g class="nad-edge-infos" transform="translate(316.48,575.22)">
+                <polyline class="nad-edge-path nad-stretchable" points="345.94,588.95 172.65,508.21"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(316.48,575.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-65.02)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -970,8 +988,8 @@
                 </g>
             </g>
             <g id="test_47.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-0.65,427.47 172.65,508.21"/>
-                <g class="nad-edge-infos" transform="translate(28.81,441.19)">
+                <polyline class="nad-edge-path nad-stretchable" points="-0.65,427.47 172.65,508.21"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(28.81,441.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(114.98)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/IEEE_14_id_prefixed.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_id_prefixed.svg
@@ -819,12 +819,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180">
-                    <circle class="nad-winding" cx="388.28" cy="351.58" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30">
-                    <circle class="nad-winding" cx="386.73" cy="371.52" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180 nad-winding" cx="388.28" cy="351.58" r="20.00"/>
+                <circle class="nad-vl0to30 nad-winding" cx="386.73" cy="371.52" r="20.00"/>
             </g>
         </g>
         <g id="test_44">
@@ -868,12 +864,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180">
-                    <circle class="nad-winding" cx="199.35" cy="264.40" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30">
-                    <circle class="nad-winding" cx="182.84" cy="275.68" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180 nad-winding" cx="199.35" cy="264.40" r="20.00"/>
+                <circle class="nad-vl0to30 nad-winding" cx="182.84" cy="275.68" r="20.00"/>
             </g>
         </g>
         <g id="test_45">
@@ -917,12 +909,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180">
-                    <circle class="nad-winding" cx="-45.49" cy="-363.85" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30">
-                    <circle class="nad-winding" cx="-65.47" cy="-364.87" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180 nad-winding" cx="-45.49" cy="-363.85" r="20.00"/>
+                <circle class="nad-vl0to30 nad-winding" cx="-65.47" cy="-364.87" r="20.00"/>
             </g>
         </g>
         <g id="test_46">

--- a/network-area-diagram/src/test/resources/IEEE_24_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_24_bus.svg
@@ -487,12 +487,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180">
-                    <circle class="nad-winding" cx="-841.37" cy="695.48" r="20.00"/>
-                </g>
-                <g class="nad-vl120to180">
-                    <circle class="nad-winding" cx="-821.37" cy="695.32" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180 nad-winding" cx="-841.37" cy="695.48" r="20.00"/>
+                <circle class="nad-vl120to180 nad-winding" cx="-821.37" cy="695.32" r="20.00"/>
             </g>
         </g>
         <g id="54">
@@ -536,12 +532,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl180to300">
-                    <circle class="nad-winding" cx="-213.35" cy="672.03" r="20.00"/>
-                </g>
-                <g class="nad-vl120to180">
-                    <circle class="nad-winding" cx="-233.30" cy="673.50" r="20.00"/>
-                </g>
+                <circle class="nad-vl180to300 nad-winding" cx="-213.35" cy="672.03" r="20.00"/>
+                <circle class="nad-vl120to180 nad-winding" cx="-233.30" cy="673.50" r="20.00"/>
             </g>
         </g>
         <g id="55">
@@ -585,12 +577,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl180to300">
-                    <circle class="nad-winding" cx="-320.15" cy="503.08" r="20.00"/>
-                </g>
-                <g class="nad-vl120to180">
-                    <circle class="nad-winding" cx="-333.65" cy="517.84" r="20.00"/>
-                </g>
+                <circle class="nad-vl180to300 nad-winding" cx="-320.15" cy="503.08" r="20.00"/>
+                <circle class="nad-vl120to180 nad-winding" cx="-333.65" cy="517.84" r="20.00"/>
             </g>
         </g>
         <g id="56">
@@ -716,12 +704,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl180to300">
-                    <circle class="nad-winding" cx="-206.44" cy="517.55" r="20.00"/>
-                </g>
-                <g class="nad-vl120to180">
-                    <circle class="nad-winding" cx="-224.08" cy="508.13" r="20.00"/>
-                </g>
+                <circle class="nad-vl180to300 nad-winding" cx="-206.44" cy="517.55" r="20.00"/>
+                <circle class="nad-vl120to180 nad-winding" cx="-224.08" cy="508.13" r="20.00"/>
             </g>
         </g>
         <g id="59">
@@ -847,12 +831,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180">
-                    <circle class="nad-winding" cx="-328.74" cy="351.93" r="20.00"/>
-                </g>
-                <g class="nad-vl180to300">
-                    <circle class="nad-winding" cx="-308.94" cy="349.14" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180 nad-winding" cx="-328.74" cy="351.93" r="20.00"/>
+                <circle class="nad-vl180to300 nad-winding" cx="-308.94" cy="349.14" r="20.00"/>
             </g>
         </g>
         <g id="62">
@@ -1675,12 +1655,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl180to300">
-                    <circle class="nad-winding" cx="-68.28" cy="-180.69" r="20.00"/>
-                </g>
-                <g class="nad-vl120to180">
-                    <circle class="nad-winding" cx="-86.90" cy="-173.39" r="20.00"/>
-                </g>
+                <circle class="nad-vl180to300 nad-winding" cx="-68.28" cy="-180.69" r="20.00"/>
+                <circle class="nad-vl120to180 nad-winding" cx="-86.90" cy="-173.39" r="20.00"/>
             </g>
         </g>
         <g id="82">

--- a/network-area-diagram/src/test/resources/IEEE_24_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_24_bus.svg
@@ -244,8 +244,8 @@
         <g id="48">
             <desc>L-1-2-1 </desc>
             <g id="48.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-962.77,506.17 -969.83,784.96"/>
-                <g class="nad-edge-infos" transform="translate(-963.59,538.66)">
+                <polyline class="nad-edge-path nad-stretchable" points="-962.77,506.17 -969.83,784.96"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-963.59,538.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-178.55)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -263,8 +263,8 @@
                 </g>
             </g>
             <g id="48.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-976.89,1063.75 -969.83,784.96"/>
-                <g class="nad-edge-infos" transform="translate(-976.06,1031.26)">
+                <polyline class="nad-edge-path nad-stretchable" points="-976.89,1063.75 -969.83,784.96"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-976.06,1031.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(1.45)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -285,8 +285,8 @@
         <g id="49">
             <desc>L-3-1-1 </desc>
             <g id="49.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-457.58,-17.26 -700.78,222.75"/>
-                <g class="nad-edge-infos" transform="translate(-480.72,5.57)">
+                <polyline class="nad-edge-path nad-stretchable" points="-457.58,-17.26 -700.78,222.75"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-480.72,5.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-134.62)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -304,8 +304,8 @@
                 </g>
             </g>
             <g id="49.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-943.98,462.77 -700.78,222.75"/>
-                <g class="nad-edge-infos" transform="translate(-920.84,439.94)">
+                <polyline class="nad-edge-path nad-stretchable" points="-943.98,462.77 -700.78,222.75"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-920.84,439.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(45.38)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -326,8 +326,8 @@
         <g id="50">
             <desc>L-1-5-1 </desc>
             <g id="50.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-979.71,499.15 -1065.61,589.38"/>
-                <g class="nad-edge-infos" transform="translate(-1002.12,522.69)">
+                <polyline class="nad-edge-path nad-stretchable" points="-979.71,499.15 -1065.61,589.38"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1002.12,522.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-136.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -345,8 +345,8 @@
                 </g>
             </g>
             <g id="50.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-1151.52,679.60 -1065.61,589.38"/>
-                <g class="nad-edge-infos" transform="translate(-1129.11,656.07)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1151.52,679.60 -1065.61,589.38"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1129.11,656.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(43.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -367,8 +367,8 @@
         <g id="51">
             <desc>L-10-6-1 </desc>
             <g id="51.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-498.14,717.83 -542.81,966.85"/>
-                <g class="nad-edge-infos" transform="translate(-503.88,749.82)">
+                <polyline class="nad-edge-path nad-stretchable" points="-498.14,717.83 -542.81,966.85"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-503.88,749.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-169.83)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -386,8 +386,8 @@
                 </g>
             </g>
             <g id="51.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-587.48,1215.86 -542.81,966.85"/>
-                <g class="nad-edge-infos" transform="translate(-581.75,1183.87)">
+                <polyline class="nad-edge-path nad-stretchable" points="-587.48,1215.86 -542.81,966.85"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-581.75,1183.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(10.17)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -408,8 +408,8 @@
         <g id="52">
             <desc>L-8-10-1 </desc>
             <g id="52.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="-832.66,147.96 -669.89,409.52"/>
-                <g class="nad-edge-infos" transform="translate(-815.49,175.55)">
+                <polyline class="nad-edge-path nad-stretchable" points="-832.66,147.96 -669.89,409.52"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-815.49,175.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(148.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -427,8 +427,8 @@
                 </g>
             </g>
             <g id="52.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-507.11,671.09 -669.89,409.52"/>
-                <g class="nad-edge-infos" transform="translate(-524.28,643.49)">
+                <polyline class="nad-edge-path nad-stretchable" points="-507.11,671.09 -669.89,409.52"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-524.28,643.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-31.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -449,8 +449,8 @@
         <g id="53">
             <desc>T-5-10-1 </desc>
             <g id="53.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-1143.60,697.87 -861.37,695.64"/>
-                <g class="nad-edge-infos" transform="translate(-1111.11,697.61)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1143.60,697.87 -861.37,695.64"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1111.11,697.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(89.55)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -466,11 +466,10 @@
                         <text transform="rotate(-0.45)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-841.37" cy="695.48" r="20.00"/>
             </g>
             <g id="53.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-519.14,692.94 -801.37,695.17"/>
-                <g class="nad-edge-infos" transform="translate(-551.64,693.19)">
+                <polyline class="nad-edge-path nad-stretchable" points="-519.14,692.94 -801.37,695.17"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-551.64,693.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-90.45)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -486,14 +485,21 @@
                         <text transform="rotate(-0.45)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-821.37" cy="695.32" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180">
+                    <circle class="nad-winding" cx="-841.37" cy="695.48" r="20.00"/>
+                </g>
+                <g class="nad-vl120to180">
+                    <circle class="nad-winding" cx="-821.37" cy="695.32" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="54">
             <desc>T-11-10-1 </desc>
             <g id="54.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="21.56,654.67 -193.40,670.55"/>
-                <g class="nad-edge-infos" transform="translate(-10.85,657.07)">
+                <polyline class="nad-edge-path nad-stretchable" points="21.56,654.67 -193.40,670.55"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-10.85,657.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-94.23)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -509,11 +515,10 @@
                         <text transform="rotate(-4.23)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-213.35" cy="672.03" r="20.00"/>
             </g>
             <g id="54.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-468.21,690.86 -253.24,674.97"/>
-                <g class="nad-edge-infos" transform="translate(-435.80,688.46)">
+                <polyline class="nad-edge-path nad-stretchable" points="-468.21,690.86 -253.24,674.97"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-435.80,688.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(85.77)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -529,14 +534,21 @@
                         <text transform="rotate(-4.23)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-233.30" cy="673.50" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl180to300">
+                    <circle class="nad-winding" cx="-213.35" cy="672.03" r="20.00"/>
+                </g>
+                <g class="nad-vl120to180">
+                    <circle class="nad-winding" cx="-233.30" cy="673.50" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="55">
             <desc>T-12-10-1 </desc>
             <g id="55.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="-177.38,347.00 -306.65,488.32"/>
-                <g class="nad-edge-infos" transform="translate(-199.31,370.98)">
+                <polyline class="nad-edge-path nad-stretchable" points="-177.38,347.00 -306.65,488.32"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-199.31,370.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-137.55)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -552,11 +564,10 @@
                         <text transform="rotate(-47.55)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-320.15" cy="503.08" r="20.00"/>
             </g>
             <g id="55.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-476.43,673.92 -347.15,532.59"/>
-                <g class="nad-edge-infos" transform="translate(-454.49,649.94)">
+                <polyline class="nad-edge-path nad-stretchable" points="-476.43,673.92 -347.15,532.59"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-454.49,649.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(42.45)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -572,14 +583,21 @@
                         <text transform="rotate(-47.55)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-333.65" cy="517.84" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl180to300">
+                    <circle class="nad-winding" cx="-320.15" cy="503.08" r="20.00"/>
+                </g>
+                <g class="nad-vl120to180">
+                    <circle class="nad-winding" cx="-333.65" cy="517.84" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="56">
             <desc>L-11-13-1 </desc>
             <g id="56.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="56.48,629.12 113.64,486.40"/>
-                <g class="nad-edge-infos" transform="translate(68.56,598.95)">
+                <polyline class="nad-edge-path nad-stretchable" points="56.48,629.12 113.64,486.40"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(68.56,598.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(21.83)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -597,8 +615,8 @@
                 </g>
             </g>
             <g id="56.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="170.80,343.68 113.64,486.40"/>
-                <g class="nad-edge-infos" transform="translate(158.71,373.85)">
+                <polyline class="nad-edge-path nad-stretchable" points="170.80,343.68 113.64,486.40"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(158.71,373.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-158.17)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -619,8 +637,8 @@
         <g id="57">
             <desc>L-11-14-1 </desc>
             <g id="57.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="70.85,643.78 345.64,539.97"/>
-                <g class="nad-edge-infos" transform="translate(101.25,632.30)">
+                <polyline class="nad-edge-path nad-stretchable" points="70.85,643.78 345.64,539.97"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(101.25,632.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(69.31)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -638,8 +656,8 @@
                 </g>
             </g>
             <g id="57.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="620.44,436.17 345.64,539.97"/>
-                <g class="nad-edge-infos" transform="translate(590.04,447.65)">
+                <polyline class="nad-edge-path nad-stretchable" points="620.44,436.17 345.64,539.97"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(590.04,447.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-110.69)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -660,8 +678,8 @@
         <g id="58">
             <desc>T-11-9-1 </desc>
             <g id="58.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="24.50,640.79 -188.79,526.96"/>
-                <g class="nad-edge-infos" transform="translate(-4.18,625.49)">
+                <polyline class="nad-edge-path nad-stretchable" points="24.50,640.79 -188.79,526.96"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-4.18,625.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-61.91)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -677,11 +695,10 @@
                         <text transform="rotate(-331.91)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-206.44" cy="517.55" r="20.00"/>
             </g>
             <g id="58.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-455.02,384.89 -241.73,498.72"/>
-                <g class="nad-edge-infos" transform="translate(-426.35,400.19)">
+                <polyline class="nad-edge-path nad-stretchable" points="-455.02,384.89 -241.73,498.72"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-426.35,400.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(118.09)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -697,14 +714,21 @@
                         <text transform="rotate(28.09)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-224.08" cy="508.13" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl180to300">
+                    <circle class="nad-winding" cx="-206.44" cy="517.55" r="20.00"/>
+                </g>
+                <g class="nad-vl120to180">
+                    <circle class="nad-winding" cx="-224.08" cy="508.13" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="59">
             <desc>L-12-13-1 </desc>
             <g id="59.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="-134.67,327.57 10.06,324.09"/>
-                <g class="nad-edge-infos" transform="translate(-102.18,326.79)">
+                <polyline class="nad-edge-path nad-stretchable" points="-134.67,327.57 10.06,324.09"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-102.18,326.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(88.62)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -722,8 +746,8 @@
                 </g>
             </g>
             <g id="59.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="154.78,320.62 10.06,324.09"/>
-                <g class="nad-edge-infos" transform="translate(122.29,321.40)">
+                <polyline class="nad-edge-path nad-stretchable" points="154.78,320.62 10.06,324.09"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(122.29,321.40)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-91.38)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -744,8 +768,8 @@
         <g id="60">
             <desc>L-12-23-1 </desc>
             <g id="60.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="-150.34,304.65 -73.41,120.39"/>
-                <g class="nad-edge-infos" transform="translate(-137.82,274.66)">
+                <polyline class="nad-edge-path nad-stretchable" points="-150.34,304.65 -73.41,120.39"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-137.82,274.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(22.66)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -763,8 +787,8 @@
                 </g>
             </g>
             <g id="60.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="3.53,-63.87 -73.41,120.39"/>
-                <g class="nad-edge-infos" transform="translate(-9.00,-33.88)">
+                <polyline class="nad-edge-path nad-stretchable" points="3.53,-63.87 -73.41,120.39"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-9.00,-33.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-157.34)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -785,8 +809,8 @@
         <g id="61">
             <desc>T-9-12-1 </desc>
             <g id="61.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-452.27,369.33 -348.55,354.72"/>
-                <g class="nad-edge-infos" transform="translate(-420.08,364.80)">
+                <polyline class="nad-edge-path nad-stretchable" points="-452.27,369.33 -348.55,354.72"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-420.08,364.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(81.98)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -802,11 +826,10 @@
                         <text transform="rotate(-8.02)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-328.74" cy="351.93" r="20.00"/>
             </g>
             <g id="61.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="-185.42,331.74 -289.13,346.35"/>
-                <g class="nad-edge-infos" transform="translate(-217.60,336.27)">
+                <polyline class="nad-edge-path nad-stretchable" points="-185.42,331.74 -289.13,346.35"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-217.60,336.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-98.02)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -822,14 +845,21 @@
                         <text transform="rotate(-8.02)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-308.94" cy="349.14" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180">
+                    <circle class="nad-winding" cx="-328.74" cy="351.93" r="20.00"/>
+                </g>
+                <g class="nad-vl180to300">
+                    <circle class="nad-winding" cx="-308.94" cy="349.14" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="62">
             <desc>L-23-13-1 </desc>
             <g id="62.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="23.02,-63.80 96.81,116.30"/>
-                <g class="nad-edge-infos" transform="translate(35.34,-33.73)">
+                <polyline class="nad-edge-path nad-stretchable" points="23.02,-63.80 96.81,116.30"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(35.34,-33.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(157.72)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -847,8 +877,8 @@
                 </g>
             </g>
             <g id="62.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="170.61,296.41 96.81,116.30"/>
-                <g class="nad-edge-infos" transform="translate(158.29,266.34)">
+                <polyline class="nad-edge-path nad-stretchable" points="170.61,296.41 96.81,116.30"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(158.29,266.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-22.28)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -869,8 +899,8 @@
         <g id="63">
             <desc>L-14-16-1 </desc>
             <g id="63.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="654.05,403.59 758.13,152.23"/>
-                <g class="nad-edge-infos" transform="translate(666.48,373.57)">
+                <polyline class="nad-edge-path nad-stretchable" points="654.05,403.59 758.13,152.23"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(666.48,373.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(22.49)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -888,8 +918,8 @@
                 </g>
             </g>
             <g id="63.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="862.21,-99.14 758.13,152.23"/>
-                <g class="nad-edge-infos" transform="translate(849.77,-69.11)">
+                <polyline class="nad-edge-path nad-stretchable" points="862.21,-99.14 758.13,152.23"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(849.77,-69.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-157.51)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -910,8 +940,8 @@
         <g id="64">
             <desc>L-16-15-1 </desc>
             <g id="64.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="872.49,-148.20 875.93,-313.74"/>
-                <g class="nad-edge-infos" transform="translate(873.16,-180.69)">
+                <polyline class="nad-edge-path nad-stretchable" points="872.49,-148.20 875.93,-313.74"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(873.16,-180.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(1.19)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -929,8 +959,8 @@
                 </g>
             </g>
             <g id="64.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="879.36,-479.29 875.93,-313.74"/>
-                <g class="nad-edge-infos" transform="translate(878.69,-446.79)">
+                <polyline class="nad-edge-path nad-stretchable" points="879.36,-479.29 875.93,-313.74"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(878.69,-446.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-178.81)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -951,8 +981,8 @@
         <g id="65">
             <desc>L-15-21-1 </desc>
             <g id="65.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="904.96,-500.10 958.53,-490.10 1142.95,-555.13"/>
-                <g class="nad-edge-infos" transform="translate(986.83,-500.08)">
+                <polyline class="nad-edge-path nad-stretchable" points="904.96,-500.10 958.53,-490.10 1142.95,-555.13"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(986.83,-500.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(70.57)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -970,8 +1000,8 @@
                 </g>
             </g>
             <g id="65.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="1362.81,-661.56 1327.36,-620.17 1142.95,-555.13"/>
-                <g class="nad-edge-infos" transform="translate(1299.07,-610.19)">
+                <polyline class="nad-edge-path nad-stretchable" points="1362.81,-661.56 1327.36,-620.17 1142.95,-555.13"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1299.07,-610.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-109.43)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -992,8 +1022,8 @@
         <g id="66">
             <desc>L-21-15-2 </desc>
             <g id="66.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="1354.33,-685.61 1300.76,-695.61 1116.34,-630.58"/>
-                <g class="nad-edge-infos" transform="translate(1272.46,-685.64)">
+                <polyline class="nad-edge-path nad-stretchable" points="1354.33,-685.61 1300.76,-695.61 1116.34,-630.58"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1272.46,-685.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-109.43)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1011,8 +1041,8 @@
                 </g>
             </g>
             <g id="66.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="896.48,-524.15 931.93,-565.54 1116.34,-630.58"/>
-                <g class="nad-edge-infos" transform="translate(960.22,-575.52)">
+                <polyline class="nad-edge-path nad-stretchable" points="896.48,-524.15 931.93,-565.54 1116.34,-630.58"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(960.22,-575.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(70.57)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1033,8 +1063,8 @@
         <g id="67">
             <desc>L-15-24-1 </desc>
             <g id="67.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="855.55,-497.18 582.08,-411.85"/>
-                <g class="nad-edge-infos" transform="translate(824.52,-487.50)">
+                <polyline class="nad-edge-path nad-stretchable" points="855.55,-497.18 582.08,-411.85"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(824.52,-487.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-107.33)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1052,8 +1082,8 @@
                 </g>
             </g>
             <g id="67.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="308.60,-326.51 582.08,-411.85"/>
-                <g class="nad-edge-infos" transform="translate(339.63,-336.19)">
+                <polyline class="nad-edge-path nad-stretchable" points="308.60,-326.51 582.08,-411.85"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(339.63,-336.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(72.67)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1074,8 +1104,8 @@
         <g id="68">
             <desc>L-16-17-1 </desc>
             <g id="68.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="897.27,-119.58 1135.31,-90.23"/>
-                <g class="nad-edge-infos" transform="translate(929.52,-115.61)">
+                <polyline class="nad-edge-path nad-stretchable" points="897.27,-119.58 1135.31,-90.23"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(929.52,-115.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(97.03)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1093,8 +1123,8 @@
                 </g>
             </g>
             <g id="68.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="1373.34,-60.88 1135.31,-90.23"/>
-                <g class="nad-edge-infos" transform="translate(1341.09,-64.86)">
+                <polyline class="nad-edge-path nad-stretchable" points="1373.34,-60.88 1135.31,-90.23"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1341.09,-64.86)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-82.97)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1115,8 +1145,8 @@
         <g id="69">
             <desc>L-16-19-1 </desc>
             <g id="69.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="857.67,-143.83 688.76,-393.57"/>
-                <g class="nad-edge-infos" transform="translate(839.47,-170.75)">
+                <polyline class="nad-edge-path nad-stretchable" points="857.67,-143.83 688.76,-393.57"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(839.47,-170.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-34.07)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1134,8 +1164,8 @@
                 </g>
             </g>
             <g id="69.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="519.85,-643.31 688.76,-393.57"/>
-                <g class="nad-edge-infos" transform="translate(538.06,-616.39)">
+                <polyline class="nad-edge-path nad-stretchable" points="519.85,-643.31 688.76,-393.57"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(538.06,-616.39)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(145.93)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1156,8 +1186,8 @@
         <g id="70">
             <desc>L-17-18-1 </desc>
             <g id="70.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="1400.74,-83.17 1411.84,-218.72"/>
-                <g class="nad-edge-infos" transform="translate(1403.39,-115.56)">
+                <polyline class="nad-edge-path nad-stretchable" points="1400.74,-83.17 1411.84,-218.72"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1403.39,-115.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(4.68)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1175,8 +1205,8 @@
                 </g>
             </g>
             <g id="70.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="1422.95,-354.28 1411.84,-218.72"/>
-                <g class="nad-edge-infos" transform="translate(1420.30,-321.88)">
+                <polyline class="nad-edge-path nad-stretchable" points="1422.95,-354.28 1411.84,-218.72"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1420.30,-321.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-175.32)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1197,8 +1227,8 @@
         <g id="71">
             <desc>L-17-22-1 </desc>
             <g id="71.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="1418.09,-74.26 1576.36,-208.63"/>
-                <g class="nad-edge-infos" transform="translate(1442.87,-95.30)">
+                <polyline class="nad-edge-path nad-stretchable" points="1418.09,-74.26 1576.36,-208.63"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1442.87,-95.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(49.67)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1216,8 +1246,8 @@
                 </g>
             </g>
             <g id="71.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="1734.63,-343.00 1576.36,-208.63"/>
-                <g class="nad-edge-infos" transform="translate(1709.86,-321.97)">
+                <polyline class="nad-edge-path nad-stretchable" points="1734.63,-343.00 1576.36,-208.63"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1709.86,-321.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-130.33)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1238,8 +1268,8 @@
         <g id="72">
             <desc>L-18-21-1 </desc>
             <g id="72.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="1434.33,-403.43 1454.20,-454.18 1441.76,-536.30"/>
-                <g class="nad-edge-infos" transform="translate(1449.71,-483.84)">
+                <polyline class="nad-edge-path nad-stretchable" points="1434.33,-403.43 1454.20,-454.18 1441.76,-536.30"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1449.71,-483.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-8.61)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1257,8 +1287,8 @@
                 </g>
             </g>
             <g id="72.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="1395.31,-661.01 1429.32,-618.42 1441.76,-536.30"/>
-                <g class="nad-edge-infos" transform="translate(1433.82,-588.76)">
+                <polyline class="nad-edge-path nad-stretchable" points="1395.31,-661.01 1429.32,-618.42 1441.76,-536.30"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1433.82,-588.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(171.39)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1279,8 +1309,8 @@
         <g id="73">
             <desc>L-18-21-2 </desc>
             <g id="73.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="1409.12,-399.62 1375.11,-442.20 1362.67,-524.32"/>
-                <g class="nad-edge-infos" transform="translate(1370.61,-471.86)">
+                <polyline class="nad-edge-path nad-stretchable" points="1409.12,-399.62 1375.11,-442.20 1362.67,-524.32"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1370.61,-471.86)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-8.61)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1298,8 +1328,8 @@
                 </g>
             </g>
             <g id="73.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="1370.10,-657.19 1350.23,-606.44 1362.67,-524.32"/>
-                <g class="nad-edge-infos" transform="translate(1354.72,-576.78)">
+                <polyline class="nad-edge-path nad-stretchable" points="1370.10,-657.19 1350.23,-606.44 1362.67,-524.32"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1354.72,-576.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(171.39)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1320,8 +1350,8 @@
         <g id="74">
             <desc>L-19-20-1 </desc>
             <g id="74.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="483.09,-676.47 435.04,-702.19 283.62,-697.34"/>
-                <g class="nad-edge-infos" transform="translate(405.05,-701.23)">
+                <polyline class="nad-edge-path nad-stretchable" points="483.09,-676.47 435.04,-702.19 283.62,-697.34"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(405.05,-701.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-91.84)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1339,8 +1369,8 @@
                 </g>
             </g>
             <g id="74.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="85.91,-663.73 132.21,-692.48 283.62,-697.34"/>
-                <g class="nad-edge-infos" transform="translate(162.20,-693.44)">
+                <polyline class="nad-edge-path nad-stretchable" points="85.91,-663.73 132.21,-692.48 283.62,-697.34"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(162.20,-693.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(88.16)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1361,8 +1391,8 @@
         <g id="75">
             <desc>L-19-20-2 </desc>
             <g id="75.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="483.91,-650.99 437.60,-622.24 286.19,-617.38"/>
-                <g class="nad-edge-infos" transform="translate(407.62,-621.27)">
+                <polyline class="nad-edge-path nad-stretchable" points="483.91,-650.99 437.60,-622.24 286.19,-617.38"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(407.62,-621.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-91.84)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1380,8 +1410,8 @@
                 </g>
             </g>
             <g id="75.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="86.73,-638.24 134.78,-612.52 286.19,-617.38"/>
-                <g class="nad-edge-infos" transform="translate(164.76,-613.48)">
+                <polyline class="nad-edge-path nad-stretchable" points="86.73,-638.24 134.78,-612.52 286.19,-617.38"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(164.76,-613.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(88.16)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1402,8 +1432,8 @@
         <g id="76">
             <desc>L-2-4-1 </desc>
             <g id="76.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-959.46,1071.25 -865.04,977.27"/>
-                <g class="nad-edge-infos" transform="translate(-936.42,1048.32)">
+                <polyline class="nad-edge-path nad-stretchable" points="-959.46,1071.25 -865.04,977.27"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-936.42,1048.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(45.13)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1421,8 +1451,8 @@
                 </g>
             </g>
             <g id="76.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-770.63,883.29 -865.04,977.27"/>
-                <g class="nad-edge-infos" transform="translate(-793.66,906.22)">
+                <polyline class="nad-edge-path nad-stretchable" points="-770.63,883.29 -865.04,977.27"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-793.66,906.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-134.87)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1443,8 +1473,8 @@
         <g id="77">
             <desc>L-2-6-1 </desc>
             <g id="77.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-953.80,1098.58 -784.76,1165.10"/>
-                <g class="nad-edge-infos" transform="translate(-923.56,1110.48)">
+                <polyline class="nad-edge-path nad-stretchable" points="-953.80,1098.58 -784.76,1165.10"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-923.56,1110.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(111.48)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1462,8 +1492,8 @@
                 </g>
             </g>
             <g id="77.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-615.72,1231.62 -784.76,1165.10"/>
-                <g class="nad-edge-infos" transform="translate(-645.96,1219.72)">
+                <polyline class="nad-edge-path nad-stretchable" points="-615.72,1231.62 -784.76,1165.10"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-645.96,1219.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-68.52)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1484,8 +1514,8 @@
         <g id="78">
             <desc>L-20-23-1 </desc>
             <g id="78.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="49.56,-629.43 18.17,-584.88 -1.04,-372.44"/>
-                <g class="nad-edge-infos" transform="translate(15.47,-555.00)">
+                <polyline class="nad-edge-path nad-stretchable" points="49.56,-629.43 18.17,-584.88 -1.04,-372.44"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(15.47,-555.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-174.83)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1503,8 +1533,8 @@
                 </g>
             </g>
             <g id="78.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="2.64,-110.54 -20.25,-160.00 -1.04,-372.44"/>
-                <g class="nad-edge-infos" transform="translate(-17.54,-189.88)">
+                <polyline class="nad-edge-path nad-stretchable" points="2.64,-110.54 -20.25,-160.00 -1.04,-372.44"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-17.54,-189.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(5.17)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1525,8 +1555,8 @@
         <g id="79">
             <desc>L-20-23-2 </desc>
             <g id="79.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="74.96,-627.14 97.85,-577.68 78.64,-365.24"/>
-                <g class="nad-edge-infos" transform="translate(95.14,-547.80)">
+                <polyline class="nad-edge-path nad-stretchable" points="74.96,-627.14 97.85,-577.68 78.64,-365.24"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(95.14,-547.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-174.83)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1544,8 +1574,8 @@
                 </g>
             </g>
             <g id="79.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="28.04,-108.25 59.43,-152.80 78.64,-365.24"/>
-                <g class="nad-edge-infos" transform="translate(62.13,-182.68)">
+                <polyline class="nad-edge-path nad-stretchable" points="28.04,-108.25 59.43,-152.80 78.64,-365.24"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(62.13,-182.68)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(5.17)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1566,8 +1596,8 @@
         <g id="80">
             <desc>L-21-22-1 </desc>
             <g id="80.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="1398.75,-664.33 1566.74,-520.22"/>
-                <g class="nad-edge-infos" transform="translate(1423.42,-643.17)">
+                <polyline class="nad-edge-path nad-stretchable" points="1398.75,-664.33 1566.74,-520.22"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1423.42,-643.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(130.63)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1585,8 +1615,8 @@
                 </g>
             </g>
             <g id="80.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="1734.72,-376.11 1566.74,-520.22"/>
-                <g class="nad-edge-infos" transform="translate(1710.05,-397.27)">
+                <polyline class="nad-edge-path nad-stretchable" points="1734.72,-376.11 1566.74,-520.22"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1710.05,-397.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-49.37)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1607,8 +1637,8 @@
         <g id="81">
             <desc>T-24-3-1 </desc>
             <g id="81.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="260.52,-309.61 -49.66,-187.99"/>
-                <g class="nad-edge-infos" transform="translate(230.26,-297.74)">
+                <polyline class="nad-edge-path nad-stretchable" points="260.52,-309.61 -49.66,-187.99"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(230.26,-297.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-111.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1624,11 +1654,10 @@
                         <text transform="rotate(-21.41)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-68.28" cy="-180.69" r="20.00"/>
             </g>
             <g id="81.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-415.69,-44.48 -105.52,-166.09"/>
-                <g class="nad-edge-infos" transform="translate(-385.44,-56.35)">
+                <polyline class="nad-edge-path nad-stretchable" points="-415.69,-44.48 -105.52,-166.09"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-385.44,-56.35)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(68.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1644,14 +1673,21 @@
                         <text transform="rotate(-21.41)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-86.90" cy="-173.39" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl180to300">
+                    <circle class="nad-winding" cx="-68.28" cy="-180.69" r="20.00"/>
+                </g>
+                <g class="nad-vl120to180">
+                    <circle class="nad-winding" cx="-86.90" cy="-173.39" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="82">
             <desc>L-3-9-1 </desc>
             <g id="82.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-441.80,-9.78 -458.48,168.86"/>
-                <g class="nad-edge-infos" transform="translate(-444.82,22.57)">
+                <polyline class="nad-edge-path nad-stretchable" points="-441.80,-9.78 -458.48,168.86"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-444.82,22.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-174.67)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1669,8 +1705,8 @@
                 </g>
             </g>
             <g id="82.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-475.15,347.50 -458.48,168.86"/>
-                <g class="nad-edge-infos" transform="translate(-472.13,315.14)">
+                <polyline class="nad-edge-path nad-stretchable" points="-475.15,347.50 -458.48,168.86"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-472.13,315.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(5.33)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1691,8 +1727,8 @@
         <g id="83">
             <desc>L-4-9-1 </desc>
             <g id="83.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-740.12,843.04 -615.03,619.10"/>
-                <g class="nad-edge-infos" transform="translate(-724.27,814.67)">
+                <polyline class="nad-edge-path nad-stretchable" points="-740.12,843.04 -615.03,619.10"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-724.27,814.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(29.19)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1710,8 +1746,8 @@
                 </g>
             </g>
             <g id="83.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-489.95,395.15 -615.03,619.10"/>
-                <g class="nad-edge-infos" transform="translate(-505.80,423.52)">
+                <polyline class="nad-edge-path nad-stretchable" points="-489.95,395.15 -615.03,619.10"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-505.80,423.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-150.81)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1732,8 +1768,8 @@
         <g id="84">
             <desc>L-7-8-1 </desc>
             <g id="84.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-1160.53,-219.25 -1011.91,-55.90"/>
-                <g class="nad-edge-infos" transform="translate(-1138.66,-195.21)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1160.53,-219.25 -1011.91,-55.90"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1138.66,-195.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(137.70)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1751,8 +1787,8 @@
                 </g>
             </g>
             <g id="84.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="-863.30,107.45 -1011.91,-55.90"/>
-                <g class="nad-edge-infos" transform="translate(-885.17,83.41)">
+                <polyline class="nad-edge-path nad-stretchable" points="-863.30,107.45 -1011.91,-55.90"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-885.17,83.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-42.30)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1773,8 +1809,8 @@
         <g id="85">
             <desc>L-8-9-1 </desc>
             <g id="85.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="-824.94,140.49 -661.83,249.60"/>
-                <g class="nad-edge-infos" transform="translate(-797.93,158.56)">
+                <polyline class="nad-edge-path nad-stretchable" points="-824.94,140.49 -661.83,249.60"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-797.93,158.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(123.78)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1792,8 +1828,8 @@
                 </g>
             </g>
             <g id="85.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-498.71,358.71 -661.83,249.60"/>
-                <g class="nad-edge-infos" transform="translate(-525.72,340.64)">
+                <polyline class="nad-edge-path nad-stretchable" points="-498.71,358.71 -661.83,249.60"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-525.72,340.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-56.22)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/IEEE_30_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_30_bus.svg
@@ -608,12 +608,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180">
-                    <circle class="nad-winding" cx="137.23" cy="258.71" r="20.00"/>
-                </g>
-                <g class="nad-vl30to50">
-                    <circle class="nad-winding" cx="144.42" cy="240.05" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180 nad-winding" cx="137.23" cy="258.71" r="20.00"/>
+                <circle class="nad-vl30to50 nad-winding" cx="144.42" cy="240.05" r="20.00"/>
             </g>
         </g>
         <g id="68">
@@ -862,12 +858,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180">
-                    <circle class="nad-winding" cx="865.36" cy="-92.31" r="20.00"/>
-                </g>
-                <g class="nad-vl30to50">
-                    <circle class="nad-winding" cx="885.35" cy="-91.52" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180 nad-winding" cx="865.36" cy="-92.31" r="20.00"/>
+                <circle class="nad-vl30to50 nad-winding" cx="885.35" cy="-91.52" r="20.00"/>
             </g>
         </g>
         <g id="74">
@@ -1608,12 +1600,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180">
-                    <circle class="nad-winding" cx="-512.96" cy="1107.52" r="20.00"/>
-                </g>
-                <g class="nad-vl30to50">
-                    <circle class="nad-winding" cx="-532.60" cy="1111.29" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180 nad-winding" cx="-512.96" cy="1107.52" r="20.00"/>
+                <circle class="nad-vl30to50 nad-winding" cx="-532.60" cy="1111.29" r="20.00"/>
             </g>
         </g>
         <g id="92">
@@ -1985,12 +1973,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl120to180">
-                    <circle class="nad-winding" cx="-59.05" cy="497.16" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30">
-                    <circle class="nad-winding" cx="-76.77" cy="506.42" r="20.00"/>
-                </g>
+                <circle class="nad-vl120to180 nad-winding" cx="-59.05" cy="497.16" r="20.00"/>
+                <circle class="nad-vl0to30 nad-winding" cx="-76.77" cy="506.42" r="20.00"/>
             </g>
         </g>
     </g>

--- a/network-area-diagram/src/test/resources/IEEE_30_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_30_bus.svg
@@ -283,8 +283,8 @@
         <g id="60">
             <desc>L1-2-1</desc>
             <g id="60.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="550.53,-796.88 372.88,-540.62"/>
-                <g class="nad-edge-infos" transform="translate(532.02,-770.17)">
+                <polyline class="nad-edge-path nad-stretchable" points="550.53,-796.88 372.88,-540.62"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(532.02,-770.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-145.27)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -302,8 +302,8 @@
                 </g>
             </g>
             <g id="60.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="195.23,-284.35 372.88,-540.62"/>
-                <g class="nad-edge-infos" transform="translate(213.75,-311.06)">
+                <polyline class="nad-edge-path nad-stretchable" points="195.23,-284.35 372.88,-540.62"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(213.75,-311.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(34.73)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -324,8 +324,8 @@
         <g id="61">
             <desc>L1-3-1</desc>
             <g id="61.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="589.47,-810.47 733.28,-767.08"/>
-                <g class="nad-edge-infos" transform="translate(620.59,-801.09)">
+                <polyline class="nad-edge-path nad-stretchable" points="589.47,-810.47 733.28,-767.08"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(620.59,-801.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(106.79)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -343,8 +343,8 @@
                 </g>
             </g>
             <g id="61.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="877.09,-723.69 733.28,-767.08"/>
-                <g class="nad-edge-infos" transform="translate(845.98,-733.08)">
+                <polyline class="nad-edge-path nad-stretchable" points="877.09,-723.69 733.28,-767.08"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(845.98,-733.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-73.21)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -365,8 +365,8 @@
         <g id="62">
             <desc>L9-10-1</desc>
             <g id="62.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-191.18,555.03 1.30,322.26"/>
-                <g class="nad-edge-infos" transform="translate(-170.47,529.98)">
+                <polyline class="nad-edge-path nad-stretchable" points="-191.18,555.03 1.30,322.26"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-170.47,529.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(39.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -384,8 +384,8 @@
                 </g>
             </g>
             <g id="62.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="193.79,89.50 1.30,322.26"/>
-                <g class="nad-edge-infos" transform="translate(173.07,114.55)">
+                <polyline class="nad-edge-path nad-stretchable" points="193.79,89.50 1.30,322.26"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(173.07,114.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-140.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -406,8 +406,8 @@
         <g id="63">
             <desc>L10-20-1</desc>
             <g id="63.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="202.63,45.45 87.78,-332.78"/>
-                <g class="nad-edge-infos" transform="translate(193.18,14.36)">
+                <polyline class="nad-edge-path nad-stretchable" points="202.63,45.45 87.78,-332.78"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(193.18,14.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-16.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -425,8 +425,8 @@
                 </g>
             </g>
             <g id="63.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="-27.07,-711.02 87.78,-332.78"/>
-                <g class="nad-edge-infos" transform="translate(-17.63,-679.92)">
+                <polyline class="nad-edge-path nad-stretchable" points="-27.07,-711.02 87.78,-332.78"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-17.63,-679.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(163.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -447,8 +447,8 @@
         <g id="64">
             <desc>L10-17-1</desc>
             <g id="64.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="232.64,58.04 566.00,-116.15"/>
-                <g class="nad-edge-infos" transform="translate(261.44,42.99)">
+                <polyline class="nad-edge-path nad-stretchable" points="232.64,58.04 566.00,-116.15"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(261.44,42.99)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(62.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -466,8 +466,8 @@
                 </g>
             </g>
             <g id="64.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="899.36,-290.34 566.00,-116.15"/>
-                <g class="nad-edge-infos" transform="translate(870.55,-275.29)">
+                <polyline class="nad-edge-path nad-stretchable" points="899.36,-290.34 566.00,-116.15"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(870.55,-275.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-117.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -488,8 +488,8 @@
         <g id="65">
             <desc>L10-21-1</desc>
             <g id="65.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="221.98,92.38 298.99,237.67"/>
-                <g class="nad-edge-infos" transform="translate(237.20,121.10)">
+                <polyline class="nad-edge-path nad-stretchable" points="221.98,92.38 298.99,237.67"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(237.20,121.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(152.07)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -507,8 +507,8 @@
                 </g>
             </g>
             <g id="65.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="376.00,382.96 298.99,237.67"/>
-                <g class="nad-edge-infos" transform="translate(360.78,354.25)">
+                <polyline class="nad-edge-path nad-stretchable" points="376.00,382.96 298.99,237.67"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(360.78,354.25)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-27.93)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -529,8 +529,8 @@
         <g id="66">
             <desc>L10-22-1</desc>
             <g id="66.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="184.87,73.98 34.73,98.58"/>
-                <g class="nad-edge-infos" transform="translate(152.80,79.23)">
+                <polyline class="nad-edge-path nad-stretchable" points="184.87,73.98 34.73,98.58"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(152.80,79.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-99.31)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -548,8 +548,8 @@
                 </g>
             </g>
             <g id="66.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="-115.40,123.18 34.73,98.58"/>
-                <g class="nad-edge-infos" transform="translate(-83.33,117.93)">
+                <polyline class="nad-edge-path nad-stretchable" points="-115.40,123.18 34.73,98.58"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-83.33,117.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(80.69)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -570,8 +570,8 @@
         <g id="67">
             <desc>T6-10-1</desc>
             <g id="67.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="80.79,405.11 130.03,277.37"/>
-                <g class="nad-edge-infos" transform="translate(92.48,374.79)">
+                <polyline class="nad-edge-path nad-stretchable" points="80.79,405.11 130.03,277.37"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(92.48,374.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(21.08)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -587,11 +587,10 @@
                         <text transform="rotate(-68.92)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="137.23" cy="258.71" r="20.00"/>
             </g>
             <g id="67.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="200.86,93.65 151.62,221.39"/>
-                <g class="nad-edge-infos" transform="translate(189.17,123.97)">
+                <polyline class="nad-edge-path nad-stretchable" points="200.86,93.65 151.62,221.39"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(189.17,123.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-158.92)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -607,14 +606,21 @@
                         <text transform="rotate(-68.92)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="144.42" cy="240.05" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180">
+                    <circle class="nad-winding" cx="137.23" cy="258.71" r="20.00"/>
+                </g>
+                <g class="nad-vl30to50">
+                    <circle class="nad-winding" cx="144.42" cy="240.05" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="68">
             <desc>L9-11-1</desc>
             <g id="68.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-230.87,584.73 -408.83,661.04"/>
-                <g class="nad-edge-infos" transform="translate(-260.74,597.53)">
+                <polyline class="nad-edge-path nad-stretchable" points="-230.87,584.73 -408.83,661.04"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-260.74,597.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-113.21)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -632,8 +638,8 @@
                 </g>
             </g>
             <g id="68.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-586.80,737.35 -408.83,661.04"/>
-                <g class="nad-edge-infos" transform="translate(-556.93,724.54)">
+                <polyline class="nad-edge-path nad-stretchable" points="-586.80,737.35 -408.83,661.04"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-556.93,724.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(66.79)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -654,8 +660,8 @@
         <g id="69">
             <desc>L12-13-1</desc>
             <g id="69.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="1166.96,-67.83 1367.00,56.45"/>
-                <g class="nad-edge-infos" transform="translate(1194.57,-50.68)">
+                <polyline class="nad-edge-path nad-stretchable" points="1166.96,-67.83 1367.00,56.45"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1194.57,-50.68)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(121.85)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -673,8 +679,8 @@
                 </g>
             </g>
             <g id="69.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="1567.04,180.73 1367.00,56.45"/>
-                <g class="nad-edge-infos" transform="translate(1539.44,163.58)">
+                <polyline class="nad-edge-path nad-stretchable" points="1567.04,180.73 1367.00,56.45"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1539.44,163.58)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-58.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -695,8 +701,8 @@
         <g id="70">
             <desc>L12-14-1</desc>
             <g id="70.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="1126.16,-64.44 1029.41,20.70"/>
-                <g class="nad-edge-infos" transform="translate(1101.76,-42.97)">
+                <polyline class="nad-edge-path nad-stretchable" points="1126.16,-64.44 1029.41,20.70"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1101.76,-42.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-131.35)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -714,8 +720,8 @@
                 </g>
             </g>
             <g id="70.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="932.66,105.85 1029.41,20.70"/>
-                <g class="nad-edge-infos" transform="translate(957.06,84.38)">
+                <polyline class="nad-edge-path nad-stretchable" points="932.66,105.85 1029.41,20.70"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(957.06,84.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.65)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -736,8 +742,8 @@
         <g id="71">
             <desc>L12-15-1</desc>
             <g id="71.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="1123.42,-94.38 816.31,-278.10"/>
-                <g class="nad-edge-infos" transform="translate(1095.53,-111.06)">
+                <polyline class="nad-edge-path nad-stretchable" points="1123.42,-94.38 816.31,-278.10"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1095.53,-111.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-59.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -755,8 +761,8 @@
                 </g>
             </g>
             <g id="71.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="509.20,-461.82 816.31,-278.10"/>
-                <g class="nad-edge-infos" transform="translate(537.09,-445.13)">
+                <polyline class="nad-edge-path nad-stretchable" points="509.20,-461.82 816.31,-278.10"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(537.09,-445.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(120.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -777,8 +783,8 @@
         <g id="72">
             <desc>L12-16-1</desc>
             <g id="72.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="1162.14,-100.44 1271.09,-224.40"/>
-                <g class="nad-edge-infos" transform="translate(1183.59,-124.85)">
+                <polyline class="nad-edge-path nad-stretchable" points="1162.14,-100.44 1271.09,-224.40"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1183.59,-124.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(41.31)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -796,8 +802,8 @@
                 </g>
             </g>
             <g id="72.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="1380.04,-348.36 1271.09,-224.40"/>
-                <g class="nad-edge-infos" transform="translate(1358.58,-323.94)">
+                <polyline class="nad-edge-path nad-stretchable" points="1380.04,-348.36 1271.09,-224.40"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1358.58,-323.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-138.69)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -818,8 +824,8 @@
         <g id="73">
             <desc>T4-12-1</desc>
             <g id="73.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="630.88,-101.54 845.38,-93.09"/>
-                <g class="nad-edge-infos" transform="translate(663.36,-100.26)">
+                <polyline class="nad-edge-path nad-stretchable" points="630.88,-101.54 845.38,-93.09"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(663.36,-100.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(92.25)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -835,11 +841,10 @@
                         <text transform="rotate(2.25)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="865.36" cy="-92.31" r="20.00"/>
             </g>
             <g id="73.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="1119.82,-82.29 905.33,-90.73"/>
-                <g class="nad-edge-infos" transform="translate(1087.35,-83.57)">
+                <polyline class="nad-edge-path nad-stretchable" points="1119.82,-82.29 905.33,-90.73"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1087.35,-83.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-87.75)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -855,14 +860,21 @@
                         <text transform="rotate(-357.75)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="885.35" cy="-91.52" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180">
+                    <circle class="nad-winding" cx="865.36" cy="-92.31" r="20.00"/>
+                </g>
+                <g class="nad-vl30to50">
+                    <circle class="nad-winding" cx="885.35" cy="-91.52" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="74">
             <desc>L14-15-1</desc>
             <g id="74.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="898.71,101.93 700.42,-176.11"/>
-                <g class="nad-edge-infos" transform="translate(879.84,75.47)">
+                <polyline class="nad-edge-path nad-stretchable" points="898.71,101.93 700.42,-176.11"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(879.84,75.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-35.50)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -880,8 +892,8 @@
                 </g>
             </g>
             <g id="74.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="502.13,-454.15 700.42,-176.11"/>
-                <g class="nad-edge-infos" transform="translate(521.00,-427.69)">
+                <polyline class="nad-edge-path nad-stretchable" points="502.13,-454.15 700.42,-176.11"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(521.00,-427.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(144.50)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -902,8 +914,8 @@
         <g id="75">
             <desc>L15-18-1</desc>
             <g id="75.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="479.99,-499.33 388.89,-802.78"/>
-                <g class="nad-edge-infos" transform="translate(470.64,-530.46)">
+                <polyline class="nad-edge-path nad-stretchable" points="479.99,-499.33 388.89,-802.78"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(470.64,-530.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-16.71)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -921,8 +933,8 @@
                 </g>
             </g>
             <g id="75.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="297.78,-1106.23 388.89,-802.78"/>
-                <g class="nad-edge-infos" transform="translate(307.13,-1075.11)">
+                <polyline class="nad-edge-path nad-stretchable" points="297.78,-1106.23 388.89,-802.78"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(307.13,-1075.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(163.29)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -943,8 +955,8 @@
         <g id="76">
             <desc>L15-23-1</desc>
             <g id="76.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="461.88,-476.63 39.74,-505.30"/>
-                <g class="nad-edge-infos" transform="translate(429.45,-478.84)">
+                <polyline class="nad-edge-path nad-stretchable" points="461.88,-476.63 39.74,-505.30"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(429.45,-478.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-86.12)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -962,8 +974,8 @@
                 </g>
             </g>
             <g id="76.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="-382.39,-533.97 39.74,-505.30"/>
-                <g class="nad-edge-infos" transform="translate(-349.97,-531.77)">
+                <polyline class="nad-edge-path nad-stretchable" points="-382.39,-533.97 39.74,-505.30"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-349.97,-531.77)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(93.88)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -984,8 +996,8 @@
         <g id="77">
             <desc>L16-17-1</desc>
             <g id="77.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="1371.61,-364.03 1159.42,-334.83"/>
-                <g class="nad-edge-infos" transform="translate(1339.41,-359.60)">
+                <polyline class="nad-edge-path nad-stretchable" points="1371.61,-364.03 1159.42,-334.83"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1339.41,-359.60)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-97.84)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1003,8 +1015,8 @@
                 </g>
             </g>
             <g id="77.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="947.22,-305.63 1159.42,-334.83"/>
-                <g class="nad-edge-infos" transform="translate(979.42,-310.06)">
+                <polyline class="nad-edge-path nad-stretchable" points="947.22,-305.63 1159.42,-334.83"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(979.42,-310.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(82.16)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1025,8 +1037,8 @@
         <g id="78">
             <desc>L18-19-1</desc>
             <g id="78.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="265.63,-1136.49 103.80,-1174.55"/>
-                <g class="nad-edge-infos" transform="translate(233.99,-1143.93)">
+                <polyline class="nad-edge-path nad-stretchable" points="265.63,-1136.49 103.80,-1174.55"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(233.99,-1143.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-76.77)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1044,8 +1056,8 @@
                 </g>
             </g>
             <g id="78.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="-58.02,-1212.60 103.80,-1174.55"/>
-                <g class="nad-edge-infos" transform="translate(-26.38,-1205.16)">
+                <polyline class="nad-edge-path nad-stretchable" points="-58.02,-1212.60 103.80,-1174.55"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-26.38,-1205.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(103.23)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1066,8 +1078,8 @@
         <g id="79">
             <desc>L19-20-1</desc>
             <g id="79.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="-80.30,-1193.06 -58.66,-976.93"/>
-                <g class="nad-edge-infos" transform="translate(-77.07,-1160.72)">
+                <polyline class="nad-edge-path nad-stretchable" points="-80.30,-1193.06 -58.66,-976.93"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-77.07,-1160.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(174.28)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1085,8 +1097,8 @@
                 </g>
             </g>
             <g id="79.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="-37.02,-760.79 -58.66,-976.93"/>
-                <g class="nad-edge-infos" transform="translate(-40.26,-793.13)">
+                <polyline class="nad-edge-path nad-stretchable" points="-37.02,-760.79 -58.66,-976.93"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-40.26,-793.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-5.72)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1107,8 +1119,8 @@
         <g id="80">
             <desc>L2-4-1</desc>
             <g id="80.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="204.55,-254.36 393.05,-182.97"/>
-                <g class="nad-edge-infos" transform="translate(234.94,-242.85)">
+                <polyline class="nad-edge-path nad-stretchable" points="204.55,-254.36 393.05,-182.97"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(234.94,-242.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(110.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1126,8 +1138,8 @@
                 </g>
             </g>
             <g id="80.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="581.56,-111.57 393.05,-182.97"/>
-                <g class="nad-edge-infos" transform="translate(551.16,-123.08)">
+                <polyline class="nad-edge-path nad-stretchable" points="581.56,-111.57 393.05,-182.97"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(551.16,-123.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-69.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1148,8 +1160,8 @@
         <g id="81">
             <desc>L2-5-1</desc>
             <g id="81.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="155.41,-260.17 -72.27,-231.11"/>
-                <g class="nad-edge-infos" transform="translate(123.17,-256.05)">
+                <polyline class="nad-edge-path nad-stretchable" points="155.41,-260.17 -72.27,-231.11"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(123.17,-256.05)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-97.27)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1167,8 +1179,8 @@
                 </g>
             </g>
             <g id="81.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-299.95,-202.06 -72.27,-231.11"/>
-                <g class="nad-edge-infos" transform="translate(-267.71,-206.17)">
+                <polyline class="nad-edge-path nad-stretchable" points="-299.95,-202.06 -72.27,-231.11"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-267.71,-206.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(82.73)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1189,8 +1201,8 @@
         <g id="82">
             <desc>L2-6-1</desc>
             <g id="82.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="176.74,-238.21 126.16,82.75"/>
-                <g class="nad-edge-infos" transform="translate(171.68,-206.10)">
+                <polyline class="nad-edge-path nad-stretchable" points="176.74,-238.21 126.16,82.75"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(171.68,-206.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-171.05)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1208,8 +1220,8 @@
                 </g>
             </g>
             <g id="82.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="75.58,403.71 126.16,82.75"/>
-                <g class="nad-edge-infos" transform="translate(80.64,371.61)">
+                <polyline class="nad-edge-path nad-stretchable" points="75.58,403.71 126.16,82.75"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(80.64,371.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(8.95)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1230,8 +1242,8 @@
         <g id="83">
             <desc>L21-22-1</desc>
             <g id="83.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="365.38,393.62 123.69,266.40"/>
-                <g class="nad-edge-infos" transform="translate(336.62,378.48)">
+                <polyline class="nad-edge-path nad-stretchable" points="365.38,393.62 123.69,266.40"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(336.62,378.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-62.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1249,8 +1261,8 @@
                 </g>
             </g>
             <g id="83.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="-118.00,139.18 123.69,266.40"/>
-                <g class="nad-edge-infos" transform="translate(-89.24,154.32)">
+                <polyline class="nad-edge-path nad-stretchable" points="-118.00,139.18 123.69,266.40"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-89.24,154.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(117.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1271,8 +1283,8 @@
         <g id="84">
             <desc>L22-24-1</desc>
             <g id="84.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="-165.21,120.76 -463.23,41.59"/>
-                <g class="nad-edge-infos" transform="translate(-196.62,112.41)">
+                <polyline class="nad-edge-path nad-stretchable" points="-165.21,120.76 -463.23,41.59"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-196.62,112.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-75.12)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1290,8 +1302,8 @@
                 </g>
             </g>
             <g id="84.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="-761.25,-37.59 -463.23,41.59"/>
-                <g class="nad-edge-infos" transform="translate(-729.84,-29.24)">
+                <polyline class="nad-edge-path nad-stretchable" points="-761.25,-37.59 -463.23,41.59"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-729.84,-29.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.88)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1312,8 +1324,8 @@
         <g id="85">
             <desc>L23-24-1</desc>
             <g id="85.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="-423.38,-515.48 -596.86,-289.91"/>
-                <g class="nad-edge-infos" transform="translate(-443.19,-489.72)">
+                <polyline class="nad-edge-path nad-stretchable" points="-423.38,-515.48 -596.86,-289.91"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-443.19,-489.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-142.44)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1331,8 +1343,8 @@
                 </g>
             </g>
             <g id="85.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="-770.35,-64.35 -596.86,-289.91"/>
-                <g class="nad-edge-infos" transform="translate(-750.53,-90.11)">
+                <polyline class="nad-edge-path nad-stretchable" points="-770.35,-64.35 -596.86,-289.91"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-750.53,-90.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(37.56)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1353,8 +1365,8 @@
         <g id="86">
             <desc>L24-25-1</desc>
             <g id="86.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="-799.33,-22.46 -961.18,238.73"/>
-                <g class="nad-edge-infos" transform="translate(-816.44,5.17)">
+                <polyline class="nad-edge-path nad-stretchable" points="-799.33,-22.46 -961.18,238.73"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-816.44,5.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-148.21)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1372,8 +1384,8 @@
                 </g>
             </g>
             <g id="86.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="-1123.03,499.91 -961.18,238.73"/>
-                <g class="nad-edge-infos" transform="translate(-1105.91,472.28)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1123.03,499.91 -961.18,238.73"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1105.91,472.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(31.79)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1394,8 +1406,8 @@
         <g id="87">
             <desc>L25-26-1</desc>
             <g id="87.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="-1160.96,514.53 -1348.75,460.44"/>
-                <g class="nad-edge-infos" transform="translate(-1192.19,505.53)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1160.96,514.53 -1348.75,460.44"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1192.19,505.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-73.93)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1413,8 +1425,8 @@
                 </g>
             </g>
             <g id="87.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="-1536.54,406.35 -1348.75,460.44"/>
-                <g class="nad-edge-infos" transform="translate(-1505.31,415.35)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1536.54,406.35 -1348.75,460.44"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1505.31,415.35)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(106.07)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1435,8 +1447,8 @@
         <g id="88">
             <desc>L25-27-1</desc>
             <g id="88.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="-1125.59,544.65 -984.04,845.16"/>
-                <g class="nad-edge-infos" transform="translate(-1111.74,574.06)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1125.59,544.65 -984.04,845.16"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1111.74,574.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(154.78)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1454,8 +1466,8 @@
                 </g>
             </g>
             <g id="88.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="-842.50,1145.66 -984.04,845.16"/>
-                <g class="nad-edge-infos" transform="translate(-856.35,1116.26)">
+                <polyline class="nad-edge-path nad-stretchable" points="-842.50,1145.66 -984.04,845.16"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-856.35,1116.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-25.22)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1476,8 +1488,8 @@
         <g id="89">
             <desc>L27-29-1</desc>
             <g id="89.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="-827.48,1193.89 -795.48,1388.11"/>
-                <g class="nad-edge-infos" transform="translate(-822.20,1225.96)">
+                <polyline class="nad-edge-path nad-stretchable" points="-827.48,1193.89 -795.48,1388.11"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-822.20,1225.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(170.64)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1495,8 +1507,8 @@
                 </g>
             </g>
             <g id="89.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="-763.48,1582.32 -795.48,1388.11"/>
-                <g class="nad-edge-infos" transform="translate(-768.76,1550.25)">
+                <polyline class="nad-edge-path nad-stretchable" points="-763.48,1582.32 -795.48,1388.11"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-768.76,1550.25)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-9.36)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1517,8 +1529,8 @@
         <g id="90">
             <desc>L27-30-1</desc>
             <g id="90.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="-846.27,1189.61 -953.64,1342.75"/>
-                <g class="nad-edge-infos" transform="translate(-864.93,1216.22)">
+                <polyline class="nad-edge-path nad-stretchable" points="-846.27,1189.61 -953.64,1342.75"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-864.93,1216.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-144.96)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1536,8 +1548,8 @@
                 </g>
             </g>
             <g id="90.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="-1061.01,1495.89 -953.64,1342.75"/>
-                <g class="nad-edge-infos" transform="translate(-1042.35,1469.28)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1061.01,1495.89 -953.64,1342.75"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1042.35,1469.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(35.04)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1558,8 +1570,8 @@
         <g id="91">
             <desc>T28-27-1</desc>
             <g id="91.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-238.98,1054.89 -493.32,1103.75"/>
-                <g class="nad-edge-infos" transform="translate(-270.90,1061.02)">
+                <polyline class="nad-edge-path nad-stretchable" points="-238.98,1054.89 -493.32,1103.75"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-270.90,1061.02)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-100.87)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1575,11 +1587,10 @@
                         <text transform="rotate(-10.87)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-512.96" cy="1107.52" r="20.00"/>
             </g>
             <g id="91.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="-806.59,1163.92 -552.24,1115.07"/>
-                <g class="nad-edge-infos" transform="translate(-774.67,1157.79)">
+                <polyline class="nad-edge-path nad-stretchable" points="-806.59,1163.92 -552.24,1115.07"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-774.67,1157.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(79.13)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1595,14 +1606,21 @@
                         <text transform="rotate(-10.87)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-532.60" cy="1111.29" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180">
+                    <circle class="nad-winding" cx="-512.96" cy="1107.52" r="20.00"/>
+                </g>
+                <g class="nad-vl30to50">
+                    <circle class="nad-winding" cx="-532.60" cy="1111.29" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="92">
             <desc>L8-28-1</desc>
             <g id="92.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="148.67,998.99 -20.01,1022.76"/>
-                <g class="nad-edge-infos" transform="translate(116.49,1003.53)">
+                <polyline class="nad-edge-path nad-stretchable" points="148.67,998.99 -20.01,1022.76"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(116.49,1003.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-98.02)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1620,8 +1638,8 @@
                 </g>
             </g>
             <g id="92.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-188.69,1046.52 -20.01,1022.76"/>
-                <g class="nad-edge-infos" transform="translate(-156.50,1041.99)">
+                <polyline class="nad-edge-path nad-stretchable" points="-188.69,1046.52 -20.01,1022.76"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-156.50,1041.99)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(81.98)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1642,8 +1660,8 @@
         <g id="93">
             <desc>L6-28-1</desc>
             <g id="93.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="60.96,452.07 -71.16,739.49"/>
-                <g class="nad-edge-infos" transform="translate(47.39,481.60)">
+                <polyline class="nad-edge-path nad-stretchable" points="60.96,452.07 -71.16,739.49"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(47.39,481.60)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-155.31)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1661,8 +1679,8 @@
                 </g>
             </g>
             <g id="93.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-203.29,1026.91 -71.16,739.49"/>
-                <g class="nad-edge-infos" transform="translate(-189.71,997.38)">
+                <polyline class="nad-edge-path nad-stretchable" points="-203.29,1026.91 -71.16,739.49"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-189.71,997.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(24.69)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1683,8 +1701,8 @@
         <g id="94">
             <desc>L29-30-1</desc>
             <g id="94.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="-783.85,1600.45 -917.49,1562.13"/>
-                <g class="nad-edge-infos" transform="translate(-815.09,1591.49)">
+                <polyline class="nad-edge-path nad-stretchable" points="-783.85,1600.45 -917.49,1562.13"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-815.09,1591.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-74.00)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1702,8 +1720,8 @@
                 </g>
             </g>
             <g id="94.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="-1051.14,1523.80 -917.49,1562.13"/>
-                <g class="nad-edge-infos" transform="translate(-1019.90,1532.76)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1051.14,1523.80 -917.49,1562.13"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1019.90,1532.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(106.00)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1724,8 +1742,8 @@
         <g id="95">
             <desc>L3-4-1</desc>
             <g id="95.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="890.43,-693.36 753.46,-409.43"/>
-                <g class="nad-edge-infos" transform="translate(876.31,-664.09)">
+                <polyline class="nad-edge-path nad-stretchable" points="890.43,-693.36 753.46,-409.43"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(876.31,-664.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-154.25)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1743,8 +1761,8 @@
                 </g>
             </g>
             <g id="95.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="616.48,-125.51 753.46,-409.43"/>
-                <g class="nad-edge-infos" transform="translate(630.61,-154.78)">
+                <polyline class="nad-edge-path nad-stretchable" points="616.48,-125.51 753.46,-409.43"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(630.61,-154.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(25.75)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1765,8 +1783,8 @@
         <g id="96">
             <desc>L4-6-1</desc>
             <g id="96.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="587.33,-84.55 338.51,163.18"/>
-                <g class="nad-edge-infos" transform="translate(564.30,-61.62)">
+                <polyline class="nad-edge-path nad-stretchable" points="587.33,-84.55 338.51,163.18"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(564.30,-61.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-134.87)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1784,8 +1802,8 @@
                 </g>
             </g>
             <g id="96.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="89.68,410.91 338.51,163.18"/>
-                <g class="nad-edge-infos" transform="translate(112.72,387.98)">
+                <polyline class="nad-edge-path nad-stretchable" points="89.68,410.91 338.51,163.18"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(112.72,387.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(45.13)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1806,8 +1824,8 @@
         <g id="97">
             <desc>L5-7-1</desc>
             <g id="97.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-333.31,-174.64 -391.98,1.43"/>
-                <g class="nad-edge-infos" transform="translate(-343.58,-143.81)">
+                <polyline class="nad-edge-path nad-stretchable" points="-333.31,-174.64 -391.98,1.43"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-343.58,-143.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-161.57)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1825,8 +1843,8 @@
                 </g>
             </g>
             <g id="97.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-450.66,177.50 -391.98,1.43"/>
-                <g class="nad-edge-infos" transform="translate(-440.38,146.67)">
+                <polyline class="nad-edge-path nad-stretchable" points="-450.66,177.50 -391.98,1.43"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-440.38,146.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(18.43)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1847,8 +1865,8 @@
         <g id="98">
             <desc>L6-7-1</desc>
             <g id="98.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="48.17,418.86 -193.55,315.30"/>
-                <g class="nad-edge-infos" transform="translate(18.30,406.06)">
+                <polyline class="nad-edge-path nad-stretchable" points="48.17,418.86 -193.55,315.30"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(18.30,406.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-66.81)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1866,8 +1884,8 @@
                 </g>
             </g>
             <g id="98.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-435.28,211.74 -193.55,315.30"/>
-                <g class="nad-edge-infos" transform="translate(-405.41,224.53)">
+                <polyline class="nad-edge-path nad-stretchable" points="-435.28,211.74 -193.55,315.30"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-405.41,224.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(113.19)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1888,8 +1906,8 @@
         <g id="99">
             <desc>L6-8-1</desc>
             <g id="99.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="76.15,454.00 122.77,712.17"/>
-                <g class="nad-edge-infos" transform="translate(81.92,485.98)">
+                <polyline class="nad-edge-path nad-stretchable" points="76.15,454.00 122.77,712.17"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(81.92,485.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(169.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1907,8 +1925,8 @@
                 </g>
             </g>
             <g id="99.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="169.39,970.34 122.77,712.17"/>
-                <g class="nad-edge-infos" transform="translate(163.62,938.36)">
+                <polyline class="nad-edge-path nad-stretchable" points="169.39,970.34 122.77,712.17"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(163.62,938.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-10.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1929,8 +1947,8 @@
         <g id="100">
             <desc>T6-9-1</desc>
             <g id="100.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="49.01,440.71 -41.32,487.90"/>
-                <g class="nad-edge-infos" transform="translate(20.21,455.76)">
+                <polyline class="nad-edge-path nad-stretchable" points="49.01,440.71 -41.32,487.90"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(20.21,455.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-117.58)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1946,11 +1964,10 @@
                         <text transform="rotate(-27.58)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-59.05" cy="497.16" r="20.00"/>
             </g>
             <g id="100.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-184.83,562.87 -94.50,515.68"/>
-                <g class="nad-edge-infos" transform="translate(-156.03,547.82)">
+                <polyline class="nad-edge-path nad-stretchable" points="-184.83,562.87 -94.50,515.68"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-156.03,547.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(62.42)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1966,7 +1983,14 @@
                         <text transform="rotate(-27.58)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-76.77" cy="506.42" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl120to180">
+                    <circle class="nad-winding" cx="-59.05" cy="497.16" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30">
+                    <circle class="nad-winding" cx="-76.77" cy="506.42" r="20.00"/>
+                </g>
             </g>
         </g>
     </g>

--- a/network-area-diagram/src/test/resources/IEEE_57_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_57_bus.svg
@@ -489,8 +489,8 @@
         <g id="99">
             <desc>L1-2-1</desc>
             <g id="99.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-296.81,-88.92 -503.09,-54.25"/>
-                <g class="nad-edge-infos" transform="translate(-328.86,-83.53)">
+                <polyline class="nad-edge-path nad-stretchable" points="-296.81,-88.92 -503.09,-54.25"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-328.86,-83.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-99.54)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -508,8 +508,8 @@
                 </g>
             </g>
             <g id="99.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-709.36,-19.58 -503.09,-54.25"/>
-                <g class="nad-edge-infos" transform="translate(-677.31,-24.96)">
+                <polyline class="nad-edge-path nad-stretchable" points="-709.36,-19.58 -503.09,-54.25"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-677.31,-24.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(80.46)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -530,8 +530,8 @@
         <g id="100">
             <desc>L1-15-1</desc>
             <g id="100.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-243.19,-86.13 -77.73,-40.30"/>
-                <g class="nad-edge-infos" transform="translate(-211.87,-77.46)">
+                <polyline class="nad-edge-path nad-stretchable" points="-243.19,-86.13 -77.73,-40.30"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-211.87,-77.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(105.48)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -549,8 +549,8 @@
                 </g>
             </g>
             <g id="100.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="87.73,5.53 -77.73,-40.30"/>
-                <g class="nad-edge-infos" transform="translate(56.41,-3.15)">
+                <polyline class="nad-edge-path nad-stretchable" points="87.73,5.53 -77.73,-40.30"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(56.41,-3.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-74.52)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -571,8 +571,8 @@
         <g id="101">
             <desc>L1-16-1</desc>
             <g id="101.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-255.96,-69.65 -134.85,140.48"/>
-                <g class="nad-edge-infos" transform="translate(-239.73,-41.49)">
+                <polyline class="nad-edge-path nad-stretchable" points="-255.96,-69.65 -134.85,140.48"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-239.73,-41.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(150.04)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -590,8 +590,8 @@
                 </g>
             </g>
             <g id="101.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-13.74,350.60 -134.85,140.48"/>
-                <g class="nad-edge-infos" transform="translate(-29.97,322.45)">
+                <polyline class="nad-edge-path nad-stretchable" points="-13.74,350.60 -134.85,140.48"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-29.97,322.45)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-29.96)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -612,8 +612,8 @@
         <g id="102">
             <desc>L1-17-1</desc>
             <g id="102.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-244.58,-104.68 -131.90,-154.95"/>
-                <g class="nad-edge-infos" transform="translate(-214.90,-117.92)">
+                <polyline class="nad-edge-path nad-stretchable" points="-244.58,-104.68 -131.90,-154.95"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-214.90,-117.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(65.96)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -631,8 +631,8 @@
                 </g>
             </g>
             <g id="102.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-19.23,-205.21 -131.90,-154.95"/>
-                <g class="nad-edge-infos" transform="translate(-48.91,-191.97)">
+                <polyline class="nad-edge-path nad-stretchable" points="-19.23,-205.21 -131.90,-154.95"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-48.91,-191.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-114.04)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -653,8 +653,8 @@
         <g id="103">
             <desc>L9-10-1</desc>
             <g id="103.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="604.90,750.12 698.39,782.42"/>
-                <g class="nad-edge-infos" transform="translate(635.62,760.74)">
+                <polyline class="nad-edge-path nad-stretchable" points="604.90,750.12 698.39,782.42"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(635.62,760.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(109.06)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -672,8 +672,8 @@
                 </g>
             </g>
             <g id="103.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="791.88,814.71 698.39,782.42"/>
-                <g class="nad-edge-infos" transform="translate(761.16,804.10)">
+                <polyline class="nad-edge-path nad-stretchable" points="791.88,814.71 698.39,782.42"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(761.16,804.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-70.94)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -694,8 +694,8 @@
         <g id="104">
             <desc>L10-12-1</desc>
             <g id="104.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="804.05,794.40 616.39,620.49"/>
-                <g class="nad-edge-infos" transform="translate(780.22,772.31)">
+                <polyline class="nad-edge-path nad-stretchable" points="804.05,794.40 616.39,620.49"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(780.22,772.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-47.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -713,8 +713,8 @@
                 </g>
             </g>
             <g id="104.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="428.72,446.59 616.39,620.49"/>
-                <g class="nad-edge-infos" transform="translate(452.56,468.68)">
+                <polyline class="nad-edge-path nad-stretchable" points="428.72,446.59 616.39,620.49"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(452.56,468.68)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(132.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -735,8 +735,8 @@
         <g id="105">
             <desc>L50-51-1</desc>
             <g id="105.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="1128.69,677.24 999.49,748.71"/>
-                <g class="nad-edge-infos" transform="translate(1100.25,692.97)">
+                <polyline class="nad-edge-path nad-stretchable" points="1128.69,677.24 999.49,748.71"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1100.25,692.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-118.95)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -754,8 +754,8 @@
                 </g>
             </g>
             <g id="105.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="870.29,820.17 999.49,748.71"/>
-                <g class="nad-edge-infos" transform="translate(924.98,789.92)">
+                <polyline class="nad-edge-path nad-stretchable" points="870.29,820.17 999.49,748.71"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(924.98,789.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(61.05)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -793,7 +793,6 @@
                         <text transform="rotate(55.05)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="866.54" cy="952.18" r="20.00"/>
             </g>
             <g id="106.2" class="nad-vl0to30-line">
                 <path class="nad-edge-path" d="M834.58,858.40 L812.35,905.96 C795.41,942.20 816.73,956.49 826.69,955.63"/>
@@ -813,14 +812,21 @@
                         <text transform="rotate(-64.95)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="846.61" cy="953.90" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl0to30-line">
+                    <circle class="nad-winding" cx="866.54" cy="952.18" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30-line">
+                    <circle class="nad-winding" cx="846.61" cy="953.90" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="107">
             <desc>L9-11-1</desc>
             <g id="107.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="594.09,693.80 903.82,426.63"/>
-                <g class="nad-edge-infos" transform="translate(618.70,672.57)">
+                <polyline class="nad-edge-path nad-stretchable" points="594.09,693.80 903.82,426.63"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(618.70,672.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(49.22)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -838,8 +844,8 @@
                 </g>
             </g>
             <g id="107.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="1213.56,159.46 903.82,426.63"/>
-                <g class="nad-edge-infos" transform="translate(1173.80,193.75)">
+                <polyline class="nad-edge-path nad-stretchable" points="1213.56,159.46 903.82,426.63"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1173.80,193.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-130.78)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -860,8 +866,8 @@
         <g id="108">
             <desc>L11-13-1</desc>
             <g id="108.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="1205.18,142.34 1000.94,183.26"/>
-                <g class="nad-edge-infos" transform="translate(1153.71,152.65)">
+                <polyline class="nad-edge-path nad-stretchable" points="1205.18,142.34 1000.94,183.26"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1153.71,152.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-101.33)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -879,8 +885,8 @@
                 </g>
             </g>
             <g id="108.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="796.69,224.19 1000.94,183.26"/>
-                <g class="nad-edge-infos" transform="translate(828.55,217.80)">
+                <polyline class="nad-edge-path nad-stretchable" points="796.69,224.19 1000.94,183.26"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(828.55,217.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(78.67)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -901,8 +907,8 @@
         <g id="109">
             <desc>L41-42-1</desc>
             <g id="109.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="1289.35,102.42 1460.45,-15.05"/>
-                <g class="nad-edge-infos" transform="translate(1316.15,84.03)">
+                <polyline class="nad-edge-path nad-stretchable" points="1289.35,102.42 1460.45,-15.05"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1316.15,84.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(55.53)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -920,8 +926,8 @@
                 </g>
             </g>
             <g id="109.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="1631.55,-132.52 1460.45,-15.05"/>
-                <g class="nad-edge-infos" transform="translate(1604.75,-114.12)">
+                <polyline class="nad-edge-path nad-stretchable" points="1631.55,-132.52 1460.45,-15.05"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1604.75,-114.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-124.47)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -983,8 +989,8 @@
         <g id="111">
             <desc>L56-41-1</desc>
             <g id="111.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="1424.75,-506.87 1341.23,-213.60"/>
-                <g class="nad-edge-infos" transform="translate(1415.85,-475.62)">
+                <polyline class="nad-edge-path nad-stretchable" points="1424.75,-506.87 1341.23,-213.60"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1415.85,-475.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-164.10)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1002,8 +1008,8 @@
                 </g>
             </g>
             <g id="111.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="1257.70,79.67 1341.23,-213.60"/>
-                <g class="nad-edge-infos" transform="translate(1266.60,48.41)">
+                <polyline class="nad-edge-path nad-stretchable" points="1257.70,79.67 1341.23,-213.60"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1266.60,48.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(15.90)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1041,7 +1047,6 @@
                         <text transform="rotate(61.32)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="1249.18" cy="255.17" r="20.00"/>
             </g>
             <g id="112.2" class="nad-vl0to30-line">
                 <path class="nad-edge-path" d="M1212.06,184.09 L1200.36,203.31 C1179.57,237.48 1199.19,254.01 1209.19,254.24"/>
@@ -1061,7 +1066,14 @@
                         <text transform="rotate(-58.68)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="1229.19" cy="254.71" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl0to30-line">
+                    <circle class="nad-winding" cx="1249.18" cy="255.17" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30-line">
+                    <circle class="nad-winding" cx="1229.19" cy="254.71" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="113">
@@ -1084,7 +1096,6 @@
                         <text transform="rotate(-342.72)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="1153.20" cy="53.59" r="20.00"/>
             </g>
             <g id="113.2" class="nad-vl0to30-line">
                 <path class="nad-edge-path" d="M1238.10,117.90 L1224.34,56.93 C1215.54,17.91 1189.94,19.67 1182.59,26.45"/>
@@ -1104,14 +1115,21 @@
                         <text transform="rotate(-282.72)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="1167.89" cy="40.02" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl0to30-line">
+                    <circle class="nad-winding" cx="1153.20" cy="53.59" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30-line">
+                    <circle class="nad-winding" cx="1167.89" cy="40.02" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="114">
             <desc>L9-12-1</desc>
             <g id="114.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="526.18,679.27 473.19,566.04"/>
-                <g class="nad-edge-infos" transform="translate(512.41,649.83)">
+                <polyline class="nad-edge-path nad-stretchable" points="526.18,679.27 473.19,566.04"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(512.41,649.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-25.08)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1129,8 +1147,8 @@
                 </g>
             </g>
             <g id="114.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="420.21,452.80 473.19,566.04"/>
-                <g class="nad-edge-infos" transform="translate(433.98,482.24)">
+                <polyline class="nad-edge-path nad-stretchable" points="420.21,452.80 473.19,566.04"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(433.98,482.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(154.92)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1151,8 +1169,8 @@
         <g id="115">
             <desc>L12-13-1</desc>
             <g id="115.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="432.34,414.10 561.45,339.21"/>
-                <g class="nad-edge-infos" transform="translate(460.45,397.79)">
+                <polyline class="nad-edge-path nad-stretchable" points="432.34,414.10 561.45,339.21"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(460.45,397.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(59.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1170,8 +1188,8 @@
                 </g>
             </g>
             <g id="115.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="690.57,264.33 561.45,339.21"/>
-                <g class="nad-edge-infos" transform="translate(662.45,280.64)">
+                <polyline class="nad-edge-path nad-stretchable" points="690.57,264.33 561.45,339.21"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(662.45,280.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-120.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1192,8 +1210,8 @@
         <g id="116">
             <desc>L12-16-1</desc>
             <g id="116.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="381.28,424.32 204.27,401.16"/>
-                <g class="nad-edge-infos" transform="translate(349.06,420.11)">
+                <polyline class="nad-edge-path nad-stretchable" points="381.28,424.32 204.27,401.16"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(349.06,420.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-82.54)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1211,8 +1229,8 @@
                 </g>
             </g>
             <g id="116.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="27.26,378.00 204.27,401.16"/>
-                <g class="nad-edge-infos" transform="translate(59.48,382.21)">
+                <polyline class="nad-edge-path nad-stretchable" points="27.26,378.00 204.27,401.16"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(59.48,382.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(97.46)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1233,8 +1251,8 @@
         <g id="117">
             <desc>L12-17-1</desc>
             <g id="117.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="393.98,404.57 207.22,105.74"/>
-                <g class="nad-edge-infos" transform="translate(376.75,377.01)">
+                <polyline class="nad-edge-path nad-stretchable" points="393.98,404.57 207.22,105.74"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(376.75,377.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-32.00)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1252,8 +1270,8 @@
                 </g>
             </g>
             <g id="117.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="20.46,-193.10 207.22,105.74"/>
-                <g class="nad-edge-infos" transform="translate(37.68,-165.54)">
+                <polyline class="nad-edge-path nad-stretchable" points="20.46,-193.10 207.22,105.74"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(37.68,-165.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(148.00)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1274,8 +1292,8 @@
         <g id="118">
             <desc>L9-13-1</desc>
             <g id="118.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="571.10,677.65 645.43,483.42"/>
-                <g class="nad-edge-infos" transform="translate(582.72,647.30)">
+                <polyline class="nad-edge-path nad-stretchable" points="571.10,677.65 645.43,483.42"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(582.72,647.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(20.94)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1293,8 +1311,8 @@
                 </g>
             </g>
             <g id="118.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="719.76,289.19 645.43,483.42"/>
-                <g class="nad-edge-infos" transform="translate(708.14,319.54)">
+                <polyline class="nad-edge-path nad-stretchable" points="719.76,289.19 645.43,483.42"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(708.14,319.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-159.06)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1315,8 +1333,8 @@
         <g id="119">
             <desc>L13-14-1</desc>
             <g id="119.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="716.84,182.99 673.11,85.16"/>
-                <g class="nad-edge-infos" transform="translate(703.58,153.32)">
+                <polyline class="nad-edge-path nad-stretchable" points="716.84,182.99 673.11,85.16"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(703.58,153.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.08)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1334,8 +1352,8 @@
                 </g>
             </g>
             <g id="119.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="629.38,-12.67 673.11,85.16"/>
-                <g class="nad-edge-infos" transform="translate(642.65,17.00)">
+                <polyline class="nad-edge-path nad-stretchable" points="629.38,-12.67 673.11,85.16"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(642.65,17.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.92)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1356,8 +1374,8 @@
         <g id="120">
             <desc>L13-15-1</desc>
             <g id="120.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="686.20,216.04 441.73,128.18"/>
-                <g class="nad-edge-infos" transform="translate(655.61,205.05)">
+                <polyline class="nad-edge-path nad-stretchable" points="686.20,216.04 441.73,128.18"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(655.61,205.05)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-70.23)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1375,8 +1393,8 @@
                 </g>
             </g>
             <g id="120.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="197.26,40.33 441.73,128.18"/>
-                <g class="nad-edge-infos" transform="translate(227.84,51.32)">
+                <polyline class="nad-edge-path nad-stretchable" points="197.26,40.33 441.73,128.18"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(227.84,51.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(109.77)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1397,8 +1415,8 @@
         <g id="121">
             <desc>L48-49-1</desc>
             <g id="121.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="904.69,-104.11 828.49,53.31"/>
-                <g class="nad-edge-infos" transform="translate(890.53,-74.86)">
+                <polyline class="nad-edge-path nad-stretchable" points="904.69,-104.11 828.49,53.31"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(890.53,-74.86)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-154.17)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1416,8 +1434,8 @@
                 </g>
             </g>
             <g id="121.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="752.29,210.73 828.49,53.31"/>
-                <g class="nad-edge-infos" transform="translate(779.52,154.48)">
+                <polyline class="nad-edge-path nad-stretchable" points="752.29,210.73 828.49,53.31"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(779.52,154.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(25.83)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1438,8 +1456,8 @@
         <g id="122">
             <desc>L49-50-1</desc>
             <g id="122.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="759.38,255.30 946.53,449.71"/>
-                <g class="nad-edge-infos" transform="translate(802.73,300.32)">
+                <polyline class="nad-edge-path nad-stretchable" points="759.38,255.30 946.53,449.71"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(802.73,300.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(136.09)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1457,8 +1475,8 @@
                 </g>
             </g>
             <g id="122.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="1133.68,644.12 946.53,449.71"/>
-                <g class="nad-edge-infos" transform="translate(1111.14,620.70)">
+                <polyline class="nad-edge-path nad-stretchable" points="1133.68,644.12 946.53,449.71"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1111.14,620.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-43.91)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1479,8 +1497,8 @@
         <g id="123">
             <desc>L38-49-1</desc>
             <g id="123.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="483.80,-320.83 606.30,-55.16"/>
-                <g class="nad-edge-infos" transform="translate(497.41,-291.31)">
+                <polyline class="nad-edge-path nad-stretchable" points="483.80,-320.83 606.30,-55.16"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(497.41,-291.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.25)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1498,8 +1516,8 @@
                 </g>
             </g>
             <g id="123.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="728.79,210.51 606.30,-55.16"/>
-                <g class="nad-edge-infos" transform="translate(702.62,153.75)">
+                <polyline class="nad-edge-path nad-stretchable" points="728.79,210.51 606.30,-55.16"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(702.62,153.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.75)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1537,7 +1555,6 @@
                         <text transform="rotate(48.52)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="774.00" cy="351.09" r="20.00"/>
             </g>
             <g id="124.2" class="nad-vl0to30-line">
                 <path class="nad-edge-path" d="M731.58,261.56 L714.90,311.34 C702.20,349.27 725.00,361.05 734.80,359.05"/>
@@ -1557,14 +1574,21 @@
                         <text transform="rotate(-71.48)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="754.40" cy="355.07" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl0to30-line">
+                    <circle class="nad-winding" cx="774.00" cy="351.09" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30-line">
+                    <circle class="nad-winding" cx="754.40" cy="355.07" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="125">
             <desc>L14-15-1</desc>
             <g id="125.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="549.39,-54.65 374.53,-22.14"/>
-                <g class="nad-edge-infos" transform="translate(517.44,-48.71)">
+                <polyline class="nad-edge-path nad-stretchable" points="549.39,-54.65 374.53,-22.14"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(517.44,-48.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-100.53)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1582,8 +1606,8 @@
                 </g>
             </g>
             <g id="125.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="199.68,10.37 374.53,-22.14"/>
-                <g class="nad-edge-infos" transform="translate(231.63,4.43)">
+                <polyline class="nad-edge-path nad-stretchable" points="199.68,10.37 374.53,-22.14"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(231.63,4.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(79.47)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1604,8 +1628,8 @@
         <g id="126">
             <desc>L46-47-1</desc>
             <g id="126.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="626.02,-83.93 789.69,-236.72"/>
-                <g class="nad-edge-infos" transform="translate(671.71,-126.58)">
+                <polyline class="nad-edge-path nad-stretchable" points="626.02,-83.93 789.69,-236.72"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(671.71,-126.58)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(46.97)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1623,8 +1647,8 @@
                 </g>
             </g>
             <g id="126.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="953.37,-389.50 789.69,-236.72"/>
-                <g class="nad-edge-infos" transform="translate(929.61,-367.33)">
+                <polyline class="nad-edge-path nad-stretchable" points="953.37,-389.50 789.69,-236.72"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(929.61,-367.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-133.03)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1662,7 +1686,6 @@
                         <text transform="rotate(-326.78)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="542.92" cy="-167.79" r="20.00"/>
             </g>
             <g id="127.2" class="nad-vl0to30-line">
                 <path class="nad-edge-path" d="M607.46,-92.62 L610.41,-145.04 C612.66,-184.98 587.56,-190.32 578.63,-185.81"/>
@@ -1682,14 +1705,21 @@
                         <text transform="rotate(-86.78)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="560.78" cy="-176.80" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl0to30-line">
+                    <circle class="nad-winding" cx="542.92" cy="-167.79" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30-line">
+                    <circle class="nad-winding" cx="560.78" cy="-176.80" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="128">
             <desc>L3-15-1</desc>
             <g id="128.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-668.71,388.37 -288.98,216.48"/>
-                <g class="nad-edge-infos" transform="translate(-639.11,374.97)">
+                <polyline class="nad-edge-path nad-stretchable" points="-668.71,388.37 -288.98,216.48"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-639.11,374.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(65.65)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1707,8 +1737,8 @@
                 </g>
             </g>
             <g id="128.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="90.76,44.59 -288.98,216.48"/>
-                <g class="nad-edge-infos" transform="translate(61.16,57.99)">
+                <polyline class="nad-edge-path nad-stretchable" points="90.76,44.59 -288.98,216.48"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(61.16,57.99)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-114.35)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1729,8 +1759,8 @@
         <g id="129">
             <desc>L44-45-1</desc>
             <g id="129.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="186.31,-550.63 165.76,-278.59"/>
-                <g class="nad-edge-infos" transform="translate(183.86,-518.23)">
+                <polyline class="nad-edge-path nad-stretchable" points="186.31,-550.63 165.76,-278.59"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(183.86,-518.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-175.68)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1748,8 +1778,8 @@
                 </g>
             </g>
             <g id="129.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="145.22,-6.54 165.76,-278.59"/>
-                <g class="nad-edge-infos" transform="translate(149.92,-68.87)">
+                <polyline class="nad-edge-path nad-stretchable" points="145.22,-6.54 165.76,-278.59"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(149.92,-68.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(4.32)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1787,7 +1817,6 @@
                         <text transform="rotate(57.71)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="157.94" cy="140.38" r="20.00"/>
             </g>
             <g id="130.2" class="nad-vl0to30-line">
                 <path class="nad-edge-path" d="M130.36,45.23 L105.95,91.71 C87.35,127.12 107.98,142.38 117.97,141.98"/>
@@ -1807,14 +1836,21 @@
                         <text transform="rotate(-62.29)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="137.96" cy="141.18" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl0to30-line">
+                    <circle class="nad-winding" cx="157.94" cy="140.38" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30-line">
+                    <circle class="nad-winding" cx="137.96" cy="141.18" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="131">
             <desc>L18-19-1</desc>
             <g id="131.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-1146.04,1108.12 -1052.22,1264.54"/>
-                <g class="nad-edge-infos" transform="translate(-1113.90,1161.72)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1146.04,1108.12 -1052.22,1264.54"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1113.90,1161.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(149.04)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1832,8 +1868,8 @@
                 </g>
             </g>
             <g id="131.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-958.41,1420.95 -1052.22,1264.54"/>
-                <g class="nad-edge-infos" transform="translate(-975.12,1393.08)">
+                <polyline class="nad-edge-path nad-stretchable" points="-958.41,1420.95 -1052.22,1264.54"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-975.12,1393.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-30.96)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1854,8 +1890,8 @@
         <g id="132">
             <desc>L19-20-1</desc>
             <g id="132.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-924.82,1425.08 -766.51,1266.73"/>
-                <g class="nad-edge-infos" transform="translate(-901.84,1402.10)">
+                <polyline class="nad-edge-path nad-stretchable" points="-924.82,1425.08 -766.51,1266.73"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-901.84,1402.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(44.99)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1873,8 +1909,8 @@
                 </g>
             </g>
             <g id="132.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-608.21,1108.37 -766.51,1266.73"/>
-                <g class="nad-edge-infos" transform="translate(-652.40,1152.57)">
+                <polyline class="nad-edge-path nad-stretchable" points="-608.21,1108.37 -766.51,1266.73"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-652.40,1152.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-135.01)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1895,8 +1931,8 @@
         <g id="133">
             <desc>L2-3-1</desc>
             <g id="133.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-733.67,12.34 -715.12,192.35"/>
-                <g class="nad-edge-infos" transform="translate(-730.34,44.67)">
+                <polyline class="nad-edge-path nad-stretchable" points="-733.67,12.34 -715.12,192.35"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-730.34,44.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(174.12)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1914,8 +1950,8 @@
                 </g>
             </g>
             <g id="133.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-696.58,372.36 -715.12,192.35"/>
-                <g class="nad-edge-infos" transform="translate(-699.91,340.03)">
+                <polyline class="nad-edge-path nad-stretchable" points="-696.58,372.36 -715.12,192.35"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-699.91,340.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-5.88)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1936,8 +1972,8 @@
         <g id="134">
             <desc>L21-22-1</desc>
             <g id="134.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-576.87,1032.66 -489.25,618.30"/>
-                <g class="nad-edge-infos" transform="translate(-570.15,1000.87)">
+                <polyline class="nad-edge-path nad-stretchable" points="-576.87,1032.66 -489.25,618.30"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-570.15,1000.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(11.94)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1955,8 +1991,8 @@
                 </g>
             </g>
             <g id="134.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-401.62,203.93 -489.25,618.30"/>
-                <g class="nad-edge-infos" transform="translate(-408.34,235.73)">
+                <polyline class="nad-edge-path nad-stretchable" points="-401.62,203.93 -489.25,618.30"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-408.34,235.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-168.06)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1994,7 +2030,6 @@
                         <text transform="rotate(-1.53)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-478.51" cy="1137.33" r="20.00"/>
             </g>
             <g id="135.2" class="nad-vl0to30-line">
                 <path class="nad-edge-path" d="M-574.39,1112.36 L-546.93,1157.11 C-526.01,1191.20 -502.34,1181.28 -497.58,1172.49"/>
@@ -2014,14 +2049,21 @@
                         <text transform="rotate(58.47)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-488.04" cy="1154.91" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl0to30-line">
+                    <circle class="nad-winding" cx="-478.51" cy="1137.33" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30-line">
+                    <circle class="nad-winding" cx="-488.04" cy="1154.91" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="136">
             <desc>L22-23-1</desc>
             <g id="136.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-414.02,156.31 -653.34,-117.74"/>
-                <g class="nad-edge-infos" transform="translate(-435.39,131.83)">
+                <polyline class="nad-edge-path nad-stretchable" points="-414.02,156.31 -653.34,-117.74"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-435.39,131.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-41.13)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2039,8 +2081,8 @@
                 </g>
             </g>
             <g id="136.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-892.67,-391.80 -653.34,-117.74"/>
-                <g class="nad-edge-infos" transform="translate(-871.29,-367.32)">
+                <polyline class="nad-edge-path nad-stretchable" points="-892.67,-391.80 -653.34,-117.74"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-871.29,-367.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(138.87)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2061,8 +2103,8 @@
         <g id="137">
             <desc>L22-38-1</desc>
             <g id="137.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-372.37,162.84 38.18,-84.39"/>
-                <g class="nad-edge-infos" transform="translate(-344.53,146.07)">
+                <polyline class="nad-edge-path nad-stretchable" points="-372.37,162.84 38.18,-84.39"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-344.53,146.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(58.94)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2080,8 +2122,8 @@
                 </g>
             </g>
             <g id="137.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="448.73,-331.61 38.18,-84.39"/>
-                <g class="nad-edge-infos" transform="translate(420.89,-314.85)">
+                <polyline class="nad-edge-path nad-stretchable" points="448.73,-331.61 38.18,-84.39"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(420.89,-314.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-121.06)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2102,8 +2144,8 @@
         <g id="138">
             <desc>L23-24-1</desc>
             <g id="138.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-931.99,-429.98 -1084.34,-555.34"/>
-                <g class="nad-edge-infos" transform="translate(-957.09,-450.63)">
+                <polyline class="nad-edge-path nad-stretchable" points="-931.99,-429.98 -1084.34,-555.34"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-957.09,-450.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-50.55)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2121,8 +2163,8 @@
                 </g>
             </g>
             <g id="138.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-1236.69,-680.70 -1084.34,-555.34"/>
-                <g class="nad-edge-infos" transform="translate(-1211.59,-660.05)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1236.69,-680.70 -1084.34,-555.34"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1211.59,-660.05)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(129.45)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2143,8 +2185,8 @@
         <g id="139">
             <desc>L25-30-1</desc>
             <g id="139.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-1266.29,-751.69 -1169.60,-976.85"/>
-                <g class="nad-edge-infos" transform="translate(-1245.58,-799.93)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1266.29,-751.69 -1169.60,-976.85"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1245.58,-799.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(23.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2162,8 +2204,8 @@
                 </g>
             </g>
             <g id="139.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-1072.91,-1202.01 -1169.60,-976.85"/>
-                <g class="nad-edge-infos" transform="translate(-1085.73,-1172.15)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1072.91,-1202.01 -1169.60,-976.85"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1085.73,-1172.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-156.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2184,8 +2226,8 @@
         <g id="140">
             <desc>L26-27-1</desc>
             <g id="140.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-1289.38,-701.82 -1405.71,-485.40"/>
-                <g class="nad-edge-infos" transform="translate(-1323.70,-637.96)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1289.38,-701.82 -1405.71,-485.40"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1323.70,-637.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-151.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2203,8 +2245,8 @@
                 </g>
             </g>
             <g id="140.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-1522.05,-268.98 -1405.71,-485.40"/>
-                <g class="nad-edge-infos" transform="translate(-1506.66,-297.61)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1522.05,-268.98 -1405.71,-485.40"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1506.66,-297.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(28.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2242,7 +2284,6 @@
                         <text transform="rotate(48.85)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-1248.08" cy="-601.43" r="20.00"/>
             </g>
             <g id="141.2" class="nad-vl0to30-line">
                 <path class="nad-edge-path" d="M-1293.21,-681.75 L-1306.94,-641.53 C-1319.87,-603.68 -1297.14,-591.77 -1287.33,-593.70"/>
@@ -2262,7 +2303,14 @@
                         <text transform="rotate(-71.15)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-1267.71" cy="-597.57" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl0to30-line">
+                    <circle class="nad-winding" cx="-1248.08" cy="-601.43" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30-line">
+                    <circle class="nad-winding" cx="-1267.71" cy="-597.57" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="142">
@@ -2285,7 +2333,6 @@
                         <text transform="rotate(-43.66)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-1166.84" cy="-755.28" r="20.00"/>
             </g>
             <g id="142.2" class="nad-vl0to30-line">
                 <path class="nad-edge-path" d="M-1245.11,-706.68 L-1204.32,-694.72 C-1165.94,-683.47 -1155.04,-706.70 -1157.40,-716.41"/>
@@ -2305,7 +2352,14 @@
                         <text transform="rotate(16.34)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-1162.12" cy="-735.85" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl0to30-line">
+                    <circle class="nad-winding" cx="-1166.84" cy="-755.28" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30-line">
+                    <circle class="nad-winding" cx="-1162.12" cy="-735.85" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="143">
@@ -2328,7 +2382,6 @@
                         <text transform="rotate(-4.25)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-1393.52" cy="-760.36" r="20.00"/>
             </g>
             <g id="143.2" class="nad-vl0to30-line">
                 <path class="nad-edge-path" d="M-1290.94,-731.70 L-1326.11,-783.37 C-1348.63,-816.43 -1371.80,-805.40 -1376.14,-796.39"/>
@@ -2348,14 +2401,21 @@
                         <text transform="rotate(-304.25)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-1384.83" cy="-778.38" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl0to30-line">
+                    <circle class="nad-winding" cx="-1393.52" cy="-760.36" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30-line">
+                    <circle class="nad-winding" cx="-1384.83" cy="-778.38" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="144">
             <desc>L27-28-1</desc>
             <g id="144.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-1526.00,-218.80 -1441.61,22.81"/>
-                <g class="nad-edge-infos" transform="translate(-1515.28,-188.12)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1526.00,-218.80 -1441.61,22.81"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1515.28,-188.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(160.75)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2373,8 +2433,8 @@
                 </g>
             </g>
             <g id="144.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-1357.22,264.41 -1441.61,22.81"/>
-                <g class="nad-edge-infos" transform="translate(-1367.94,233.73)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1357.22,264.41 -1441.61,22.81"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1367.94,233.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-19.25)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2395,8 +2455,8 @@
         <g id="145">
             <desc>L28-29-1</desc>
             <g id="145.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-1327.67,308.73 -1056.78,551.44"/>
-                <g class="nad-edge-infos" transform="translate(-1303.46,330.41)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1327.67,308.73 -1056.78,551.44"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1303.46,330.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(131.86)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2414,8 +2474,8 @@
                 </g>
             </g>
             <g id="145.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-785.90,794.16 -1056.78,551.44"/>
-                <g class="nad-edge-infos" transform="translate(-810.11,772.47)">
+                <polyline class="nad-edge-path nad-stretchable" points="-785.90,794.16 -1056.78,551.44"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-810.11,772.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-48.14)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2436,8 +2496,8 @@
         <g id="146">
             <desc>L3-4-1</desc>
             <g id="146.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-709.25,422.44 -918.53,729.73"/>
-                <g class="nad-edge-infos" transform="translate(-727.54,449.30)">
+                <polyline class="nad-edge-path nad-stretchable" points="-709.25,422.44 -918.53,729.73"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-727.54,449.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-145.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2455,8 +2515,8 @@
                 </g>
             </g>
             <g id="146.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-1127.82,1037.02 -918.53,729.73"/>
-                <g class="nad-edge-infos" transform="translate(-1109.53,1010.15)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1127.82,1037.02 -918.53,729.73"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1109.53,1010.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(34.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2477,8 +2537,8 @@
         <g id="147">
             <desc>L30-31-1</desc>
             <g id="147.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-1040.33,-1244.14 -851.44,-1390.77"/>
-                <g class="nad-edge-infos" transform="translate(-1014.66,-1264.07)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1040.33,-1244.14 -851.44,-1390.77"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1014.66,-1264.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(52.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2496,8 +2556,8 @@
                 </g>
             </g>
             <g id="147.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-662.54,-1537.39 -851.44,-1390.77"/>
-                <g class="nad-edge-infos" transform="translate(-688.22,-1517.47)">
+                <polyline class="nad-edge-path nad-stretchable" points="-662.54,-1537.39 -851.44,-1390.77"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-688.22,-1517.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-127.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2518,8 +2578,8 @@
         <g id="148">
             <desc>L31-32-1</desc>
             <g id="148.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-614.74,-1562.99 -386.26,-1639.49"/>
-                <g class="nad-edge-infos" transform="translate(-583.92,-1573.31)">
+                <polyline class="nad-edge-path nad-stretchable" points="-614.74,-1562.99 -386.26,-1639.49"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-583.92,-1573.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(71.49)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2537,8 +2597,8 @@
                 </g>
             </g>
             <g id="148.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-157.79,-1715.99 -386.26,-1639.49"/>
-                <g class="nad-edge-infos" transform="translate(-188.61,-1705.67)">
+                <polyline class="nad-edge-path nad-stretchable" points="-157.79,-1715.99 -386.26,-1639.49"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-188.61,-1705.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-108.51)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2559,8 +2619,8 @@
         <g id="149">
             <desc>L32-33-1</desc>
             <g id="149.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-111.56,-1791.14 -134.15,-1946.09"/>
-                <g class="nad-edge-infos" transform="translate(-116.25,-1823.30)">
+                <polyline class="nad-edge-path nad-stretchable" points="-111.56,-1791.14 -134.15,-1946.09"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-116.25,-1823.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-8.30)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2578,8 +2638,8 @@
                 </g>
             </g>
             <g id="149.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-156.74,-2101.05 -134.15,-1946.09"/>
-                <g class="nad-edge-infos" transform="translate(-152.05,-2068.89)">
+                <polyline class="nad-edge-path nad-stretchable" points="-156.74,-2101.05 -134.15,-1946.09"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-152.05,-2068.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(171.70)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2600,8 +2660,8 @@
         <g id="150">
             <desc>L34-35-1</desc>
             <g id="150.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-76.65,-1727.30 184.70,-1659.14"/>
-                <g class="nad-edge-infos" transform="translate(-16.17,-1711.53)">
+                <polyline class="nad-edge-path nad-stretchable" points="-76.65,-1727.30 184.70,-1659.14"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-16.17,-1711.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.62)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2619,8 +2679,8 @@
                 </g>
             </g>
             <g id="150.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="446.06,-1590.98 184.70,-1659.14"/>
-                <g class="nad-edge-infos" transform="translate(414.61,-1599.18)">
+                <polyline class="nad-edge-path nad-stretchable" points="446.06,-1590.98 184.70,-1659.14"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(414.61,-1599.18)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-75.38)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2658,7 +2718,6 @@
                         <text transform="rotate(58.05)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-89.19" cy="-1614.65" r="20.00"/>
             </g>
             <g id="151.2" class="nad-vl0to30-line">
                 <path class="nad-edge-path" d="M-130.30,-1683.50 L-140.88,-1663.64 C-159.70,-1628.34 -139.16,-1612.95 -129.17,-1613.29"/>
@@ -2678,14 +2737,21 @@
                         <text transform="rotate(-61.95)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-109.18" cy="-1613.97" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl0to30-line">
+                    <circle class="nad-winding" cx="-89.19" cy="-1614.65" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30-line">
+                    <circle class="nad-winding" cx="-109.18" cy="-1613.97" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="152">
             <desc>L35-36-1</desc>
             <g id="152.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="495.16,-1568.21 731.41,-1402.05"/>
-                <g class="nad-edge-infos" transform="translate(521.75,-1549.52)">
+                <polyline class="nad-edge-path nad-stretchable" points="495.16,-1568.21 731.41,-1402.05"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(521.75,-1549.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(125.12)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2703,8 +2769,8 @@
                 </g>
             </g>
             <g id="152.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="967.66,-1235.89 731.41,-1402.05"/>
-                <g class="nad-edge-infos" transform="translate(941.07,-1254.58)">
+                <polyline class="nad-edge-path nad-stretchable" points="967.66,-1235.89 731.41,-1402.05"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(941.07,-1254.58)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-54.88)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2725,8 +2791,8 @@
         <g id="153">
             <desc>L36-37-1</desc>
             <g id="153.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="984.88,-1193.08 957.06,-1050.78"/>
-                <g class="nad-edge-infos" transform="translate(978.64,-1161.18)">
+                <polyline class="nad-edge-path nad-stretchable" points="984.88,-1193.08 957.06,-1050.78"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(978.64,-1161.18)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-168.94)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2744,8 +2810,8 @@
                 </g>
             </g>
             <g id="153.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="929.25,-908.49 957.06,-1050.78"/>
-                <g class="nad-edge-infos" transform="translate(935.48,-940.38)">
+                <polyline class="nad-edge-path nad-stretchable" points="929.25,-908.49 957.06,-1050.78"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(935.48,-940.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(11.06)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2766,8 +2832,8 @@
         <g id="154">
             <desc>L36-40-1</desc>
             <g id="154.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="1005.68,-1197.37 1215.33,-891.12"/>
-                <g class="nad-edge-infos" transform="translate(1024.04,-1170.55)">
+                <polyline class="nad-edge-path nad-stretchable" points="1005.68,-1197.37 1215.33,-891.12"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1024.04,-1170.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(145.61)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2785,8 +2851,8 @@
                 </g>
             </g>
             <g id="154.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="1424.97,-584.87 1215.33,-891.12"/>
-                <g class="nad-edge-infos" transform="translate(1389.66,-636.44)">
+                <polyline class="nad-edge-path nad-stretchable" points="1424.97,-584.87 1215.33,-891.12"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1389.66,-636.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-34.39)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2807,8 +2873,8 @@
         <g id="155">
             <desc>L37-38-1</desc>
             <g id="155.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="906.25,-860.47 698.13,-613.65"/>
-                <g class="nad-edge-infos" transform="translate(885.30,-835.63)">
+                <polyline class="nad-edge-path nad-stretchable" points="906.25,-860.47 698.13,-613.65"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(885.30,-835.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-139.86)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2826,8 +2892,8 @@
                 </g>
             </g>
             <g id="155.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="490.02,-366.83 698.13,-613.65"/>
-                <g class="nad-edge-infos" transform="translate(510.97,-391.67)">
+                <polyline class="nad-edge-path nad-stretchable" points="490.02,-366.83 698.13,-613.65"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(510.97,-391.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(40.14)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2848,8 +2914,8 @@
         <g id="156">
             <desc>L37-39-1</desc>
             <g id="156.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="951.19,-885.43 1171.30,-917.25"/>
-                <g class="nad-edge-infos" transform="translate(983.36,-890.08)">
+                <polyline class="nad-edge-path nad-stretchable" points="951.19,-885.43 1171.30,-917.25"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(983.36,-890.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(81.77)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2867,8 +2933,8 @@
                 </g>
             </g>
             <g id="156.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="1391.42,-949.08 1171.30,-917.25"/>
-                <g class="nad-edge-infos" transform="translate(1329.56,-940.13)">
+                <polyline class="nad-edge-path nad-stretchable" points="1391.42,-949.08 1171.30,-917.25"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1329.56,-940.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-98.23)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2889,8 +2955,8 @@
         <g id="157">
             <desc>L38-44-1</desc>
             <g id="157.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="451.00,-363.21 330.33,-461.93"/>
-                <g class="nad-edge-infos" transform="translate(425.85,-383.79)">
+                <polyline class="nad-edge-path nad-stretchable" points="451.00,-363.21 330.33,-461.93"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(425.85,-383.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-50.71)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2908,8 +2974,8 @@
                 </g>
             </g>
             <g id="157.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="209.66,-560.64 330.33,-461.93"/>
-                <g class="nad-edge-infos" transform="translate(234.82,-540.06)">
+                <polyline class="nad-edge-path nad-stretchable" points="209.66,-560.64 330.33,-461.93"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(234.82,-540.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(129.29)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2930,8 +2996,8 @@
         <g id="158">
             <desc>L38-48-1</desc>
             <g id="158.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="497.00,-333.74 694.48,-237.33"/>
-                <g class="nad-edge-infos" transform="translate(526.21,-319.48)">
+                <polyline class="nad-edge-path nad-stretchable" points="497.00,-333.74 694.48,-237.33"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(526.21,-319.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(116.02)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2949,8 +3015,8 @@
                 </g>
             </g>
             <g id="158.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="891.96,-140.93 694.48,-237.33"/>
-                <g class="nad-edge-infos" transform="translate(862.75,-155.19)">
+                <polyline class="nad-edge-path nad-stretchable" points="891.96,-140.93 694.48,-237.33"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(862.75,-155.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-63.98)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2971,8 +3037,8 @@
         <g id="159">
             <desc>L57-56-1</desc>
             <g id="159.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="1421.85,-895.60 1429.57,-757.59"/>
-                <g class="nad-edge-infos" transform="translate(1423.66,-863.15)">
+                <polyline class="nad-edge-path nad-stretchable" points="1421.85,-895.60 1429.57,-757.59"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1423.66,-863.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(176.80)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2990,8 +3056,8 @@
                 </g>
             </g>
             <g id="159.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="1437.29,-619.59 1429.57,-757.59"/>
-                <g class="nad-edge-infos" transform="translate(1435.47,-652.04)">
+                <polyline class="nad-edge-path nad-stretchable" points="1437.29,-619.59 1429.57,-757.59"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1435.47,-652.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-3.20)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3029,7 +3095,6 @@
                         <text transform="rotate(-80.71)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="1486.88" cy="-1052.22" r="20.00"/>
             </g>
             <g id="160.2" class="nad-vl0to30-line">
                 <path class="nad-edge-path" d="M1472.42,-973.35 L1493.46,-981.31 C1530.88,-995.46 1525.58,-1020.57 1517.84,-1026.90"/>
@@ -3049,14 +3114,21 @@
                         <text transform="rotate(-20.71)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="1502.36" cy="-1039.56" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl0to30-line">
+                    <circle class="nad-winding" cx="1486.88" cy="-1052.22" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30-line">
+                    <circle class="nad-winding" cx="1502.36" cy="-1039.56" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="161">
             <desc>L4-5-1</desc>
             <g id="161.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-1217.03,1075.84 -1347.52,1055.87"/>
-                <g class="nad-edge-infos" transform="translate(-1249.15,1070.92)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1217.03,1075.84 -1347.52,1055.87"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1249.15,1070.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-81.30)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3074,8 +3146,8 @@
                 </g>
             </g>
             <g id="161.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-1478.02,1035.89 -1347.52,1055.87"/>
-                <g class="nad-edge-infos" transform="translate(-1445.89,1040.81)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1478.02,1035.89 -1347.52,1055.87"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1445.89,1040.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(98.70)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3096,8 +3168,8 @@
         <g id="162">
             <desc>L4-6-1</desc>
             <g id="162.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-1134.36,1033.17 -1093.75,952.40"/>
-                <g class="nad-edge-infos" transform="translate(-1119.76,1004.13)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1134.36,1033.17 -1093.75,952.40"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1119.76,1004.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(26.69)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3115,8 +3187,8 @@
                 </g>
             </g>
             <g id="162.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-1053.14,871.63 -1093.75,952.40"/>
-                <g class="nad-edge-infos" transform="translate(-1067.74,900.67)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1053.14,871.63 -1093.75,952.40"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1067.74,900.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-153.31)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3154,7 +3226,6 @@
                         <text transform="rotate(-28.35)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-1039.95" cy="1078.00" r="20.00"/>
             </g>
             <g id="163.2" class="nad-vl0to30-line">
                 <path class="nad-edge-path" d="M-1136.78,1098.97 L-1092.09,1126.52 C-1058.04,1147.51 -1041.39,1127.98 -1041.10,1117.99"/>
@@ -3174,7 +3245,14 @@
                         <text transform="rotate(31.65)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-1040.53" cy="1097.99" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl0to30-line">
+                    <circle class="nad-winding" cx="-1039.95" cy="1078.00" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30-line">
+                    <circle class="nad-winding" cx="-1040.53" cy="1097.99" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="164">
@@ -3197,7 +3275,6 @@
                         <text transform="rotate(-86.13)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-1218.77" cy="1189.75" r="20.00"/>
             </g>
             <g id="164.2" class="nad-vl0to30-line">
                 <path class="nad-edge-path" d="M-1184.88,1096.65 L-1232.02,1119.77 C-1267.93,1137.38 -1260.28,1161.88 -1251.98,1167.45"/>
@@ -3217,14 +3294,21 @@
                         <text transform="rotate(-26.13)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-1235.38" cy="1178.60" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl0to30-line">
+                    <circle class="nad-winding" cx="-1218.77" cy="1189.75" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30-line">
+                    <circle class="nad-winding" cx="-1235.38" cy="1178.60" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="165">
             <desc>L56-42-1</desc>
             <g id="165.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="1466.87,-511.08 1554.24,-341.80"/>
-                <g class="nad-edge-infos" transform="translate(1481.78,-482.20)">
+                <polyline class="nad-edge-path nad-stretchable" points="1466.87,-511.08 1554.24,-341.80"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1481.78,-482.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(152.70)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3242,8 +3326,8 @@
                 </g>
             </g>
             <g id="165.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="1641.60,-172.52 1554.24,-341.80"/>
-                <g class="nad-edge-infos" transform="translate(1626.70,-201.40)">
+                <polyline class="nad-edge-path nad-stretchable" points="1641.60,-172.52 1554.24,-341.80"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1626.70,-201.40)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-27.30)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3281,7 +3365,6 @@
                         <text transform="rotate(-45.25)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="1553.64" cy="-603.39" r="20.00"/>
             </g>
             <g id="166.2" class="nad-vl0to30-line">
                 <path class="nad-edge-path" d="M1496.11,-547.54 L1517.86,-541.81 C1556.55,-531.62 1566.80,-555.15 1564.17,-564.80"/>
@@ -3301,14 +3384,21 @@
                         <text transform="rotate(14.75)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="1558.90" cy="-584.09" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl0to30-line">
+                    <circle class="nad-winding" cx="1553.64" cy="-603.39" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30-line">
+                    <circle class="nad-winding" cx="1558.90" cy="-584.09" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="167">
             <desc>L47-48-1</desc>
             <g id="167.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="967.99,-381.32 945.07,-268.57"/>
-                <g class="nad-edge-infos" transform="translate(961.52,-349.47)">
+                <polyline class="nad-edge-path nad-stretchable" points="967.99,-381.32 945.07,-268.57"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(961.52,-349.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-168.51)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3326,8 +3416,8 @@
                 </g>
             </g>
             <g id="167.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="922.15,-155.81 945.07,-268.57"/>
-                <g class="nad-edge-infos" transform="translate(928.62,-187.66)">
+                <polyline class="nad-edge-path nad-stretchable" points="922.15,-155.81 945.07,-268.57"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(928.62,-187.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(11.49)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3348,8 +3438,8 @@
         <g id="168">
             <desc>L5-6-1</desc>
             <g id="168.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-1479.65,1021.57 -1272.99,939.40"/>
-                <g class="nad-edge-infos" transform="translate(-1449.44,1009.56)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1479.65,1021.57 -1272.99,939.40"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1449.44,1009.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(68.32)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3367,8 +3457,8 @@
                 </g>
             </g>
             <g id="168.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-1066.34,857.23 -1272.99,939.40"/>
-                <g class="nad-edge-infos" transform="translate(-1096.54,869.23)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1066.34,857.23 -1272.99,939.40"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1096.54,869.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-111.68)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3389,8 +3479,8 @@
         <g id="169">
             <desc>L29-52-1</desc>
             <g id="169.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-710.22,879.71 -514.35,1160.97"/>
-                <g class="nad-edge-infos" transform="translate(-691.64,906.38)">
+                <polyline class="nad-edge-path nad-stretchable" points="-710.22,879.71 -514.35,1160.97"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-691.64,906.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(145.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3408,8 +3498,8 @@
                 </g>
             </g>
             <g id="169.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-318.48,1442.23 -514.35,1160.97"/>
-                <g class="nad-edge-infos" transform="translate(-337.05,1415.56)">
+                <polyline class="nad-edge-path nad-stretchable" points="-318.48,1442.23 -514.35,1160.97"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-337.05,1415.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-34.85)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3430,8 +3520,8 @@
         <g id="170">
             <desc>L52-53-1</desc>
             <g id="170.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-277.43,1475.51 -81.16,1558.51"/>
-                <g class="nad-edge-infos" transform="translate(-247.50,1488.17)">
+                <polyline class="nad-edge-path nad-stretchable" points="-277.43,1475.51 -81.16,1558.51"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-247.50,1488.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(112.92)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3449,8 +3539,8 @@
                 </g>
             </g>
             <g id="170.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="115.11,1641.51 -81.16,1558.51"/>
-                <g class="nad-edge-infos" transform="translate(85.17,1628.85)">
+                <polyline class="nad-edge-path nad-stretchable" points="115.11,1641.51 -81.16,1558.51"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(85.17,1628.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-67.08)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3471,8 +3561,8 @@
         <g id="171">
             <desc>L53-54-1</desc>
             <g id="171.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="160.70,1633.62 308.58,1497.93"/>
-                <g class="nad-edge-infos" transform="translate(184.64,1611.65)">
+                <polyline class="nad-edge-path nad-stretchable" points="160.70,1633.62 308.58,1497.93"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(184.64,1611.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(47.46)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3490,8 +3580,8 @@
                 </g>
             </g>
             <g id="171.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="456.46,1362.24 308.58,1497.93"/>
-                <g class="nad-edge-infos" transform="translate(432.52,1384.21)">
+                <polyline class="nad-edge-path nad-stretchable" points="456.46,1362.24 308.58,1497.93"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(432.52,1384.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-132.54)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3512,8 +3602,8 @@
         <g id="172">
             <desc>L54-55-1</desc>
             <g id="172.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="480.02,1316.35 513.64,1037.50"/>
-                <g class="nad-edge-infos" transform="translate(483.91,1284.08)">
+                <polyline class="nad-edge-path nad-stretchable" points="480.02,1316.35 513.64,1037.50"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(483.91,1284.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(6.87)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3531,8 +3621,8 @@
                 </g>
             </g>
             <g id="172.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="547.26,758.65 513.64,1037.50"/>
-                <g class="nad-edge-infos" transform="translate(539.78,820.70)">
+                <polyline class="nad-edge-path nad-stretchable" points="547.26,758.65 513.64,1037.50"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(539.78,820.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-173.13)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3553,8 +3643,8 @@
         <g id="173">
             <desc>L6-7-1</desc>
             <g id="173.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-1013.32,845.72 -891.93,839.80"/>
-                <g class="nad-edge-infos" transform="translate(-980.85,844.14)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1013.32,845.72 -891.93,839.80"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-980.85,844.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(87.20)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3572,8 +3662,8 @@
                 </g>
             </g>
             <g id="173.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-770.54,833.87 -891.93,839.80"/>
-                <g class="nad-edge-infos" transform="translate(-832.97,836.92)">
+                <polyline class="nad-edge-path nad-stretchable" points="-770.54,833.87 -891.93,839.80"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-832.97,836.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-92.80)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3594,8 +3684,8 @@
         <g id="174">
             <desc>L6-8-1</desc>
             <g id="174.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-1013.29,847.52 -663.96,853.35"/>
-                <g class="nad-edge-infos" transform="translate(-980.79,848.07)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1013.29,847.52 -663.96,853.35"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-980.79,848.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(90.96)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3613,8 +3703,8 @@
                 </g>
             </g>
             <g id="174.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-314.64,859.17 -663.96,853.35"/>
-                <g class="nad-edge-infos" transform="translate(-347.14,858.63)">
+                <polyline class="nad-edge-path nad-stretchable" points="-314.64,859.17 -663.96,853.35"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-347.14,858.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-89.04)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3635,8 +3725,8 @@
         <g id="175">
             <desc>L7-8-1</desc>
             <g id="175.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-715.63,834.16 -515.11,846.08"/>
-                <g class="nad-edge-infos" transform="translate(-653.24,837.87)">
+                <polyline class="nad-edge-path nad-stretchable" points="-715.63,834.16 -515.11,846.08"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-653.24,837.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(93.40)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3654,8 +3744,8 @@
                 </g>
             </g>
             <g id="175.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-314.59,858.00 -515.11,846.08"/>
-                <g class="nad-edge-infos" transform="translate(-347.04,856.07)">
+                <polyline class="nad-edge-path nad-stretchable" points="-314.59,858.00 -515.11,846.08"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-347.04,856.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-86.60)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3693,7 +3783,6 @@
                         <text transform="rotate(-277.37)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-706.13" cy="717.92" r="20.00"/>
             </g>
             <g id="176.2" class="nad-vl0to30-line">
                 <path class="nad-edge-path" d="M-697.38,797.63 L-679.50,783.97 C-647.71,759.69 -659.98,737.16 -669.21,733.31"/>
@@ -3713,14 +3802,21 @@
                         <text transform="rotate(-37.37)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-687.67" cy="725.62" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl0to30-line">
+                    <circle class="nad-winding" cx="-706.13" cy="717.92" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30-line">
+                    <circle class="nad-winding" cx="-687.67" cy="725.62" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="177">
             <desc>L8-9-1</desc>
             <g id="177.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="-259.96,855.47 116.88,797.76"/>
-                <g class="nad-edge-infos" transform="translate(-227.83,850.55)">
+                <polyline class="nad-edge-path nad-stretchable" points="-259.96,855.47 116.88,797.76"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-227.83,850.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(81.29)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3738,8 +3834,8 @@
                 </g>
             </g>
             <g id="177.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path" points="493.71,740.06 116.88,797.76"/>
-                <g class="nad-edge-infos" transform="translate(461.59,744.98)">
+                <polyline class="nad-edge-path nad-stretchable" points="493.71,740.06 116.88,797.76"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(461.59,744.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-98.71)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3777,7 +3873,6 @@
                         <text transform="rotate(27.97)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="622.68" cy="827.77" r="20.00"/>
             </g>
             <g id="178.2" class="nad-vl0to30-line">
                 <path class="nad-edge-path" d="M551.53,758.83 L553.39,811.30 C554.81,851.28 580.29,854.30 588.77,848.99"/>
@@ -3797,7 +3892,14 @@
                         <text transform="rotate(87.97)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="605.73" cy="838.38" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl0to30-line">
+                    <circle class="nad-winding" cx="622.68" cy="827.77" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30-line">
+                    <circle class="nad-winding" cx="605.73" cy="838.38" r="20.00"/>
+                </g>
             </g>
         </g>
     </g>

--- a/network-area-diagram/src/test/resources/IEEE_57_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_57_bus.svg
@@ -814,12 +814,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl0to30-line">
-                    <circle class="nad-winding" cx="866.54" cy="952.18" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30-line">
-                    <circle class="nad-winding" cx="846.61" cy="953.90" r="20.00"/>
-                </g>
+                <circle class="nad-vl0to30-line nad-winding" cx="866.54" cy="952.18" r="20.00"/>
+                <circle class="nad-vl0to30-line nad-winding" cx="846.61" cy="953.90" r="20.00"/>
             </g>
         </g>
         <g id="107">
@@ -1068,12 +1064,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl0to30-line">
-                    <circle class="nad-winding" cx="1249.18" cy="255.17" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30-line">
-                    <circle class="nad-winding" cx="1229.19" cy="254.71" r="20.00"/>
-                </g>
+                <circle class="nad-vl0to30-line nad-winding" cx="1249.18" cy="255.17" r="20.00"/>
+                <circle class="nad-vl0to30-line nad-winding" cx="1229.19" cy="254.71" r="20.00"/>
             </g>
         </g>
         <g id="113">
@@ -1117,12 +1109,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl0to30-line">
-                    <circle class="nad-winding" cx="1153.20" cy="53.59" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30-line">
-                    <circle class="nad-winding" cx="1167.89" cy="40.02" r="20.00"/>
-                </g>
+                <circle class="nad-vl0to30-line nad-winding" cx="1153.20" cy="53.59" r="20.00"/>
+                <circle class="nad-vl0to30-line nad-winding" cx="1167.89" cy="40.02" r="20.00"/>
             </g>
         </g>
         <g id="114">
@@ -1576,12 +1564,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl0to30-line">
-                    <circle class="nad-winding" cx="774.00" cy="351.09" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30-line">
-                    <circle class="nad-winding" cx="754.40" cy="355.07" r="20.00"/>
-                </g>
+                <circle class="nad-vl0to30-line nad-winding" cx="774.00" cy="351.09" r="20.00"/>
+                <circle class="nad-vl0to30-line nad-winding" cx="754.40" cy="355.07" r="20.00"/>
             </g>
         </g>
         <g id="125">
@@ -1707,12 +1691,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl0to30-line">
-                    <circle class="nad-winding" cx="542.92" cy="-167.79" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30-line">
-                    <circle class="nad-winding" cx="560.78" cy="-176.80" r="20.00"/>
-                </g>
+                <circle class="nad-vl0to30-line nad-winding" cx="542.92" cy="-167.79" r="20.00"/>
+                <circle class="nad-vl0to30-line nad-winding" cx="560.78" cy="-176.80" r="20.00"/>
             </g>
         </g>
         <g id="128">
@@ -1838,12 +1818,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl0to30-line">
-                    <circle class="nad-winding" cx="157.94" cy="140.38" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30-line">
-                    <circle class="nad-winding" cx="137.96" cy="141.18" r="20.00"/>
-                </g>
+                <circle class="nad-vl0to30-line nad-winding" cx="157.94" cy="140.38" r="20.00"/>
+                <circle class="nad-vl0to30-line nad-winding" cx="137.96" cy="141.18" r="20.00"/>
             </g>
         </g>
         <g id="131">
@@ -2051,12 +2027,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl0to30-line">
-                    <circle class="nad-winding" cx="-478.51" cy="1137.33" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30-line">
-                    <circle class="nad-winding" cx="-488.04" cy="1154.91" r="20.00"/>
-                </g>
+                <circle class="nad-vl0to30-line nad-winding" cx="-478.51" cy="1137.33" r="20.00"/>
+                <circle class="nad-vl0to30-line nad-winding" cx="-488.04" cy="1154.91" r="20.00"/>
             </g>
         </g>
         <g id="136">
@@ -2305,12 +2277,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl0to30-line">
-                    <circle class="nad-winding" cx="-1248.08" cy="-601.43" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30-line">
-                    <circle class="nad-winding" cx="-1267.71" cy="-597.57" r="20.00"/>
-                </g>
+                <circle class="nad-vl0to30-line nad-winding" cx="-1248.08" cy="-601.43" r="20.00"/>
+                <circle class="nad-vl0to30-line nad-winding" cx="-1267.71" cy="-597.57" r="20.00"/>
             </g>
         </g>
         <g id="142">
@@ -2354,12 +2322,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl0to30-line">
-                    <circle class="nad-winding" cx="-1166.84" cy="-755.28" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30-line">
-                    <circle class="nad-winding" cx="-1162.12" cy="-735.85" r="20.00"/>
-                </g>
+                <circle class="nad-vl0to30-line nad-winding" cx="-1166.84" cy="-755.28" r="20.00"/>
+                <circle class="nad-vl0to30-line nad-winding" cx="-1162.12" cy="-735.85" r="20.00"/>
             </g>
         </g>
         <g id="143">
@@ -2403,12 +2367,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl0to30-line">
-                    <circle class="nad-winding" cx="-1393.52" cy="-760.36" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30-line">
-                    <circle class="nad-winding" cx="-1384.83" cy="-778.38" r="20.00"/>
-                </g>
+                <circle class="nad-vl0to30-line nad-winding" cx="-1393.52" cy="-760.36" r="20.00"/>
+                <circle class="nad-vl0to30-line nad-winding" cx="-1384.83" cy="-778.38" r="20.00"/>
             </g>
         </g>
         <g id="144">
@@ -2739,12 +2699,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl0to30-line">
-                    <circle class="nad-winding" cx="-89.19" cy="-1614.65" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30-line">
-                    <circle class="nad-winding" cx="-109.18" cy="-1613.97" r="20.00"/>
-                </g>
+                <circle class="nad-vl0to30-line nad-winding" cx="-89.19" cy="-1614.65" r="20.00"/>
+                <circle class="nad-vl0to30-line nad-winding" cx="-109.18" cy="-1613.97" r="20.00"/>
             </g>
         </g>
         <g id="152">
@@ -3116,12 +3072,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl0to30-line">
-                    <circle class="nad-winding" cx="1486.88" cy="-1052.22" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30-line">
-                    <circle class="nad-winding" cx="1502.36" cy="-1039.56" r="20.00"/>
-                </g>
+                <circle class="nad-vl0to30-line nad-winding" cx="1486.88" cy="-1052.22" r="20.00"/>
+                <circle class="nad-vl0to30-line nad-winding" cx="1502.36" cy="-1039.56" r="20.00"/>
             </g>
         </g>
         <g id="161">
@@ -3247,12 +3199,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl0to30-line">
-                    <circle class="nad-winding" cx="-1039.95" cy="1078.00" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30-line">
-                    <circle class="nad-winding" cx="-1040.53" cy="1097.99" r="20.00"/>
-                </g>
+                <circle class="nad-vl0to30-line nad-winding" cx="-1039.95" cy="1078.00" r="20.00"/>
+                <circle class="nad-vl0to30-line nad-winding" cx="-1040.53" cy="1097.99" r="20.00"/>
             </g>
         </g>
         <g id="164">
@@ -3296,12 +3244,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl0to30-line">
-                    <circle class="nad-winding" cx="-1218.77" cy="1189.75" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30-line">
-                    <circle class="nad-winding" cx="-1235.38" cy="1178.60" r="20.00"/>
-                </g>
+                <circle class="nad-vl0to30-line nad-winding" cx="-1218.77" cy="1189.75" r="20.00"/>
+                <circle class="nad-vl0to30-line nad-winding" cx="-1235.38" cy="1178.60" r="20.00"/>
             </g>
         </g>
         <g id="165">
@@ -3386,12 +3330,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl0to30-line">
-                    <circle class="nad-winding" cx="1553.64" cy="-603.39" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30-line">
-                    <circle class="nad-winding" cx="1558.90" cy="-584.09" r="20.00"/>
-                </g>
+                <circle class="nad-vl0to30-line nad-winding" cx="1553.64" cy="-603.39" r="20.00"/>
+                <circle class="nad-vl0to30-line nad-winding" cx="1558.90" cy="-584.09" r="20.00"/>
             </g>
         </g>
         <g id="167">
@@ -3804,12 +3744,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl0to30-line">
-                    <circle class="nad-winding" cx="-706.13" cy="717.92" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30-line">
-                    <circle class="nad-winding" cx="-687.67" cy="725.62" r="20.00"/>
-                </g>
+                <circle class="nad-vl0to30-line nad-winding" cx="-706.13" cy="717.92" r="20.00"/>
+                <circle class="nad-vl0to30-line nad-winding" cx="-687.67" cy="725.62" r="20.00"/>
             </g>
         </g>
         <g id="177">
@@ -3894,12 +3830,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl0to30-line">
-                    <circle class="nad-winding" cx="622.68" cy="827.77" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30-line">
-                    <circle class="nad-winding" cx="605.73" cy="838.38" r="20.00"/>
-                </g>
+                <circle class="nad-vl0to30-line nad-winding" cx="622.68" cy="827.77" r="20.00"/>
+                <circle class="nad-vl0to30-line nad-winding" cx="605.73" cy="838.38" r="20.00"/>
             </g>
         </g>
     </g>

--- a/network-area-diagram/src/test/resources/current_limits.svg
+++ b/network-area-diagram/src/test/resources/current_limits.svg
@@ -72,8 +72,8 @@
     <g class="nad-branch-edges">
         <g id="4" class="nad-overload">
             <g id="4.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="140.62,-69.02 37.43,39.35"/>
-                <g class="nad-edge-infos" transform="translate(118.21,-45.48)">
+                <polyline class="nad-edge-path nad-stretchable" points="140.62,-69.02 37.43,39.35"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(118.21,-45.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-136.40)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -91,8 +91,8 @@
                 </g>
             </g>
             <g id="4.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="-65.77,147.71 37.43,39.35"/>
-                <g class="nad-edge-infos" transform="translate(-43.36,124.17)">
+                <polyline class="nad-edge-path nad-stretchable" points="-65.77,147.71 37.43,39.35"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-43.36,124.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(43.60)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/detailed_text_node.svg
+++ b/network-area-diagram/src/test/resources/detailed_text_node.svg
@@ -137,8 +137,8 @@
     <g class="nad-branch-edges">
         <g id="4">
             <g id="4.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="140.62,-69.02 37.43,39.35"/>
-                <g class="nad-edge-infos" transform="translate(118.21,-45.48)">
+                <polyline class="nad-edge-path nad-stretchable" points="140.62,-69.02 37.43,39.35"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(118.21,-45.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-136.40)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -156,8 +156,8 @@
                 </g>
             </g>
             <g id="4.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-65.77,147.71 37.43,39.35"/>
-                <g class="nad-edge-infos" transform="translate(-43.36,124.17)">
+                <polyline class="nad-edge-path nad-stretchable" points="-65.77,147.71 37.43,39.35"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-43.36,124.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(43.60)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/detailed_text_node_no_legend.svg
+++ b/network-area-diagram/src/test/resources/detailed_text_node_no_legend.svg
@@ -137,8 +137,8 @@
     <g class="nad-branch-edges">
         <g id="4">
             <g id="4.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="140.62,-69.02 37.43,39.35"/>
-                <g class="nad-edge-infos" transform="translate(118.21,-45.48)">
+                <polyline class="nad-edge-path nad-stretchable" points="140.62,-69.02 37.43,39.35"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(118.21,-45.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-136.40)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -156,8 +156,8 @@
                 </g>
             </g>
             <g id="4.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-65.77,147.71 37.43,39.35"/>
-                <g class="nad-edge-infos" transform="translate(-43.36,124.17)">
+                <polyline class="nad-edge-path nad-stretchable" points="-65.77,147.71 37.43,39.35"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-43.36,124.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(43.60)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.0.svg
+++ b/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.0.svg
@@ -230,12 +230,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl300to500">
-                    <circle class="nad-winding" cx="-1248.48" cy="216.21" r="20.00"/>
-                </g>
-                <g class="nad-vl180to300">
-                    <circle class="nad-winding" cx="-1232.08" cy="227.65" r="20.00"/>
-                </g>
+                <circle class="nad-vl300to500 nad-winding" cx="-1248.48" cy="216.21" r="20.00"/>
+                <circle class="nad-vl180to300 nad-winding" cx="-1232.08" cy="227.65" r="20.00"/>
             </g>
         </g>
         <g id="32">
@@ -318,12 +314,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl50to70">
-                    <circle class="nad-winding" cx="876.35" cy="-194.88" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30">
-                    <circle class="nad-winding" cx="891.71" cy="-207.68" r="20.00"/>
-                </g>
+                <circle class="nad-vl50to70 nad-winding" cx="876.35" cy="-194.88" r="20.00"/>
+                <circle class="nad-vl0to30 nad-winding" cx="891.71" cy="-207.68" r="20.00"/>
             </g>
         </g>
         <g id="34">
@@ -366,12 +358,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl180to300">
-                    <circle class="nad-winding" cx="272.79" cy="162.82" r="20.00"/>
-                </g>
-                <g class="nad-vl50to70">
-                    <circle class="nad-winding" cx="290.75" cy="154.02" r="20.00"/>
-                </g>
+                <circle class="nad-vl180to300 nad-winding" cx="272.79" cy="162.82" r="20.00"/>
+                <circle class="nad-vl50to70 nad-winding" cx="290.75" cy="154.02" r="20.00"/>
             </g>
         </g>
         <g id="35">
@@ -574,12 +562,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl50to70">
-                    <circle class="nad-winding" cx="651.79" cy="111.03" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30">
-                    <circle class="nad-winding" cx="632.97" cy="104.26" r="20.00"/>
-                </g>
+                <circle class="nad-vl50to70 nad-winding" cx="651.79" cy="111.03" r="20.00"/>
+                <circle class="nad-vl0to30 nad-winding" cx="632.97" cy="104.26" r="20.00"/>
             </g>
         </g>
         <g id="40">

--- a/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.0.svg
+++ b/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.0.svg
@@ -152,8 +152,8 @@
     <g class="nad-branch-edges">
         <g id="30">
             <g id="30.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="-1053.42,340.93 -866.40,391.80"/>
-                <g class="nad-edge-infos" transform="translate(-1022.06,349.46)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1053.42,340.93 -866.40,391.80"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1022.06,349.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(105.22)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -171,8 +171,8 @@
                 </g>
             </g>
             <g id="30.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="-679.38,442.67 -866.40,391.80"/>
-                <g class="nad-edge-infos" transform="translate(-710.74,434.14)">
+                <polyline class="nad-edge-path nad-stretchable" points="-679.38,442.67 -866.40,391.80"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-710.74,434.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-74.78)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -192,8 +192,8 @@
         </g>
         <g id="31">
             <g id="31.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="-1378.04,125.88 -1264.89,204.77"/>
-                <g class="nad-edge-infos" transform="translate(-1351.38,144.47)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1378.04,125.88 -1264.89,204.77"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1351.38,144.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(124.88)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -209,11 +209,10 @@
                         <text transform="rotate(34.88)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-1248.48" cy="216.21" r="20.00"/>
             </g>
             <g id="31.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="-1102.52,317.98 -1215.67,239.09"/>
-                <g class="nad-edge-infos" transform="translate(-1129.18,299.39)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1102.52,317.98 -1215.67,239.09"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1129.18,299.39)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-55.12)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -229,13 +228,20 @@
                         <text transform="rotate(-325.12)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-1232.08" cy="227.65" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl300to500">
+                    <circle class="nad-winding" cx="-1248.48" cy="216.21" r="20.00"/>
+                </g>
+                <g class="nad-vl180to300">
+                    <circle class="nad-winding" cx="-1232.08" cy="227.65" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="32">
             <g id="32.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="-625.73,445.30 -392.94,405.86"/>
-                <g class="nad-edge-infos" transform="translate(-593.69,439.87)">
+                <polyline class="nad-edge-path nad-stretchable" points="-625.73,445.30 -392.94,405.86"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-593.69,439.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(80.39)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -253,8 +259,8 @@
                 </g>
             </g>
             <g id="32.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="-160.15,366.42 -392.94,405.86"/>
-                <g class="nad-edge-infos" transform="translate(-192.19,371.85)">
+                <polyline class="nad-edge-path nad-stretchable" points="-160.15,366.42 -392.94,405.86"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-192.19,371.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-99.61)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -274,8 +280,8 @@
         </g>
         <g id="33">
             <g id="33.1" class="nad-vl50to70">
-                <polyline class="nad-edge-path" points="717.69,-62.60 860.99,-182.07"/>
-                <g class="nad-edge-infos" transform="translate(742.65,-83.41)">
+                <polyline class="nad-edge-path nad-stretchable" points="717.69,-62.60 860.99,-182.07"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(742.65,-83.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(50.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -291,11 +297,10 @@
                         <text transform="rotate(-39.82)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="876.35" cy="-194.88" r="20.00"/>
             </g>
             <g id="33.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="1050.37,-339.96 907.07,-220.49"/>
-                <g class="nad-edge-infos" transform="translate(1025.41,-319.14)">
+                <polyline class="nad-edge-path nad-stretchable" points="1050.37,-339.96 907.07,-220.49"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1025.41,-319.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-129.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -311,13 +316,20 @@
                         <text transform="rotate(-39.82)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="891.71" cy="-207.68" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl50to70">
+                    <circle class="nad-winding" cx="876.35" cy="-194.88" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30">
+                    <circle class="nad-winding" cx="891.71" cy="-207.68" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="34">
             <g id="34.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="-108.34,349.72 254.83,171.63"/>
-                <g class="nad-edge-infos" transform="translate(-79.16,335.41)">
+                <polyline class="nad-edge-path nad-stretchable" points="-108.34,349.72 254.83,171.63"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-79.16,335.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(63.88)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -333,11 +345,10 @@
                         <text transform="rotate(-26.12)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="272.79" cy="162.82" r="20.00"/>
             </g>
             <g id="34.2" class="nad-vl50to70">
-                <polyline class="nad-edge-path" points="671.88,-32.88 308.70,145.21"/>
-                <g class="nad-edge-infos" transform="translate(642.70,-18.57)">
+                <polyline class="nad-edge-path nad-stretchable" points="671.88,-32.88 308.70,145.21"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(642.70,-18.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-116.12)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -353,13 +364,20 @@
                         <text transform="rotate(-26.12)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="290.75" cy="154.02" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl180to300">
+                    <circle class="nad-winding" cx="272.79" cy="162.82" r="20.00"/>
+                </g>
+                <g class="nad-vl50to70">
+                    <circle class="nad-winding" cx="290.75" cy="154.02" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="35">
             <g id="35.1" class="nad-vl50to70">
-                <polyline class="nad-edge-path" points="713.75,-23.52 793.31,75.87"/>
-                <g class="nad-edge-infos" transform="translate(734.06,1.85)">
+                <polyline class="nad-edge-path nad-stretchable" points="713.75,-23.52 793.31,75.87"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(734.06,1.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(141.33)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -377,8 +395,8 @@
                 </g>
             </g>
             <g id="35.2" class="nad-vl50to70">
-                <polyline class="nad-edge-path" points="872.86,175.25 793.31,75.87"/>
-                <g class="nad-edge-infos" transform="translate(852.55,149.88)">
+                <polyline class="nad-edge-path nad-stretchable" points="872.86,175.25 793.31,75.87"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(852.55,149.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-38.67)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -398,8 +416,8 @@
         </g>
         <g id="36">
             <g id="36.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="394.36,-8.93 391.55,-230.95"/>
-                <g class="nad-edge-infos" transform="translate(393.95,-41.43)">
+                <polyline class="nad-edge-path nad-stretchable" points="394.36,-8.93 391.55,-230.95"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(393.95,-41.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-0.72)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -417,8 +435,8 @@
                 </g>
             </g>
             <g id="36.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="388.74,-452.96 391.55,-230.95"/>
-                <g class="nad-edge-infos" transform="translate(389.15,-420.46)">
+                <polyline class="nad-edge-path nad-stretchable" points="388.74,-452.96 391.55,-230.95"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(389.15,-420.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(179.28)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -438,8 +456,8 @@
         </g>
         <g id="37">
             <g id="37.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-177.00,-244.11 96.36,-118.51"/>
-                <g class="nad-edge-infos" transform="translate(-147.47,-230.54)">
+                <polyline class="nad-edge-path nad-stretchable" points="-177.00,-244.11 96.36,-118.51"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-147.47,-230.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(114.68)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -457,8 +475,8 @@
                 </g>
             </g>
             <g id="37.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="369.72,7.08 96.36,-118.51"/>
-                <g class="nad-edge-infos" transform="translate(340.19,-6.49)">
+                <polyline class="nad-edge-path nad-stretchable" points="369.72,7.08 96.36,-118.51"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(340.19,-6.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-65.32)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -478,8 +496,8 @@
         </g>
         <g id="38">
             <g id="38.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="524.17,514.32 462.91,279.75"/>
-                <g class="nad-edge-infos" transform="translate(515.96,482.88)">
+                <polyline class="nad-edge-path nad-stretchable" points="524.17,514.32 462.91,279.75"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(515.96,482.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-14.64)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -497,8 +515,8 @@
                 </g>
             </g>
             <g id="38.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="401.66,45.17 462.91,279.75"/>
-                <g class="nad-edge-infos" transform="translate(409.87,76.62)">
+                <polyline class="nad-edge-path nad-stretchable" points="401.66,45.17 462.91,279.75"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(409.87,76.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(165.36)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -518,8 +536,8 @@
         </g>
         <g id="39">
             <g id="39.1" class="nad-vl50to70">
-                <polyline class="nad-edge-path" points="864.17,187.42 670.61,117.80"/>
-                <g class="nad-edge-infos" transform="translate(833.58,176.42)">
+                <polyline class="nad-edge-path nad-stretchable" points="864.17,187.42 670.61,117.80"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(833.58,176.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-70.22)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -535,11 +553,10 @@
                         <text transform="rotate(-340.22)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="651.79" cy="111.03" r="20.00"/>
             </g>
             <g id="39.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="420.58,27.87 614.15,97.49"/>
-                <g class="nad-edge-infos" transform="translate(451.17,38.87)">
+                <polyline class="nad-edge-path nad-stretchable" points="420.58,27.87 614.15,97.49"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(451.17,38.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(109.78)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -555,13 +572,20 @@
                         <text transform="rotate(19.78)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="632.97" cy="104.26" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl50to70">
+                    <circle class="nad-winding" cx="651.79" cy="111.03" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30">
+                    <circle class="nad-winding" cx="632.97" cy="104.26" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="40">
             <g id="40.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="361.12,-484.01 207.73,-504.02"/>
-                <g class="nad-edge-infos" transform="translate(328.90,-488.22)">
+                <polyline class="nad-edge-path nad-stretchable" points="361.12,-484.01 207.73,-504.02"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(328.90,-488.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-82.57)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -579,8 +603,8 @@
                 </g>
             </g>
             <g id="40.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="54.34,-524.02 207.73,-504.02"/>
-                <g class="nad-edge-infos" transform="translate(86.56,-519.82)">
+                <polyline class="nad-edge-path nad-stretchable" points="54.34,-524.02 207.73,-504.02"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(86.56,-519.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(97.43)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -600,8 +624,8 @@
         </g>
         <g id="41">
             <g id="41.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="0.47,-534.58 -163.09,-577.62"/>
-                <g class="nad-edge-infos" transform="translate(-30.96,-542.85)">
+                <polyline class="nad-edge-path nad-stretchable" points="0.47,-534.58 -163.09,-577.62"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-30.96,-542.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-75.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -619,8 +643,8 @@
                 </g>
             </g>
             <g id="41.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-326.66,-620.67 -163.09,-577.62"/>
-                <g class="nad-edge-infos" transform="translate(-295.23,-612.40)">
+                <polyline class="nad-edge-path nad-stretchable" points="-326.66,-620.67 -163.09,-577.62"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-295.23,-612.40)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -640,8 +664,8 @@
         </g>
         <g id="42">
             <g id="42.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="27.54,-500.09 32.02,-240.72"/>
-                <g class="nad-edge-infos" transform="translate(28.10,-467.59)">
+                <polyline class="nad-edge-path nad-stretchable" points="27.54,-500.09 32.02,-240.72"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(28.10,-467.59)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(179.01)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -659,8 +683,8 @@
                 </g>
             </g>
             <g id="42.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="36.49,18.65 32.02,-240.72"/>
-                <g class="nad-edge-infos" transform="translate(35.93,-13.84)">
+                <polyline class="nad-edge-path nad-stretchable" points="36.49,18.65 32.02,-240.72"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(35.93,-13.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-0.99)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -680,8 +704,8 @@
         </g>
         <g id="43">
             <g id="43.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-342.90,-602.19 -277.62,-441.63"/>
-                <g class="nad-edge-infos" transform="translate(-330.66,-572.08)">
+                <polyline class="nad-edge-path nad-stretchable" points="-342.90,-602.19 -277.62,-441.63"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-330.66,-572.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(157.88)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -699,8 +723,8 @@
                 </g>
             </g>
             <g id="43.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-212.34,-281.06 -277.62,-441.63"/>
-                <g class="nad-edge-infos" transform="translate(-224.58,-311.17)">
+                <polyline class="nad-edge-path nad-stretchable" points="-212.34,-281.06 -277.62,-441.63"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-224.58,-311.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-22.12)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -720,8 +744,8 @@
         </g>
         <g id="44">
             <g id="44.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="44.75,72.52 117.06,317.59"/>
-                <g class="nad-edge-infos" transform="translate(53.95,103.69)">
+                <polyline class="nad-edge-path nad-stretchable" points="44.75,72.52 117.06,317.59"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(53.95,103.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(163.56)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -739,8 +763,8 @@
                 </g>
             </g>
             <g id="44.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="189.36,562.66 117.06,317.59"/>
-                <g class="nad-edge-infos" transform="translate(180.17,531.49)">
+                <polyline class="nad-edge-path nad-stretchable" points="189.36,562.66 117.06,317.59"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(180.17,531.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-16.44)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -760,8 +784,8 @@
         </g>
         <g id="45">
             <g id="45.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="224.37,585.12 364.13,564.99"/>
-                <g class="nad-edge-infos" transform="translate(256.53,580.49)">
+                <polyline class="nad-edge-path nad-stretchable" points="224.37,585.12 364.13,564.99"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(256.53,580.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(81.80)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -779,8 +803,8 @@
                 </g>
             </g>
             <g id="45.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="503.90,544.85 364.13,564.99"/>
-                <g class="nad-edge-infos" transform="translate(471.73,549.48)">
+                <polyline class="nad-edge-path nad-stretchable" points="503.90,544.85 364.13,564.99"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(471.73,549.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-98.20)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.2.svg
+++ b/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.2.svg
@@ -230,12 +230,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl300to500">
-                    <circle class="nad-winding" cx="-1912.68" cy="121.15" r="20.00"/>
-                </g>
-                <g class="nad-vl180to300">
-                    <circle class="nad-winding" cx="-1900.80" cy="137.24" r="20.00"/>
-                </g>
+                <circle class="nad-vl300to500 nad-winding" cx="-1912.68" cy="121.15" r="20.00"/>
+                <circle class="nad-vl180to300 nad-winding" cx="-1900.80" cy="137.24" r="20.00"/>
             </g>
         </g>
         <g id="32">
@@ -318,12 +314,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl50to70">
-                    <circle class="nad-winding" cx="-502.81" cy="570.73" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30">
-                    <circle class="nad-winding" cx="-507.79" cy="551.36" r="20.00"/>
-                </g>
+                <circle class="nad-vl50to70 nad-winding" cx="-502.81" cy="570.73" r="20.00"/>
+                <circle class="nad-vl0to30 nad-winding" cx="-507.79" cy="551.36" r="20.00"/>
             </g>
         </g>
         <g id="34">
@@ -366,12 +358,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl180to300">
-                    <circle class="nad-winding" cx="-739.28" cy="813.01" r="20.00"/>
-                </g>
-                <g class="nad-vl50to70">
-                    <circle class="nad-winding" cx="-719.62" cy="809.34" r="20.00"/>
-                </g>
+                <circle class="nad-vl180to300 nad-winding" cx="-739.28" cy="813.01" r="20.00"/>
+                <circle class="nad-vl50to70 nad-winding" cx="-719.62" cy="809.34" r="20.00"/>
             </g>
         </g>
         <g id="35">
@@ -574,12 +562,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl50to70">
-                    <circle class="nad-winding" cx="302.70" cy="372.93" r="20.00"/>
-                </g>
-                <g class="nad-vl0to30">
-                    <circle class="nad-winding" cx="315.17" cy="357.29" r="20.00"/>
-                </g>
+                <circle class="nad-vl50to70 nad-winding" cx="302.70" cy="372.93" r="20.00"/>
+                <circle class="nad-vl0to30 nad-winding" cx="315.17" cy="357.29" r="20.00"/>
             </g>
         </g>
         <g id="40">

--- a/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.2.svg
+++ b/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.2.svg
@@ -152,8 +152,8 @@
     <g class="nad-branch-edges">
         <g id="30">
             <g id="30.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="-1767.52,311.35 -1619.12,463.19"/>
-                <g class="nad-edge-infos" transform="translate(-1744.81,334.60)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1767.52,311.35 -1619.12,463.19"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1744.81,334.60)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(135.65)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -171,8 +171,8 @@
                 </g>
             </g>
             <g id="30.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="-1470.72,615.02 -1619.12,463.19"/>
-                <g class="nad-edge-infos" transform="translate(-1493.44,591.78)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1470.72,615.02 -1619.12,463.19"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1493.44,591.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-44.35)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -192,8 +192,8 @@
         </g>
         <g id="31">
             <g id="31.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="-2010.40,-11.18 -1924.56,105.06"/>
-                <g class="nad-edge-infos" transform="translate(-1991.10,14.97)">
+                <polyline class="nad-edge-path nad-stretchable" points="-2010.40,-11.18 -1924.56,105.06"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1991.10,14.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(143.55)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -209,11 +209,10 @@
                         <text transform="rotate(53.55)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-1912.68" cy="121.15" r="20.00"/>
             </g>
             <g id="31.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="-1803.08,269.57 -1888.92,153.33"/>
-                <g class="nad-edge-infos" transform="translate(-1822.39,243.42)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1803.08,269.57 -1888.92,153.33"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1822.39,243.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-36.45)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -229,13 +228,20 @@
                         <text transform="rotate(-306.45)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-1900.80" cy="137.24" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl300to500">
+                    <circle class="nad-winding" cx="-1912.68" cy="121.15" r="20.00"/>
+                </g>
+                <g class="nad-vl180to300">
+                    <circle class="nad-winding" cx="-1900.80" cy="137.24" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="32">
             <g id="32.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="-1427.00,647.18 -1228.08,748.64"/>
-                <g class="nad-edge-infos" transform="translate(-1398.05,661.95)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1427.00,647.18 -1228.08,748.64"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1398.05,661.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(117.02)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -253,8 +259,8 @@
                 </g>
             </g>
             <g id="32.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="-1029.17,850.09 -1228.08,748.64"/>
-                <g class="nad-edge-infos" transform="translate(-1058.12,835.33)">
+                <polyline class="nad-edge-path nad-stretchable" points="-1029.17,850.09 -1228.08,748.64"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1058.12,835.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-62.98)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -274,8 +280,8 @@
         </g>
         <g id="33">
             <g id="33.1" class="nad-vl50to70">
-                <polyline class="nad-edge-path" points="-461.07,733.13 -497.83,590.10"/>
-                <g class="nad-edge-infos" transform="translate(-469.16,701.65)">
+                <polyline class="nad-edge-path nad-stretchable" points="-461.07,733.13 -497.83,590.10"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-469.16,701.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-14.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -291,11 +297,10 @@
                         <text transform="rotate(-284.41)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-502.81" cy="570.73" r="20.00"/>
             </g>
             <g id="33.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-549.53,388.95 -512.77,531.99"/>
-                <g class="nad-edge-infos" transform="translate(-541.44,420.43)">
+                <polyline class="nad-edge-path nad-stretchable" points="-549.53,388.95 -512.77,531.99"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-541.44,420.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(165.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -311,13 +316,20 @@
                         <text transform="rotate(75.59)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-507.79" cy="551.36" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl50to70">
+                    <circle class="nad-winding" cx="-502.81" cy="570.73" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30">
+                    <circle class="nad-winding" cx="-507.79" cy="551.36" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="34">
             <g id="34.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="-977.64,857.54 -758.94,816.68"/>
-                <g class="nad-edge-infos" transform="translate(-945.69,851.57)">
+                <polyline class="nad-edge-path nad-stretchable" points="-977.64,857.54 -758.94,816.68"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-945.69,851.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(79.42)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -333,11 +345,10 @@
                         <text transform="rotate(-10.58)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-739.28" cy="813.01" r="20.00"/>
             </g>
             <g id="34.2" class="nad-vl50to70">
-                <polyline class="nad-edge-path" points="-481.26,764.81 -699.96,805.67"/>
-                <g class="nad-edge-infos" transform="translate(-513.21,770.78)">
+                <polyline class="nad-edge-path nad-stretchable" points="-481.26,764.81 -699.96,805.67"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-513.21,770.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-100.58)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -353,13 +364,20 @@
                         <text transform="rotate(-10.58)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-719.62" cy="809.34" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl180to300">
+                    <circle class="nad-winding" cx="-739.28" cy="813.01" r="20.00"/>
+                </g>
+                <g class="nad-vl50to70">
+                    <circle class="nad-winding" cx="-719.62" cy="809.34" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="35">
             <g id="35.1" class="nad-vl50to70">
-                <polyline class="nad-edge-path" points="-427.62,752.81 -170.92,685.75"/>
-                <g class="nad-edge-infos" transform="translate(-396.17,744.60)">
+                <polyline class="nad-edge-path nad-stretchable" points="-427.62,752.81 -170.92,685.75"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-396.17,744.60)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(75.36)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -377,8 +395,8 @@
                 </g>
             </g>
             <g id="35.2" class="nad-vl50to70">
-                <polyline class="nad-edge-path" points="85.77,618.69 -170.92,685.75"/>
-                <g class="nad-edge-infos" transform="translate(54.33,626.91)">
+                <polyline class="nad-edge-path nad-stretchable" points="85.77,618.69 -170.92,685.75"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(54.33,626.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-104.64)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -398,8 +416,8 @@
         </g>
         <g id="36">
             <g id="36.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="516.57,93.31 611.37,-122.24"/>
-                <g class="nad-edge-infos" transform="translate(529.65,63.56)">
+                <polyline class="nad-edge-path nad-stretchable" points="516.57,93.31 611.37,-122.24"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(529.65,63.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(23.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -417,8 +435,8 @@
                 </g>
             </g>
             <g id="36.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="706.18,-337.78 611.37,-122.24"/>
-                <g class="nad-edge-infos" transform="translate(693.09,-308.03)">
+                <polyline class="nad-edge-path nad-stretchable" points="706.18,-337.78 611.37,-122.24"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(693.09,-308.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-156.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -438,8 +456,8 @@
         </g>
         <g id="37">
             <g id="37.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="127.64,-376.35 308.22,-139.86"/>
-                <g class="nad-edge-infos" transform="translate(147.36,-350.52)">
+                <polyline class="nad-edge-path nad-stretchable" points="127.64,-376.35 308.22,-139.86"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(147.36,-350.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(142.63)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -457,8 +475,8 @@
                 </g>
             </g>
             <g id="37.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="488.80,96.62 308.22,-139.86"/>
-                <g class="nad-edge-infos" transform="translate(469.08,70.79)">
+                <polyline class="nad-edge-path nad-stretchable" points="488.80,96.62 308.22,-139.86"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(469.08,70.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-37.37)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -478,8 +496,8 @@
         </g>
         <g id="38">
             <g id="38.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="1109.90,193.19 821.34,157.52"/>
-                <g class="nad-edge-infos" transform="translate(1077.65,189.20)">
+                <polyline class="nad-edge-path nad-stretchable" points="1109.90,193.19 821.34,157.52"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1077.65,189.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-82.95)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -497,8 +515,8 @@
                 </g>
             </g>
             <g id="38.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="532.79,121.85 821.34,157.52"/>
-                <g class="nad-edge-infos" transform="translate(565.04,125.84)">
+                <polyline class="nad-edge-path nad-stretchable" points="532.79,121.85 821.34,157.52"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(565.04,125.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(97.05)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -518,8 +536,8 @@
         </g>
         <g id="39">
             <g id="39.1" class="nad-vl50to70">
-                <polyline class="nad-edge-path" points="129.52,590.23 290.24,388.57"/>
-                <g class="nad-edge-infos" transform="translate(149.77,564.82)">
+                <polyline class="nad-edge-path nad-stretchable" points="129.52,590.23 290.24,388.57"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(149.77,564.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(38.55)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -535,11 +553,10 @@
                         <text transform="rotate(-51.45)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="302.70" cy="372.93" r="20.00"/>
             </g>
             <g id="39.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="488.35,139.98 327.63,341.65"/>
-                <g class="nad-edge-infos" transform="translate(468.10,165.40)">
+                <polyline class="nad-edge-path nad-stretchable" points="488.35,139.98 327.63,341.65"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(468.10,165.40)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-141.45)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -555,13 +572,20 @@
                         <text transform="rotate(-51.45)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="315.17" cy="357.29" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl50to70">
+                    <circle class="nad-winding" cx="302.70" cy="372.93" r="20.00"/>
+                </g>
+                <g class="nad-vl0to30">
+                    <circle class="nad-winding" cx="315.17" cy="357.29" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="40">
             <g id="40.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="722.81,-389.89 768.34,-610.30"/>
-                <g class="nad-edge-infos" transform="translate(729.39,-421.71)">
+                <polyline class="nad-edge-path nad-stretchable" points="722.81,-389.89 768.34,-610.30"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(729.39,-421.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(11.67)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -579,8 +603,8 @@
                 </g>
             </g>
             <g id="40.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="813.87,-830.71 768.34,-610.30"/>
-                <g class="nad-edge-infos" transform="translate(807.30,-798.88)">
+                <polyline class="nad-edge-path nad-stretchable" points="813.87,-830.71 768.34,-610.30"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(807.30,-798.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-168.33)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -600,8 +624,8 @@
         </g>
         <g id="41">
             <g id="41.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="791.98,-859.19 543.88,-873.14"/>
-                <g class="nad-edge-infos" transform="translate(759.53,-861.01)">
+                <polyline class="nad-edge-path nad-stretchable" points="791.98,-859.19 543.88,-873.14"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(759.53,-861.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-86.78)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -619,8 +643,8 @@
                 </g>
             </g>
             <g id="41.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="295.78,-887.10 543.88,-873.14"/>
-                <g class="nad-edge-infos" transform="translate(328.23,-885.27)">
+                <polyline class="nad-edge-path nad-stretchable" points="295.78,-887.10 543.88,-873.14"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(328.23,-885.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(93.22)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -640,8 +664,8 @@
         </g>
         <g id="42">
             <g id="42.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="845.92,-850.24 1089.27,-782.19"/>
-                <g class="nad-edge-infos" transform="translate(877.22,-841.49)">
+                <polyline class="nad-edge-path nad-stretchable" points="845.92,-850.24 1089.27,-782.19"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(877.22,-841.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(105.62)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -659,8 +683,8 @@
                 </g>
             </g>
             <g id="42.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="1332.63,-714.15 1089.27,-782.19"/>
-                <g class="nad-edge-infos" transform="translate(1301.33,-722.90)">
+                <polyline class="nad-edge-path nad-stretchable" points="1332.63,-714.15 1089.27,-782.19"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1301.33,-722.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-74.38)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -680,8 +704,8 @@
         </g>
         <g id="43">
             <g id="43.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="259.92,-862.46 189.63,-643.42"/>
-                <g class="nad-edge-infos" transform="translate(249.99,-831.51)">
+                <polyline class="nad-edge-path nad-stretchable" points="259.92,-862.46 189.63,-643.42"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(249.99,-831.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-162.21)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -699,8 +723,8 @@
                 </g>
             </g>
             <g id="43.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="119.35,-424.39 189.63,-643.42"/>
-                <g class="nad-edge-infos" transform="translate(129.28,-455.34)">
+                <polyline class="nad-edge-path nad-stretchable" points="119.35,-424.39 189.63,-643.42"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(129.28,-455.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(17.79)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -720,8 +744,8 @@
         </g>
         <g id="44">
             <g id="44.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="1366.06,-680.13 1425.49,-452.55"/>
-                <g class="nad-edge-infos" transform="translate(1374.27,-648.69)">
+                <polyline class="nad-edge-path nad-stretchable" points="1366.06,-680.13 1425.49,-452.55"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1374.27,-648.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(165.37)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -739,8 +763,8 @@
                 </g>
             </g>
             <g id="44.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="1484.91,-224.96 1425.49,-452.55"/>
-                <g class="nad-edge-infos" transform="translate(1476.70,-256.41)">
+                <polyline class="nad-edge-path nad-stretchable" points="1484.91,-224.96 1425.49,-452.55"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1476.70,-256.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-14.63)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -760,8 +784,8 @@
         </g>
         <g id="45">
             <g id="45.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="1473.48,-177.89 1314.53,-0.90"/>
-                <g class="nad-edge-infos" transform="translate(1451.77,-153.71)">
+                <polyline class="nad-edge-path nad-stretchable" points="1473.48,-177.89 1314.53,-0.90"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1451.77,-153.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-138.07)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -779,8 +803,8 @@
                 </g>
             </g>
             <g id="45.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="1155.57,176.10 1314.53,-0.90"/>
-                <g class="nad-edge-infos" transform="translate(1177.28,151.92)">
+                <polyline class="nad-edge-path nad-stretchable" points="1155.57,176.10 1314.53,-0.90"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1177.28,151.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(41.93)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/edge_info_missing_label.svg
+++ b/network-area-diagram/src/test/resources/edge_info_missing_label.svg
@@ -72,8 +72,8 @@
     <g class="nad-branch-edges">
         <g id="4">
             <g id="4.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="140.62,-69.02 37.43,39.35"/>
-                <g class="nad-edge-infos" transform="translate(132.00,-59.96)">
+                <polyline class="nad-edge-path nad-stretchable" points="140.62,-69.02 37.43,39.35"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(132.00,-59.96)">
                     <g class="nad-state-out">
                         <g transform="rotate(-136.40)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-2 -1 H2 L0 1z"/>
@@ -83,8 +83,8 @@
                 </g>
             </g>
             <g id="4.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="-65.77,147.71 37.43,39.35"/>
-                <g class="nad-edge-infos" transform="translate(-57.15,138.66)">
+                <polyline class="nad-edge-path nad-stretchable" points="-65.77,147.71 37.43,39.35"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-57.15,138.66)">
                     <g class="nad-state-out">
                         <g transform="rotate(43.60)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-2 -1 H2 L0 1z"/>

--- a/network-area-diagram/src/test/resources/edge_info_perpendicular_label.svg
+++ b/network-area-diagram/src/test/resources/edge_info_perpendicular_label.svg
@@ -72,8 +72,8 @@
     <g class="nad-branch-edges">
         <g id="4">
             <g id="4.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="140.62,-69.02 37.43,39.35"/>
-                <g class="nad-edge-infos" transform="translate(104.42,-31.00)">
+                <polyline class="nad-edge-path nad-stretchable" points="140.62,-69.02 37.43,39.35"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(104.42,-31.00)">
                     <g class="nad-state-out">
                         <g transform="rotate(-136.40)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-2 -1 H2 L0 1z"/>
@@ -85,8 +85,8 @@
                 </g>
             </g>
             <g id="4.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="-65.77,147.71 37.43,39.35"/>
-                <g class="nad-edge-infos" transform="translate(-29.57,109.69)">
+                <polyline class="nad-edge-path nad-stretchable" points="-65.77,147.71 37.43,39.35"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-29.57,109.69)">
                     <g class="nad-state-out">
                         <g transform="rotate(43.60)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-2 -1 H2 L0 1z"/>

--- a/network-area-diagram/src/test/resources/edge_info_shift.svg
+++ b/network-area-diagram/src/test/resources/edge_info_shift.svg
@@ -202,12 +202,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl300to500">
-                    <circle class="nad-winding" cx="102.74" cy="-28.41" r="20.00"/>
-                </g>
-                <g class="nad-vl180to300">
-                    <circle class="nad-winding" cx="118.28" cy="-15.82" r="20.00"/>
-                </g>
+                <circle class="nad-vl300to500 nad-winding" cx="102.74" cy="-28.41" r="20.00"/>
+                <circle class="nad-vl180to300 nad-winding" cx="118.28" cy="-15.82" r="20.00"/>
             </g>
         </g>
         <g id="11">
@@ -250,12 +246,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl300to500">
-                    <circle class="nad-winding" cx="39.67" cy="145.31" r="20.00"/>
-                </g>
-                <g class="nad-vl180to300">
-                    <circle class="nad-winding" cx="58.52" cy="138.61" r="20.00"/>
-                </g>
+                <circle class="nad-vl300to500 nad-winding" cx="39.67" cy="145.31" r="20.00"/>
+                <circle class="nad-vl180to300 nad-winding" cx="58.52" cy="138.61" r="20.00"/>
             </g>
         </g>
     </g>

--- a/network-area-diagram/src/test/resources/edge_info_shift.svg
+++ b/network-area-diagram/src/test/resources/edge_info_shift.svg
@@ -84,8 +84,8 @@
     <g class="nad-branch-edges">
         <g id="8">
             <g id="8.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="-53.19,-119.42 -88.28,-80.37 -109.57,20.35"/>
-                <g class="nad-edge-infos" transform="translate(-92.42,-60.80)">
+                <polyline class="nad-edge-path nad-stretchable" points="-53.19,-119.42 -88.28,-80.37 -109.57,20.35"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-92.42,-60.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-168.06)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -103,8 +103,8 @@
                 </g>
             </g>
             <g id="8.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="-114.59,170.97 -130.87,121.06 -109.57,20.35"/>
-                <g class="nad-edge-infos" transform="translate(-126.73,101.49)">
+                <polyline class="nad-edge-path nad-stretchable" points="-114.59,170.97 -130.87,121.06 -109.57,20.35"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-126.73,101.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(11.94)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -124,8 +124,8 @@
         </g>
         <g id="9">
             <g id="9.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="-16.99,-85.21 -10.01,-63.82 -31.30,36.90"/>
-                <g class="nad-edge-infos" transform="translate(-14.15,-44.25)">
+                <polyline class="nad-edge-path nad-stretchable" points="-16.99,-85.21 -10.01,-63.82 -31.30,36.90"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-14.15,-44.25)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-168.06)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -143,8 +143,8 @@
                 </g>
             </g>
             <g id="9.2" class="nad-disconnected nad-vl300to500">
-                <polyline class="nad-edge-path" points="-87.68,176.66 -52.60,137.61 -31.30,36.90"/>
-                <g class="nad-edge-infos" transform="translate(-48.46,118.04)">
+                <polyline class="nad-edge-path nad-stretchable" points="-87.68,176.66 -52.60,137.61 -31.30,36.90"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-48.46,118.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(11.94)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -164,8 +164,8 @@
         </g>
         <g id="10">
             <g id="10.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="9.86,-103.67 87.20,-41.00"/>
-                <g class="nad-edge-infos" transform="translate(27.34,-89.51)">
+                <polyline class="nad-edge-path nad-stretchable" points="9.86,-103.67 87.20,-41.00"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(27.34,-89.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(129.02)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -181,11 +181,10 @@
                         <text transform="rotate(39.02)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="102.74" cy="-28.41" r="20.00"/>
             </g>
             <g id="10.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="211.16,59.44 133.82,-3.23"/>
-                <g class="nad-edge-infos" transform="translate(170.37,26.39)">
+                <polyline class="nad-edge-path nad-stretchable" points="211.16,59.44 133.82,-3.23"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(170.37,26.39)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-50.98)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -201,13 +200,20 @@
                         <text transform="rotate(-320.98)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="118.28" cy="-15.82" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl300to500">
+                    <circle class="nad-winding" cx="102.74" cy="-28.41" r="20.00"/>
+                </g>
+                <g class="nad-vl180to300">
+                    <circle class="nad-winding" cx="118.28" cy="-15.82" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="11">
             <g id="11.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="-80.15,187.91 20.83,152.01"/>
-                <g class="nad-edge-infos" transform="translate(-58.95,180.37)">
+                <polyline class="nad-edge-path nad-stretchable" points="-80.15,187.91 20.83,152.01"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-58.95,180.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(70.43)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -223,11 +229,10 @@
                         <text transform="rotate(-19.57)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="39.67" cy="145.31" r="20.00"/>
             </g>
             <g id="11.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="178.34,96.01 77.36,131.91"/>
-                <g class="nad-edge-infos" transform="translate(157.14,103.55)">
+                <polyline class="nad-edge-path nad-stretchable" points="178.34,96.01 77.36,131.91"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(157.14,103.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-109.57)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -243,7 +248,14 @@
                         <text transform="rotate(-19.57)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="58.52" cy="138.61" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl300to500">
+                    <circle class="nad-winding" cx="39.67" cy="145.31" r="20.00"/>
+                </g>
+                <g class="nad-vl180to300">
+                    <circle class="nad-winding" cx="58.52" cy="138.61" r="20.00"/>
+                </g>
             </g>
         </g>
     </g>

--- a/network-area-diagram/src/test/resources/hvdc-vl-depth-1.svg
+++ b/network-area-diagram/src/test/resources/hvdc-vl-depth-1.svg
@@ -112,7 +112,9 @@
                     </g>
                 </g>
             </g>
-            <polyline points="58.11,17.62 16.74,61.07" class="nad-hvdc"/>
+            <g class="nad-glued-center">
+                <polyline points="58.11,17.62 16.74,61.07" class="nad-hvdc"/>
+            </g>
         </g>
     </g>
     <g class="nad-text-edges">

--- a/network-area-diagram/src/test/resources/hvdc-vl-depth-1.svg
+++ b/network-area-diagram/src/test/resources/hvdc-vl-depth-1.svg
@@ -75,8 +75,8 @@
         <g id="4" class="nad-hvdc-edge">
             <desc>HVDC</desc>
             <g id="4.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="140.62,-69.02 37.43,39.35"/>
-                <g class="nad-edge-infos" transform="translate(118.21,-45.48)">
+                <polyline class="nad-edge-path nad-stretchable" points="140.62,-69.02 37.43,39.35"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(118.21,-45.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-136.40)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -94,8 +94,8 @@
                 </g>
             </g>
             <g id="4.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="-65.77,147.71 37.43,39.35"/>
-                <g class="nad-edge-infos" transform="translate(-43.36,124.17)">
+                <polyline class="nad-edge-path nad-stretchable" points="-65.77,147.71 37.43,39.35"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-43.36,124.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(43.60)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/hvdc.svg
+++ b/network-area-diagram/src/test/resources/hvdc.svg
@@ -135,14 +135,10 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl180to300">
-                    <circle class="nad-winding" cx="-380.65" cy="53.86" r="20.00"/>
-                </g>
-                <g class="nad-vl300to500">
-                    <circle class="nad-winding" cx="-360.67" cy="53.11" r="20.00"/>
-                </g>
+                <circle class="nad-vl180to300 nad-winding" cx="-380.65" cy="53.86" r="20.00"/>
+                <circle class="nad-vl300to500 nad-winding" cx="-360.67" cy="53.11" r="20.00"/>
+                <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(1.00,-0.04,0.04,1.00,-401.77,24.64)" class="nad-pst-arrow"/>
             </g>
-            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(1.00,-0.04,0.04,1.00,-401.77,24.64)" class="nad-pst-arrow nad-glued-center"/>
         </g>
         <g id="11" class="nad-hvdc-edge">
             <desc>HVDC1</desc>
@@ -184,7 +180,9 @@
                     </g>
                 </g>
             </g>
-            <polyline points="-67.95,-64.79 -27.53,-109.12" class="nad-hvdc"/>
+            <g class="nad-glued-center">
+                <polyline points="-67.95,-64.79 -27.53,-109.12" class="nad-hvdc"/>
+            </g>
         </g>
         <g id="12" class="nad-hvdc-edge">
             <desc>HVDC2</desc>
@@ -226,7 +224,9 @@
                     </g>
                 </g>
             </g>
-            <polyline points="11.04,66.41 70.65,73.23" class="nad-hvdc"/>
+            <g class="nad-glued-center">
+                <polyline points="11.04,66.41 70.65,73.23" class="nad-hvdc"/>
+            </g>
         </g>
         <g id="13">
             <desc>LINE_S2S3</desc>

--- a/network-area-diagram/src/test/resources/hvdc.svg
+++ b/network-area-diagram/src/test/resources/hvdc.svg
@@ -97,8 +97,8 @@
         <g id="10">
             <desc>TWT</desc>
             <g id="10.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="-547.03,60.17 -400.64,54.62"/>
-                <g class="nad-edge-infos" transform="translate(-514.56,58.94)">
+                <polyline class="nad-edge-path nad-stretchable" points="-547.03,60.17 -400.64,54.62"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-514.56,58.94)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(87.83)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -114,11 +114,10 @@
                         <text transform="rotate(-2.17)" x="19.00">-10</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-380.65" cy="53.86" r="20.00"/>
             </g>
             <g id="10.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="-194.28,46.80 -340.68,52.35"/>
-                <g class="nad-edge-infos" transform="translate(-226.76,48.03)">
+                <polyline class="nad-edge-path nad-stretchable" points="-194.28,46.80 -340.68,52.35"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-226.76,48.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-92.17)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -134,15 +133,22 @@
                         <text transform="rotate(-2.17)" x="-19.00" style="text-anchor:end">5</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-360.67" cy="53.11" r="20.00"/>
             </g>
-            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(1.00,-0.04,0.04,1.00,-401.77,24.64)" class="nad-pst-arrow"/>
+            <g class="nad-glued-center">
+                <g class="nad-vl180to300">
+                    <circle class="nad-winding" cx="-380.65" cy="53.86" r="20.00"/>
+                </g>
+                <g class="nad-vl300to500">
+                    <circle class="nad-winding" cx="-360.67" cy="53.11" r="20.00"/>
+                </g>
+            </g>
+            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(1.00,-0.04,0.04,1.00,-401.77,24.64)" class="nad-pst-arrow nad-glued-center"/>
         </g>
         <g id="11" class="nad-hvdc-edge">
             <desc>HVDC1</desc>
             <g id="11.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="-151.62,26.99 -47.74,-86.96"/>
-                <g class="nad-edge-infos" transform="translate(-129.73,2.97)">
+                <polyline class="nad-edge-path nad-stretchable" points="-151.62,26.99 -47.74,-86.96"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-129.73,2.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(42.36)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -160,8 +166,8 @@
                 </g>
             </g>
             <g id="11.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="56.14,-200.90 -47.74,-86.96"/>
-                <g class="nad-edge-infos" transform="translate(34.25,-176.88)">
+                <polyline class="nad-edge-path nad-stretchable" points="56.14,-200.90 -47.74,-86.96"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(34.25,-176.88)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-137.64)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -183,8 +189,8 @@
         <g id="12" class="nad-hvdc-edge">
             <desc>HVDC2</desc>
             <g id="12.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="-143.47,48.73 40.85,69.82"/>
-                <g class="nad-edge-infos" transform="translate(-111.18,52.42)">
+                <polyline class="nad-edge-path nad-stretchable" points="-143.47,48.73 40.85,69.82"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-111.18,52.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(96.53)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -202,8 +208,8 @@
                 </g>
             </g>
             <g id="12.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="225.16,90.92 40.85,69.82"/>
-                <g class="nad-edge-infos" transform="translate(192.87,87.22)">
+                <polyline class="nad-edge-path nad-stretchable" points="225.16,90.92 40.85,69.82"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(192.87,87.22)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-83.47)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -225,8 +231,8 @@
         <g id="13">
             <desc>LINE_S2S3</desc>
             <g id="13.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="85.87,-197.54 161.91,-62.96"/>
-                <g class="nad-edge-infos" transform="translate(101.86,-169.24)">
+                <polyline class="nad-edge-path nad-stretchable" points="85.87,-197.54 161.91,-62.96"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(101.86,-169.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(150.53)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -244,8 +250,8 @@
                 </g>
             </g>
             <g id="13.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="237.95,71.61 161.91,-62.96"/>
-                <g class="nad-edge-infos" transform="translate(221.96,43.32)">
+                <polyline class="nad-edge-path nad-stretchable" points="237.95,71.61 161.91,-62.96"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(221.96,43.32)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-29.47)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -266,8 +272,8 @@
         <g id="14">
             <desc>LINE_S3S4</desc>
             <g id="14.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="274.69,101.87 442.12,157.61"/>
-                <g class="nad-edge-infos" transform="translate(305.53,112.14)">
+                <polyline class="nad-edge-path nad-stretchable" points="274.69,101.87 442.12,157.61"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(305.53,112.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(108.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -285,8 +291,8 @@
                 </g>
             </g>
             <g id="14.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="609.55,213.35 442.12,157.61"/>
-                <g class="nad-edge-infos" transform="translate(578.71,203.09)">
+                <polyline class="nad-edge-path nad-stretchable" points="609.55,213.35 442.12,157.61"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(578.71,203.09)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-71.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/parallel_transformers.svg
+++ b/network-area-diagram/src/test/resources/parallel_transformers.svg
@@ -75,8 +75,8 @@
     <g class="nad-branch-edges">
         <g id="5">
             <g id="5.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="133.21,-81.17 82.84,-66.34 29.15,-9.96"/>
-                <g class="nad-edge-infos" transform="translate(62.15,-44.62)">
+                <polyline class="nad-edge-path nad-stretchable" points="133.21,-81.17 82.84,-66.34 29.15,-9.96"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(62.15,-44.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-136.40)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -92,11 +92,10 @@
                         <text transform="rotate(-46.40)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="15.36" cy="4.52" r="20.00"/>
             </g>
             <g id="5.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="-78.27,140.89 -65.92,89.87 -12.23,33.49"/>
-                <g class="nad-edge-infos" transform="translate(-45.23,68.14)">
+                <polyline class="nad-edge-path nad-stretchable" points="-78.27,140.89 -65.92,89.87 -12.23,33.49"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-45.23,68.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(43.60)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -112,13 +111,20 @@
                         <text transform="rotate(-46.40)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="1.56" cy="19.00" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl300to500">
+                    <circle class="nad-winding" cx="15.36" cy="4.52" r="20.00"/>
+                </g>
+                <g class="nad-vl180to300">
+                    <circle class="nad-winding" cx="1.56" cy="19.00" r="20.00"/>
+                </g>
             </g>
         </g>
         <g id="6">
             <g id="6.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="146.06,-33.04 140.77,-11.17 87.08,45.21"/>
-                <g class="nad-edge-infos" transform="translate(120.08,10.55)">
+                <polyline class="nad-edge-path nad-stretchable" points="146.06,-33.04 140.77,-11.17 87.08,45.21"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(120.08,10.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-136.40)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -134,11 +140,10 @@
                         <text transform="rotate(-46.40)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="73.29" cy="59.69" r="20.00"/>
             </g>
             <g id="6.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="-58.36,159.86 -7.99,145.04 45.70,88.66"/>
-                <g class="nad-edge-infos" transform="translate(12.70,123.31)">
+                <polyline class="nad-edge-path nad-stretchable" points="-58.36,159.86 -7.99,145.04 45.70,88.66"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(12.70,123.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(43.60)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -154,7 +159,14 @@
                         <text transform="rotate(-46.40)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="59.49" cy="74.17" r="20.00"/>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-vl300to500">
+                    <circle class="nad-winding" cx="73.29" cy="59.69" r="20.00"/>
+                </g>
+                <g class="nad-vl180to300">
+                    <circle class="nad-winding" cx="59.49" cy="74.17" r="20.00"/>
+                </g>
             </g>
         </g>
     </g>

--- a/network-area-diagram/src/test/resources/parallel_transformers.svg
+++ b/network-area-diagram/src/test/resources/parallel_transformers.svg
@@ -113,12 +113,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl300to500">
-                    <circle class="nad-winding" cx="15.36" cy="4.52" r="20.00"/>
-                </g>
-                <g class="nad-vl180to300">
-                    <circle class="nad-winding" cx="1.56" cy="19.00" r="20.00"/>
-                </g>
+                <circle class="nad-vl300to500 nad-winding" cx="15.36" cy="4.52" r="20.00"/>
+                <circle class="nad-vl180to300 nad-winding" cx="1.56" cy="19.00" r="20.00"/>
             </g>
         </g>
         <g id="6">
@@ -161,12 +157,8 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl300to500">
-                    <circle class="nad-winding" cx="73.29" cy="59.69" r="20.00"/>
-                </g>
-                <g class="nad-vl180to300">
-                    <circle class="nad-winding" cx="59.49" cy="74.17" r="20.00"/>
-                </g>
+                <circle class="nad-vl300to500 nad-winding" cx="73.29" cy="59.69" r="20.00"/>
+                <circle class="nad-vl180to300 nad-winding" cx="59.49" cy="74.17" r="20.00"/>
             </g>
         </g>
     </g>

--- a/network-area-diagram/src/test/resources/simple-eu-loop100.svg
+++ b/network-area-diagram/src/test/resources/simple-eu-loop100.svg
@@ -411,14 +411,10 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl300to500-line">
-                    <circle class="nad-winding" cx="-379.08" cy="-134.16" r="20.00"/>
-                </g>
-                <g class="nad-vl300to500-line">
-                    <circle class="nad-winding" cx="-392.60" cy="-119.43" r="20.00"/>
-                </g>
+                <circle class="nad-vl300to500-line nad-winding" cx="-379.08" cy="-134.16" r="20.00"/>
+                <circle class="nad-vl300to500-line nad-winding" cx="-392.60" cy="-119.43" r="20.00"/>
+                <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(-0.68,0.74,-0.74,-0.68,-343.45,-128.61)" class="nad-pst-arrow"/>
             </g>
-            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(-0.68,0.74,-0.74,-0.68,-343.45,-128.61)" class="nad-pst-arrow nad-glued-center"/>
         </g>
         <g id="27">
             <desc>BBE2AA1  FFR3AA1  1</desc>
@@ -830,14 +826,10 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl300to500-line">
-                    <circle class="nad-winding" cx="-29.27" cy="630.71" r="20.00"/>
-                </g>
-                <g class="nad-vl300to500-line">
-                    <circle class="nad-winding" cx="-11.66" cy="621.24" r="20.00"/>
-                </g>
+                <circle class="nad-vl300to500-line nad-winding" cx="-29.27" cy="630.71" r="20.00"/>
+                <circle class="nad-vl300to500-line nad-winding" cx="-11.66" cy="621.24" r="20.00"/>
+                <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(0.88,-0.47,0.47,0.88,-61.10,613.77)" class="nad-pst-arrow"/>
             </g>
-            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(0.88,-0.47,0.47,0.88,-61.10,613.77)" class="nad-pst-arrow nad-glued-center"/>
         </g>
         <g id="37">
             <desc>NNL1AA1  NNL2AA1  1</desc>

--- a/network-area-diagram/src/test/resources/simple-eu-loop100.svg
+++ b/network-area-diagram/src/test/resources/simple-eu-loop100.svg
@@ -209,8 +209,8 @@
         <g id="22">
             <desc>BBE1AA1  BBE2AA1  1</desc>
             <g id="22.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-492.02,-186.98 -525.98,-146.94 -553.50,4.50"/>
-                <g class="nad-edge-infos" transform="translate(-531.34,-117.42)">
+                <polyline class="nad-edge-path nad-stretchable" points="-492.02,-186.98 -525.98,-146.94 -553.50,4.50"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-531.34,-117.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-169.70)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -228,8 +228,8 @@
                 </g>
             </g>
             <g id="22.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-563.32,205.36 -581.02,155.93 -553.50,4.50"/>
-                <g class="nad-edge-infos" transform="translate(-575.65,126.42)">
+                <polyline class="nad-edge-path nad-stretchable" points="-563.32,205.36 -581.02,155.93 -553.50,4.50"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-575.65,126.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(10.30)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -291,8 +291,8 @@
         <g id="24">
             <desc>BBE2AA1  BBE3AA1  1</desc>
             <g id="24.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-536.26,210.28 -502.31,170.24 -474.79,18.80"/>
-                <g class="nad-edge-infos" transform="translate(-496.94,140.72)">
+                <polyline class="nad-edge-path nad-stretchable" points="-536.26,210.28 -502.31,170.24 -474.79,18.80"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-496.94,140.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(10.30)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -310,8 +310,8 @@
                 </g>
             </g>
             <g id="24.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-454.85,-153.82 -447.27,-132.64 -474.79,18.80"/>
-                <g class="nad-edge-infos" transform="translate(-452.63,-103.12)">
+                <polyline class="nad-edge-path nad-stretchable" points="-454.85,-153.82 -447.27,-132.64 -474.79,18.80"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-452.63,-103.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-169.70)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -332,8 +332,8 @@
         <g id="25">
             <desc>NNL2AA1  BBE3AA1  1</desc>
             <g id="25.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-169.02,-515.19 -301.37,-381.97"/>
-                <g class="nad-edge-infos" transform="translate(-191.93,-492.13)">
+                <polyline class="nad-edge-path nad-stretchable" points="-169.02,-515.19 -301.37,-381.97"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-191.93,-492.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-135.19)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -351,8 +351,8 @@
                 </g>
             </g>
             <g id="25.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-433.71,-248.75 -301.37,-381.97"/>
-                <g class="nad-edge-infos" transform="translate(-410.81,-271.80)">
+                <polyline class="nad-edge-path nad-stretchable" points="-433.71,-248.75 -301.37,-381.97"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-410.81,-271.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(44.81)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -390,7 +390,6 @@
                         <text transform="rotate(-7.44)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-379.08" cy="-134.16" r="20.00"/>
             </g>
             <g id="26.2" class="nad-vl300to500-line">
                 <path class="nad-edge-path" d="M-475.46,-180.48 L-477.80,-128.03 C-479.59,-88.07 -412.89,-97.33 -406.13,-104.70"/>
@@ -410,15 +409,22 @@
                         <text transform="rotate(-87.44)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-392.60" cy="-119.43" r="20.00"/>
             </g>
-            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(-0.68,0.74,-0.74,-0.68,-343.45,-128.61)" class="nad-pst-arrow"/>
+            <g class="nad-glued-center">
+                <g class="nad-vl300to500-line">
+                    <circle class="nad-winding" cx="-379.08" cy="-134.16" r="20.00"/>
+                </g>
+                <g class="nad-vl300to500-line">
+                    <circle class="nad-winding" cx="-392.60" cy="-119.43" r="20.00"/>
+                </g>
+            </g>
+            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(-0.68,0.74,-0.74,-0.68,-343.45,-128.61)" class="nad-pst-arrow nad-glued-center"/>
         </g>
         <g id="27">
             <desc>BBE2AA1  FFR3AA1  1</desc>
             <g id="27.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-542.54,256.22 -463.08,428.65"/>
-                <g class="nad-edge-infos" transform="translate(-528.94,285.74)">
+                <polyline class="nad-edge-path nad-stretchable" points="-542.54,256.22 -463.08,428.65"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-528.94,285.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -436,8 +442,8 @@
                 </g>
             </g>
             <g id="27.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-383.63,601.07 -463.08,428.65"/>
-                <g class="nad-edge-infos" transform="translate(-397.23,571.55)">
+                <polyline class="nad-edge-path nad-stretchable" points="-383.63,601.07 -463.08,428.65"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-397.23,571.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -458,8 +464,8 @@
         <g id="28">
             <desc>DDE1AA1  DDE2AA1  1</desc>
             <g id="28.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="686.85,254.06 577.89,137.39"/>
-                <g class="nad-edge-infos" transform="translate(664.67,230.31)">
+                <polyline class="nad-edge-path nad-stretchable" points="686.85,254.06 577.89,137.39"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(664.67,230.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-43.04)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -477,8 +483,8 @@
                 </g>
             </g>
             <g id="28.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="468.92,20.71 577.89,137.39"/>
-                <g class="nad-edge-infos" transform="translate(491.10,44.47)">
+                <polyline class="nad-edge-path nad-stretchable" points="468.92,20.71 577.89,137.39"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(491.10,44.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(136.96)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -499,8 +505,8 @@
         <g id="29">
             <desc>DDE1AA1  DDE3AA1  1</desc>
             <g id="29.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="680.95,286.30 540.26,355.48"/>
-                <g class="nad-edge-infos" transform="translate(651.78,300.64)">
+                <polyline class="nad-edge-path nad-stretchable" points="680.95,286.30 540.26,355.48"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(651.78,300.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-116.19)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -518,8 +524,8 @@
                 </g>
             </g>
             <g id="29.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="399.58,424.67 540.26,355.48"/>
-                <g class="nad-edge-infos" transform="translate(428.75,410.33)">
+                <polyline class="nad-edge-path nad-stretchable" points="399.58,424.67 540.26,355.48"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(428.75,410.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(63.81)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -540,8 +546,8 @@
         <g id="30">
             <desc>DDE2AA1  DDE3AA1  1</desc>
             <g id="30.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="445.47,27.72 412.53,218.71"/>
-                <g class="nad-edge-infos" transform="translate(439.95,59.74)">
+                <polyline class="nad-edge-path nad-stretchable" points="445.47,27.72 412.53,218.71"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(439.95,59.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-170.21)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -559,8 +565,8 @@
                 </g>
             </g>
             <g id="30.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="379.58,409.70 412.53,218.71"/>
-                <g class="nad-edge-infos" transform="translate(385.11,377.68)">
+                <polyline class="nad-edge-path nad-stretchable" points="379.58,409.70 412.53,218.71"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(385.11,377.68)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(9.79)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -581,8 +587,8 @@
         <g id="31">
             <desc>DDE2AA1  NNL3AA1  1</desc>
             <g id="31.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="438.92,-24.49 351.07,-220.83"/>
-                <g class="nad-edge-infos" transform="translate(425.65,-54.15)">
+                <polyline class="nad-edge-path nad-stretchable" points="438.92,-24.49 351.07,-220.83"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(425.65,-54.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.10)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -600,8 +606,8 @@
                 </g>
             </g>
             <g id="31.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="263.22,-417.18 351.07,-220.83"/>
-                <g class="nad-edge-infos" transform="translate(276.49,-387.51)">
+                <polyline class="nad-edge-path nad-stretchable" points="263.22,-417.18 351.07,-220.83"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(276.49,-387.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.90)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -622,8 +628,8 @@
         <g id="32">
             <desc>FFR2AA1  DDE3AA1  1</desc>
             <g id="32.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="79.75,693.89 216.96,574.38"/>
-                <g class="nad-edge-infos" transform="translate(104.26,672.54)">
+                <polyline class="nad-edge-path nad-stretchable" points="79.75,693.89 216.96,574.38"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(104.26,672.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.94)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -641,8 +647,8 @@
                 </g>
             </g>
             <g id="32.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="354.17,454.87 216.96,574.38"/>
-                <g class="nad-edge-infos" transform="translate(329.66,476.21)">
+                <polyline class="nad-edge-path nad-stretchable" points="354.17,454.87 216.96,574.38"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(329.66,476.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-131.06)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -704,8 +710,8 @@
         <g id="34">
             <desc>FFR1AA1  FFR3AA1  1</desc>
             <g id="34.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="16.78,712.38 -20.67,675.58 -157.85,640.12"/>
-                <g class="nad-edge-infos" transform="translate(-49.72,668.08)">
+                <polyline class="nad-edge-path nad-stretchable" points="16.78,712.38 -20.67,675.58 -157.85,640.12"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-49.72,668.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-75.51)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -723,8 +729,8 @@
                 </g>
             </g>
             <g id="34.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-345.62,618.69 -295.03,604.66 -157.85,640.12"/>
-                <g class="nad-edge-infos" transform="translate(-265.98,612.17)">
+                <polyline class="nad-edge-path nad-stretchable" points="-345.62,618.69 -295.03,604.66 -157.85,640.12"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-265.98,612.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.49)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -745,8 +751,8 @@
         <g id="35">
             <desc>FFR2AA1  FFR3AA1  1</desc>
             <g id="35.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-19.02,747.02 -40.70,753.04 -177.87,717.58"/>
-                <g class="nad-edge-infos" transform="translate(-69.74,745.53)">
+                <polyline class="nad-edge-path nad-stretchable" points="-19.02,747.02 -40.70,753.04 -177.87,717.58"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-69.74,745.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-75.51)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -764,8 +770,8 @@
                 </g>
             </g>
             <g id="35.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-352.50,645.32 -315.05,682.11 -177.87,717.58"/>
-                <g class="nad-edge-infos" transform="translate(-286.01,689.62)">
+                <polyline class="nad-edge-path nad-stretchable" points="-352.50,645.32 -315.05,682.11 -177.87,717.58"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-286.01,689.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.49)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -803,7 +809,6 @@
                         <text transform="rotate(-348.28)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-29.27" cy="630.71" r="20.00"/>
             </g>
             <g id="36.2" class="nad-vl300to500-line">
                 <path class="nad-edge-path" d="M46.57,706.10 L66.00,657.33 C80.80,620.17 14.76,607.02 5.96,611.76"/>
@@ -823,15 +828,22 @@
                         <text transform="rotate(-68.28)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-11.66" cy="621.24" r="20.00"/>
             </g>
-            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(0.88,-0.47,0.47,0.88,-61.10,613.77)" class="nad-pst-arrow"/>
+            <g class="nad-glued-center">
+                <g class="nad-vl300to500-line">
+                    <circle class="nad-winding" cx="-29.27" cy="630.71" r="20.00"/>
+                </g>
+                <g class="nad-vl300to500-line">
+                    <circle class="nad-winding" cx="-11.66" cy="621.24" r="20.00"/>
+                </g>
+            </g>
+            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(0.88,-0.47,0.47,0.88,-61.10,613.77)" class="nad-pst-arrow nad-glued-center"/>
         </g>
         <g id="37">
             <desc>NNL1AA1  NNL2AA1  1</desc>
             <g id="37.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="103.48,-784.15 -13.29,-669.08"/>
-                <g class="nad-edge-infos" transform="translate(80.33,-761.34)">
+                <polyline class="nad-edge-path nad-stretchable" points="103.48,-784.15 -13.29,-669.08"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(80.33,-761.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-134.58)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -849,8 +861,8 @@
                 </g>
             </g>
             <g id="37.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-130.06,-554.00 -13.29,-669.08"/>
-                <g class="nad-edge-infos" transform="translate(-106.91,-576.81)">
+                <polyline class="nad-edge-path nad-stretchable" points="-130.06,-554.00 -13.29,-669.08"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-106.91,-576.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(45.42)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -871,8 +883,8 @@
         <g id="38">
             <desc>NNL1AA1  NNL3AA1  1</desc>
             <g id="38.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="132.31,-777.55 187.53,-622.87"/>
-                <g class="nad-edge-infos" transform="translate(143.24,-746.94)">
+                <polyline class="nad-edge-path nad-stretchable" points="132.31,-777.55 187.53,-622.87"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(143.24,-746.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(160.36)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -890,8 +902,8 @@
                 </g>
             </g>
             <g id="38.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="242.74,-468.18 187.53,-622.87"/>
-                <g class="nad-edge-infos" transform="translate(231.82,-498.79)">
+                <polyline class="nad-edge-path nad-stretchable" points="242.74,-468.18 187.53,-622.87"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(231.82,-498.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-19.64)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -912,8 +924,8 @@
         <g id="39">
             <desc>NNL2AA1  NNL3AA1  1</desc>
             <g id="39.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-122.84,-528.53 51.17,-488.49"/>
-                <g class="nad-edge-infos" transform="translate(-91.17,-521.24)">
+                <polyline class="nad-edge-path nad-stretchable" points="-122.84,-528.53 51.17,-488.49"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-91.17,-521.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(102.96)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -931,8 +943,8 @@
                 </g>
             </g>
             <g id="39.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="225.19,-448.45 51.17,-488.49"/>
-                <g class="nad-edge-infos" transform="translate(193.52,-455.73)">
+                <polyline class="nad-edge-path nad-stretchable" points="225.19,-448.45 51.17,-488.49"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(193.52,-455.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-77.04)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/simple-eu-loop80.svg
+++ b/network-area-diagram/src/test/resources/simple-eu-loop80.svg
@@ -411,14 +411,10 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl300to500-line">
-                    <circle class="nad-winding" cx="-569.39" cy="-281.74" r="20.00"/>
-                </g>
-                <g class="nad-vl300to500-line">
-                    <circle class="nad-winding" cx="-555.87" cy="-296.48" r="20.00"/>
-                </g>
+                <circle class="nad-vl300to500-line nad-winding" cx="-569.39" cy="-281.74" r="20.00"/>
+                <circle class="nad-vl300to500-line nad-winding" cx="-555.87" cy="-296.48" r="20.00"/>
+                <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(0.68,-0.74,0.74,0.68,-605.02,-287.30)" class="nad-pst-arrow"/>
             </g>
-            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(0.68,-0.74,0.74,0.68,-605.02,-287.30)" class="nad-pst-arrow nad-glued-center"/>
         </g>
         <g id="27">
             <desc>BBE2AA1  FFR3AA1  1</desc>
@@ -830,14 +826,10 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl300to500-line">
-                    <circle class="nad-winding" cx="6.14" cy="848.21" r="20.00"/>
-                </g>
-                <g class="nad-vl300to500-line">
-                    <circle class="nad-winding" cx="-12.73" cy="841.59" r="20.00"/>
-                </g>
+                <circle class="nad-vl300to500-line nad-winding" cx="6.14" cy="848.21" r="20.00"/>
+                <circle class="nad-vl300to500-line nad-winding" cx="-12.73" cy="841.59" r="20.00"/>
+                <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(-0.94,-0.33,0.33,-0.94,15.10,883.13)" class="nad-pst-arrow"/>
             </g>
-            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(-0.94,-0.33,0.33,-0.94,15.10,883.13)" class="nad-pst-arrow nad-glued-center"/>
         </g>
         <g id="37">
             <desc>NNL1AA1  NNL2AA1  1</desc>

--- a/network-area-diagram/src/test/resources/simple-eu-loop80.svg
+++ b/network-area-diagram/src/test/resources/simple-eu-loop80.svg
@@ -209,8 +209,8 @@
         <g id="22">
             <desc>BBE1AA1  BBE2AA1  1</desc>
             <g id="22.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-492.02,-186.98 -525.98,-146.94 -553.50,4.50"/>
-                <g class="nad-edge-infos" transform="translate(-531.34,-117.42)">
+                <polyline class="nad-edge-path nad-stretchable" points="-492.02,-186.98 -525.98,-146.94 -553.50,4.50"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-531.34,-117.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-169.70)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -228,8 +228,8 @@
                 </g>
             </g>
             <g id="22.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-563.32,205.36 -581.02,155.93 -553.50,4.50"/>
-                <g class="nad-edge-infos" transform="translate(-575.65,126.42)">
+                <polyline class="nad-edge-path nad-stretchable" points="-563.32,205.36 -581.02,155.93 -553.50,4.50"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-575.65,126.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(10.30)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -291,8 +291,8 @@
         <g id="24">
             <desc>BBE2AA1  BBE3AA1  1</desc>
             <g id="24.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-536.26,210.28 -502.31,170.24 -474.79,18.80"/>
-                <g class="nad-edge-infos" transform="translate(-496.94,140.72)">
+                <polyline class="nad-edge-path nad-stretchable" points="-536.26,210.28 -502.31,170.24 -474.79,18.80"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-496.94,140.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(10.30)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -310,8 +310,8 @@
                 </g>
             </g>
             <g id="24.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-454.85,-153.82 -447.27,-132.64 -474.79,18.80"/>
-                <g class="nad-edge-infos" transform="translate(-452.63,-103.12)">
+                <polyline class="nad-edge-path nad-stretchable" points="-454.85,-153.82 -447.27,-132.64 -474.79,18.80"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-452.63,-103.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-169.70)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -332,8 +332,8 @@
         <g id="25">
             <desc>NNL2AA1  BBE3AA1  1</desc>
             <g id="25.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-169.02,-515.19 -301.37,-381.97"/>
-                <g class="nad-edge-infos" transform="translate(-191.93,-492.13)">
+                <polyline class="nad-edge-path nad-stretchable" points="-169.02,-515.19 -301.37,-381.97"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-191.93,-492.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-135.19)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -351,8 +351,8 @@
                 </g>
             </g>
             <g id="25.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-433.71,-248.75 -301.37,-381.97"/>
-                <g class="nad-edge-infos" transform="translate(-410.81,-271.80)">
+                <polyline class="nad-edge-path nad-stretchable" points="-433.71,-248.75 -301.37,-381.97"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-410.81,-271.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(44.81)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -390,7 +390,6 @@
                         <text transform="rotate(-357.44)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-569.39" cy="-281.74" r="20.00"/>
             </g>
             <g id="26.2" class="nad-vl300to500-line">
                 <path class="nad-edge-path" d="M-477.80,-235.22 L-484.60,-287.28 C-489.79,-326.94 -535.58,-318.58 -542.34,-311.21"/>
@@ -410,15 +409,22 @@
                         <text transform="rotate(-277.44)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-555.87" cy="-296.48" r="20.00"/>
             </g>
-            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(0.68,-0.74,0.74,0.68,-605.02,-287.30)" class="nad-pst-arrow"/>
+            <g class="nad-glued-center">
+                <g class="nad-vl300to500-line">
+                    <circle class="nad-winding" cx="-569.39" cy="-281.74" r="20.00"/>
+                </g>
+                <g class="nad-vl300to500-line">
+                    <circle class="nad-winding" cx="-555.87" cy="-296.48" r="20.00"/>
+                </g>
+            </g>
+            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(0.68,-0.74,0.74,0.68,-605.02,-287.30)" class="nad-pst-arrow nad-glued-center"/>
         </g>
         <g id="27">
             <desc>BBE2AA1  FFR3AA1  1</desc>
             <g id="27.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-542.54,256.22 -463.08,428.65"/>
-                <g class="nad-edge-infos" transform="translate(-528.94,285.74)">
+                <polyline class="nad-edge-path nad-stretchable" points="-542.54,256.22 -463.08,428.65"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-528.94,285.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -436,8 +442,8 @@
                 </g>
             </g>
             <g id="27.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-383.63,601.07 -463.08,428.65"/>
-                <g class="nad-edge-infos" transform="translate(-397.23,571.55)">
+                <polyline class="nad-edge-path nad-stretchable" points="-383.63,601.07 -463.08,428.65"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-397.23,571.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -458,8 +464,8 @@
         <g id="28">
             <desc>DDE1AA1  DDE2AA1  1</desc>
             <g id="28.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="686.85,254.06 577.89,137.39"/>
-                <g class="nad-edge-infos" transform="translate(664.67,230.31)">
+                <polyline class="nad-edge-path nad-stretchable" points="686.85,254.06 577.89,137.39"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(664.67,230.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-43.04)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -477,8 +483,8 @@
                 </g>
             </g>
             <g id="28.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="468.92,20.71 577.89,137.39"/>
-                <g class="nad-edge-infos" transform="translate(491.10,44.47)">
+                <polyline class="nad-edge-path nad-stretchable" points="468.92,20.71 577.89,137.39"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(491.10,44.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(136.96)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -499,8 +505,8 @@
         <g id="29">
             <desc>DDE1AA1  DDE3AA1  1</desc>
             <g id="29.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="680.95,286.30 540.26,355.48"/>
-                <g class="nad-edge-infos" transform="translate(651.78,300.64)">
+                <polyline class="nad-edge-path nad-stretchable" points="680.95,286.30 540.26,355.48"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(651.78,300.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-116.19)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -518,8 +524,8 @@
                 </g>
             </g>
             <g id="29.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="399.58,424.67 540.26,355.48"/>
-                <g class="nad-edge-infos" transform="translate(428.75,410.33)">
+                <polyline class="nad-edge-path nad-stretchable" points="399.58,424.67 540.26,355.48"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(428.75,410.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(63.81)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -540,8 +546,8 @@
         <g id="30">
             <desc>DDE2AA1  DDE3AA1  1</desc>
             <g id="30.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="445.47,27.72 412.53,218.71"/>
-                <g class="nad-edge-infos" transform="translate(439.95,59.74)">
+                <polyline class="nad-edge-path nad-stretchable" points="445.47,27.72 412.53,218.71"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(439.95,59.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-170.21)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -559,8 +565,8 @@
                 </g>
             </g>
             <g id="30.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="379.58,409.70 412.53,218.71"/>
-                <g class="nad-edge-infos" transform="translate(385.11,377.68)">
+                <polyline class="nad-edge-path nad-stretchable" points="379.58,409.70 412.53,218.71"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(385.11,377.68)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(9.79)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -581,8 +587,8 @@
         <g id="31">
             <desc>DDE2AA1  NNL3AA1  1</desc>
             <g id="31.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="438.92,-24.49 351.07,-220.83"/>
-                <g class="nad-edge-infos" transform="translate(425.65,-54.15)">
+                <polyline class="nad-edge-path nad-stretchable" points="438.92,-24.49 351.07,-220.83"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(425.65,-54.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.10)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -600,8 +606,8 @@
                 </g>
             </g>
             <g id="31.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="263.22,-417.18 351.07,-220.83"/>
-                <g class="nad-edge-infos" transform="translate(276.49,-387.51)">
+                <polyline class="nad-edge-path nad-stretchable" points="263.22,-417.18 351.07,-220.83"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(276.49,-387.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.90)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -622,8 +628,8 @@
         <g id="32">
             <desc>FFR2AA1  DDE3AA1  1</desc>
             <g id="32.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="79.75,693.89 216.96,574.38"/>
-                <g class="nad-edge-infos" transform="translate(104.26,672.54)">
+                <polyline class="nad-edge-path nad-stretchable" points="79.75,693.89 216.96,574.38"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(104.26,672.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.94)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -641,8 +647,8 @@
                 </g>
             </g>
             <g id="32.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="354.17,454.87 216.96,574.38"/>
-                <g class="nad-edge-infos" transform="translate(329.66,476.21)">
+                <polyline class="nad-edge-path nad-stretchable" points="354.17,454.87 216.96,574.38"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(329.66,476.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-131.06)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -704,8 +710,8 @@
         <g id="34">
             <desc>FFR1AA1  FFR3AA1  1</desc>
             <g id="34.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="16.78,712.38 -20.67,675.58 -157.85,640.12"/>
-                <g class="nad-edge-infos" transform="translate(-49.72,668.08)">
+                <polyline class="nad-edge-path nad-stretchable" points="16.78,712.38 -20.67,675.58 -157.85,640.12"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-49.72,668.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-75.51)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -723,8 +729,8 @@
                 </g>
             </g>
             <g id="34.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-345.62,618.69 -295.03,604.66 -157.85,640.12"/>
-                <g class="nad-edge-infos" transform="translate(-265.98,612.17)">
+                <polyline class="nad-edge-path nad-stretchable" points="-345.62,618.69 -295.03,604.66 -157.85,640.12"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-265.98,612.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.49)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -745,8 +751,8 @@
         <g id="35">
             <desc>FFR2AA1  FFR3AA1  1</desc>
             <g id="35.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-19.02,747.02 -40.70,753.04 -177.87,717.58"/>
-                <g class="nad-edge-infos" transform="translate(-69.74,745.53)">
+                <polyline class="nad-edge-path nad-stretchable" points="-19.02,747.02 -40.70,753.04 -177.87,717.58"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-69.74,745.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-75.51)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -764,8 +770,8 @@
                 </g>
             </g>
             <g id="35.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-352.50,645.32 -315.05,682.11 -177.87,717.58"/>
-                <g class="nad-edge-infos" transform="translate(-286.01,689.62)">
+                <polyline class="nad-edge-path nad-stretchable" points="-352.50,645.32 -315.05,682.11 -177.87,717.58"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-286.01,689.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.49)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -803,7 +809,6 @@
                         <text transform="rotate(69.31)" x="19.00">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="6.14" cy="848.21" r="20.00"/>
             </g>
             <g id="36.2" class="nad-vl300to500-line">
                 <path class="nad-edge-path" d="M12.74,745.69 L-32.40,772.48 C-66.80,792.90 -41.04,831.67 -31.60,834.98"/>
@@ -823,15 +828,22 @@
                         <text transform="rotate(-30.69)" x="-19.00" style="text-anchor:end">—</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-12.73" cy="841.59" r="20.00"/>
             </g>
-            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(-0.94,-0.33,0.33,-0.94,15.10,883.13)" class="nad-pst-arrow"/>
+            <g class="nad-glued-center">
+                <g class="nad-vl300to500-line">
+                    <circle class="nad-winding" cx="6.14" cy="848.21" r="20.00"/>
+                </g>
+                <g class="nad-vl300to500-line">
+                    <circle class="nad-winding" cx="-12.73" cy="841.59" r="20.00"/>
+                </g>
+            </g>
+            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(-0.94,-0.33,0.33,-0.94,15.10,883.13)" class="nad-pst-arrow nad-glued-center"/>
         </g>
         <g id="37">
             <desc>NNL1AA1  NNL2AA1  1</desc>
             <g id="37.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="103.48,-784.15 -13.29,-669.08"/>
-                <g class="nad-edge-infos" transform="translate(80.33,-761.34)">
+                <polyline class="nad-edge-path nad-stretchable" points="103.48,-784.15 -13.29,-669.08"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(80.33,-761.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-134.58)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -849,8 +861,8 @@
                 </g>
             </g>
             <g id="37.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-130.06,-554.00 -13.29,-669.08"/>
-                <g class="nad-edge-infos" transform="translate(-106.91,-576.81)">
+                <polyline class="nad-edge-path nad-stretchable" points="-130.06,-554.00 -13.29,-669.08"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-106.91,-576.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(45.42)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -871,8 +883,8 @@
         <g id="38">
             <desc>NNL1AA1  NNL3AA1  1</desc>
             <g id="38.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="132.31,-777.55 187.53,-622.87"/>
-                <g class="nad-edge-infos" transform="translate(143.24,-746.94)">
+                <polyline class="nad-edge-path nad-stretchable" points="132.31,-777.55 187.53,-622.87"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(143.24,-746.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(160.36)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -890,8 +902,8 @@
                 </g>
             </g>
             <g id="38.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="242.74,-468.18 187.53,-622.87"/>
-                <g class="nad-edge-infos" transform="translate(231.82,-498.79)">
+                <polyline class="nad-edge-path nad-stretchable" points="242.74,-468.18 187.53,-622.87"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(231.82,-498.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-19.64)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -912,8 +924,8 @@
         <g id="39">
             <desc>NNL2AA1  NNL3AA1  1</desc>
             <g id="39.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-122.84,-528.53 51.17,-488.49"/>
-                <g class="nad-edge-infos" transform="translate(-91.17,-521.24)">
+                <polyline class="nad-edge-path nad-stretchable" points="-122.84,-528.53 51.17,-488.49"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-91.17,-521.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(102.96)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -931,8 +943,8 @@
                 </g>
             </g>
             <g id="39.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="225.19,-448.45 51.17,-488.49"/>
-                <g class="nad-edge-infos" transform="translate(193.52,-455.73)">
+                <polyline class="nad-edge-path nad-stretchable" points="225.19,-448.45 51.17,-488.49"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(193.52,-455.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-77.04)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/simple-eu.svg
+++ b/network-area-diagram/src/test/resources/simple-eu.svg
@@ -411,14 +411,10 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl300to500-line">
-                    <circle class="nad-winding" cx="-569.39" cy="-281.74" r="20.00"/>
-                </g>
-                <g class="nad-vl300to500-line">
-                    <circle class="nad-winding" cx="-555.87" cy="-296.48" r="20.00"/>
-                </g>
+                <circle class="nad-vl300to500-line nad-winding" cx="-569.39" cy="-281.74" r="20.00"/>
+                <circle class="nad-vl300to500-line nad-winding" cx="-555.87" cy="-296.48" r="20.00"/>
+                <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(0.68,-0.74,0.74,0.68,-605.02,-287.30)" class="nad-pst-arrow"/>
             </g>
-            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(0.68,-0.74,0.74,0.68,-605.02,-287.30)" class="nad-pst-arrow nad-glued-center"/>
         </g>
         <g id="27">
             <desc>BBE2AA1  FFR3AA1  1</desc>
@@ -830,14 +826,10 @@
                 </g>
             </g>
             <g class="nad-glued-center">
-                <g class="nad-vl300to500-line">
-                    <circle class="nad-winding" cx="102.05" cy="832.59" r="20.00"/>
-                </g>
-                <g class="nad-vl300to500-line">
-                    <circle class="nad-winding" cx="84.44" cy="842.07" r="20.00"/>
-                </g>
+                <circle class="nad-vl300to500-line nad-winding" cx="102.05" cy="832.59" r="20.00"/>
+                <circle class="nad-vl300to500-line nad-winding" cx="84.44" cy="842.07" r="20.00"/>
+                <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(-0.88,0.47,-0.47,-0.88,133.88,849.53)" class="nad-pst-arrow"/>
             </g>
-            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(-0.88,0.47,-0.47,-0.88,133.88,849.53)" class="nad-pst-arrow nad-glued-center"/>
         </g>
         <g id="37">
             <desc>NNL1AA1  NNL2AA1  1</desc>

--- a/network-area-diagram/src/test/resources/simple-eu.svg
+++ b/network-area-diagram/src/test/resources/simple-eu.svg
@@ -209,8 +209,8 @@
         <g id="22">
             <desc>BBE1AA1  BBE2AA1  1</desc>
             <g id="22.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-492.02,-186.98 -525.98,-146.94 -553.50,4.50"/>
-                <g class="nad-edge-infos" transform="translate(-531.34,-117.42)">
+                <polyline class="nad-edge-path nad-stretchable" points="-492.02,-186.98 -525.98,-146.94 -553.50,4.50"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-531.34,-117.42)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-169.70)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -228,8 +228,8 @@
                 </g>
             </g>
             <g id="22.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-563.32,205.36 -581.02,155.93 -553.50,4.50"/>
-                <g class="nad-edge-infos" transform="translate(-575.65,126.42)">
+                <polyline class="nad-edge-path nad-stretchable" points="-563.32,205.36 -581.02,155.93 -553.50,4.50"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-575.65,126.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(10.30)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -291,8 +291,8 @@
         <g id="24">
             <desc>BBE2AA1  BBE3AA1  1</desc>
             <g id="24.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-536.26,210.28 -502.31,170.24 -474.79,18.80"/>
-                <g class="nad-edge-infos" transform="translate(-496.94,140.72)">
+                <polyline class="nad-edge-path nad-stretchable" points="-536.26,210.28 -502.31,170.24 -474.79,18.80"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-496.94,140.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(10.30)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -310,8 +310,8 @@
                 </g>
             </g>
             <g id="24.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-454.85,-153.82 -447.27,-132.64 -474.79,18.80"/>
-                <g class="nad-edge-infos" transform="translate(-452.63,-103.12)">
+                <polyline class="nad-edge-path nad-stretchable" points="-454.85,-153.82 -447.27,-132.64 -474.79,18.80"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-452.63,-103.12)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-169.70)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -332,8 +332,8 @@
         <g id="25">
             <desc>NNL2AA1  BBE3AA1  1</desc>
             <g id="25.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-169.02,-515.19 -301.37,-381.97"/>
-                <g class="nad-edge-infos" transform="translate(-191.93,-492.13)">
+                <polyline class="nad-edge-path nad-stretchable" points="-169.02,-515.19 -301.37,-381.97"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-191.93,-492.13)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-135.19)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -351,8 +351,8 @@
                 </g>
             </g>
             <g id="25.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-433.71,-248.75 -301.37,-381.97"/>
-                <g class="nad-edge-infos" transform="translate(-410.81,-271.80)">
+                <polyline class="nad-edge-path nad-stretchable" points="-433.71,-248.75 -301.37,-381.97"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-410.81,-271.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(44.81)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -390,7 +390,6 @@
                         <text transform="rotate(-347.44)" x="-19.00" style="text-anchor:end">8</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-569.39" cy="-281.74" r="20.00"/>
             </g>
             <g id="26.2" class="nad-vl300to500-line">
                 <path class="nad-edge-path" d="M-482.48,-234.19 L-498.22,-284.27 C-510.21,-322.43 -535.58,-318.58 -542.34,-311.21"/>
@@ -410,15 +409,22 @@
                         <text transform="rotate(-287.44)" x="-19.00" style="text-anchor:end">4</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="-555.87" cy="-296.48" r="20.00"/>
             </g>
-            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(0.68,-0.74,0.74,0.68,-605.02,-287.30)" class="nad-pst-arrow"/>
+            <g class="nad-glued-center">
+                <g class="nad-vl300to500-line">
+                    <circle class="nad-winding" cx="-569.39" cy="-281.74" r="20.00"/>
+                </g>
+                <g class="nad-vl300to500-line">
+                    <circle class="nad-winding" cx="-555.87" cy="-296.48" r="20.00"/>
+                </g>
+            </g>
+            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(0.68,-0.74,0.74,0.68,-605.02,-287.30)" class="nad-pst-arrow nad-glued-center"/>
         </g>
         <g id="27">
             <desc>BBE2AA1  FFR3AA1  1</desc>
             <g id="27.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-542.54,256.22 -463.08,428.65"/>
-                <g class="nad-edge-infos" transform="translate(-528.94,285.74)">
+                <polyline class="nad-edge-path nad-stretchable" points="-542.54,256.22 -463.08,428.65"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-528.94,285.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -436,8 +442,8 @@
                 </g>
             </g>
             <g id="27.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-383.63,601.07 -463.08,428.65"/>
-                <g class="nad-edge-infos" transform="translate(-397.23,571.55)">
+                <polyline class="nad-edge-path nad-stretchable" points="-383.63,601.07 -463.08,428.65"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-397.23,571.55)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-24.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -458,8 +464,8 @@
         <g id="28">
             <desc>DDE1AA1  DDE2AA1  1</desc>
             <g id="28.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="686.85,254.06 577.89,137.39"/>
-                <g class="nad-edge-infos" transform="translate(664.67,230.31)">
+                <polyline class="nad-edge-path nad-stretchable" points="686.85,254.06 577.89,137.39"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(664.67,230.31)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-43.04)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -477,8 +483,8 @@
                 </g>
             </g>
             <g id="28.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="468.92,20.71 577.89,137.39"/>
-                <g class="nad-edge-infos" transform="translate(491.10,44.47)">
+                <polyline class="nad-edge-path nad-stretchable" points="468.92,20.71 577.89,137.39"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(491.10,44.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(136.96)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -499,8 +505,8 @@
         <g id="29">
             <desc>DDE1AA1  DDE3AA1  1</desc>
             <g id="29.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="680.95,286.30 540.26,355.48"/>
-                <g class="nad-edge-infos" transform="translate(651.78,300.64)">
+                <polyline class="nad-edge-path nad-stretchable" points="680.95,286.30 540.26,355.48"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(651.78,300.64)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-116.19)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -518,8 +524,8 @@
                 </g>
             </g>
             <g id="29.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="399.58,424.67 540.26,355.48"/>
-                <g class="nad-edge-infos" transform="translate(428.75,410.33)">
+                <polyline class="nad-edge-path nad-stretchable" points="399.58,424.67 540.26,355.48"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(428.75,410.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(63.81)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -540,8 +546,8 @@
         <g id="30">
             <desc>DDE2AA1  DDE3AA1  1</desc>
             <g id="30.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="445.47,27.72 412.53,218.71"/>
-                <g class="nad-edge-infos" transform="translate(439.95,59.74)">
+                <polyline class="nad-edge-path nad-stretchable" points="445.47,27.72 412.53,218.71"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(439.95,59.74)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-170.21)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -559,8 +565,8 @@
                 </g>
             </g>
             <g id="30.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="379.58,409.70 412.53,218.71"/>
-                <g class="nad-edge-infos" transform="translate(385.11,377.68)">
+                <polyline class="nad-edge-path nad-stretchable" points="379.58,409.70 412.53,218.71"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(385.11,377.68)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(9.79)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -581,8 +587,8 @@
         <g id="31">
             <desc>DDE2AA1  NNL3AA1  1</desc>
             <g id="31.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="438.92,-24.49 351.07,-220.83"/>
-                <g class="nad-edge-infos" transform="translate(425.65,-54.15)">
+                <polyline class="nad-edge-path nad-stretchable" points="438.92,-24.49 351.07,-220.83"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(425.65,-54.15)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-24.10)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -600,8 +606,8 @@
                 </g>
             </g>
             <g id="31.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="263.22,-417.18 351.07,-220.83"/>
-                <g class="nad-edge-infos" transform="translate(276.49,-387.51)">
+                <polyline class="nad-edge-path nad-stretchable" points="263.22,-417.18 351.07,-220.83"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(276.49,-387.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.90)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -622,8 +628,8 @@
         <g id="32">
             <desc>FFR2AA1  DDE3AA1  1</desc>
             <g id="32.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="79.75,693.89 216.96,574.38"/>
-                <g class="nad-edge-infos" transform="translate(104.26,672.54)">
+                <polyline class="nad-edge-path nad-stretchable" points="79.75,693.89 216.96,574.38"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(104.26,672.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.94)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -641,8 +647,8 @@
                 </g>
             </g>
             <g id="32.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="354.17,454.87 216.96,574.38"/>
-                <g class="nad-edge-infos" transform="translate(329.66,476.21)">
+                <polyline class="nad-edge-path nad-stretchable" points="354.17,454.87 216.96,574.38"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(329.66,476.21)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-131.06)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -704,8 +710,8 @@
         <g id="34">
             <desc>FFR1AA1  FFR3AA1  1</desc>
             <g id="34.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="16.78,712.38 -20.67,675.58 -157.85,640.12"/>
-                <g class="nad-edge-infos" transform="translate(-49.72,668.08)">
+                <polyline class="nad-edge-path nad-stretchable" points="16.78,712.38 -20.67,675.58 -157.85,640.12"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-49.72,668.08)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-75.51)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -723,8 +729,8 @@
                 </g>
             </g>
             <g id="34.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-345.62,618.69 -295.03,604.66 -157.85,640.12"/>
-                <g class="nad-edge-infos" transform="translate(-265.98,612.17)">
+                <polyline class="nad-edge-path nad-stretchable" points="-345.62,618.69 -295.03,604.66 -157.85,640.12"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-265.98,612.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.49)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -745,8 +751,8 @@
         <g id="35">
             <desc>FFR2AA1  FFR3AA1  1</desc>
             <g id="35.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-19.02,747.02 -40.70,753.04 -177.87,717.58"/>
-                <g class="nad-edge-infos" transform="translate(-69.74,745.53)">
+                <polyline class="nad-edge-path nad-stretchable" points="-19.02,747.02 -40.70,753.04 -177.87,717.58"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-69.74,745.53)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-75.51)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -764,8 +770,8 @@
                 </g>
             </g>
             <g id="35.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-352.50,645.32 -315.05,682.11 -177.87,717.58"/>
-                <g class="nad-edge-infos" transform="translate(-286.01,689.62)">
+                <polyline class="nad-edge-path nad-stretchable" points="-352.50,645.32 -315.05,682.11 -177.87,717.58"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-286.01,689.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.49)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -803,7 +809,6 @@
                         <text transform="rotate(31.72)" x="19.00">4</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="102.05" cy="832.59" r="20.00"/>
             </g>
             <g id="36.2" class="nad-vl300to500-line">
                 <path class="nad-edge-path" d="M35.57,759.14 L33.99,811.62 C32.79,851.60 58.02,856.28 66.83,851.54"/>
@@ -823,15 +828,22 @@
                         <text transform="rotate(-88.28)" x="-19.00" style="text-anchor:end">9</text>
                     </g>
                 </g>
-                <circle class="nad-winding" cx="84.44" cy="842.07" r="20.00"/>
             </g>
-            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(-0.88,0.47,-0.47,-0.88,133.88,849.53)" class="nad-pst-arrow"/>
+            <g class="nad-glued-center">
+                <g class="nad-vl300to500-line">
+                    <circle class="nad-winding" cx="102.05" cy="832.59" r="20.00"/>
+                </g>
+                <g class="nad-vl300to500-line">
+                    <circle class="nad-winding" cx="84.44" cy="842.07" r="20.00"/>
+                </g>
+            </g>
+            <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(-0.88,0.47,-0.47,-0.88,133.88,849.53)" class="nad-pst-arrow nad-glued-center"/>
         </g>
         <g id="37">
             <desc>NNL1AA1  NNL2AA1  1</desc>
             <g id="37.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="103.48,-784.15 -13.29,-669.08"/>
-                <g class="nad-edge-infos" transform="translate(80.33,-761.34)">
+                <polyline class="nad-edge-path nad-stretchable" points="103.48,-784.15 -13.29,-669.08"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(80.33,-761.34)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-134.58)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -849,8 +861,8 @@
                 </g>
             </g>
             <g id="37.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-130.06,-554.00 -13.29,-669.08"/>
-                <g class="nad-edge-infos" transform="translate(-106.91,-576.81)">
+                <polyline class="nad-edge-path nad-stretchable" points="-130.06,-554.00 -13.29,-669.08"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-106.91,-576.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(45.42)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -871,8 +883,8 @@
         <g id="38">
             <desc>NNL1AA1  NNL3AA1  1</desc>
             <g id="38.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="132.31,-777.55 187.53,-622.87"/>
-                <g class="nad-edge-infos" transform="translate(143.24,-746.94)">
+                <polyline class="nad-edge-path nad-stretchable" points="132.31,-777.55 187.53,-622.87"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(143.24,-746.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(160.36)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -890,8 +902,8 @@
                 </g>
             </g>
             <g id="38.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="242.74,-468.18 187.53,-622.87"/>
-                <g class="nad-edge-infos" transform="translate(231.82,-498.79)">
+                <polyline class="nad-edge-path nad-stretchable" points="242.74,-468.18 187.53,-622.87"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(231.82,-498.79)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-19.64)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -912,8 +924,8 @@
         <g id="39">
             <desc>NNL2AA1  NNL3AA1  1</desc>
             <g id="39.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-122.84,-528.53 51.17,-488.49"/>
-                <g class="nad-edge-infos" transform="translate(-91.17,-521.24)">
+                <polyline class="nad-edge-path nad-stretchable" points="-122.84,-528.53 51.17,-488.49"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-91.17,-521.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(102.96)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -931,8 +943,8 @@
                 </g>
             </g>
             <g id="39.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="225.19,-448.45 51.17,-488.49"/>
-                <g class="nad-edge-infos" transform="translate(193.52,-455.73)">
+                <polyline class="nad-edge-path nad-stretchable" points="225.19,-448.45 51.17,-488.49"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(193.52,-455.73)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-77.04)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/vl_description_id.svg
+++ b/network-area-diagram/src/test/resources/vl_description_id.svg
@@ -137,8 +137,8 @@
     <g class="nad-branch-edges">
         <g id="4">
             <g id="4.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="140.62,-69.02 37.43,39.35"/>
-                <g class="nad-edge-infos" transform="translate(118.21,-45.48)">
+                <polyline class="nad-edge-path nad-stretchable" points="140.62,-69.02 37.43,39.35"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(118.21,-45.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-136.40)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -156,8 +156,8 @@
                 </g>
             </g>
             <g id="4.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-65.77,147.71 37.43,39.35"/>
-                <g class="nad-edge-infos" transform="translate(-43.36,124.17)">
+                <polyline class="nad-edge-path nad-stretchable" points="-65.77,147.71 37.43,39.35"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-43.36,124.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(43.60)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/vl_description_substation.svg
+++ b/network-area-diagram/src/test/resources/vl_description_substation.svg
@@ -137,8 +137,8 @@
     <g class="nad-branch-edges">
         <g id="4">
             <g id="4.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="140.62,-69.02 37.43,39.35"/>
-                <g class="nad-edge-infos" transform="translate(118.21,-45.48)">
+                <polyline class="nad-edge-path nad-stretchable" points="140.62,-69.02 37.43,39.35"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(118.21,-45.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-136.40)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -156,8 +156,8 @@
                 </g>
             </g>
             <g id="4.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-65.77,147.71 37.43,39.35"/>
-                <g class="nad-edge-infos" transform="translate(-43.36,124.17)">
+                <polyline class="nad-edge-path nad-stretchable" points="-65.77,147.71 37.43,39.35"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-43.36,124.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(43.60)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/vl_description_substation_id.svg
+++ b/network-area-diagram/src/test/resources/vl_description_substation_id.svg
@@ -137,8 +137,8 @@
     <g class="nad-branch-edges">
         <g id="4">
             <g id="4.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="140.62,-69.02 37.43,39.35"/>
-                <g class="nad-edge-infos" transform="translate(118.21,-45.48)">
+                <polyline class="nad-edge-path nad-stretchable" points="140.62,-69.02 37.43,39.35"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(118.21,-45.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-136.40)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -156,8 +156,8 @@
                 </g>
             </g>
             <g id="4.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path" points="-65.77,147.71 37.43,39.35"/>
-                <g class="nad-edge-infos" transform="translate(-43.36,124.17)">
+                <polyline class="nad-edge-path nad-stretchable" points="-65.77,147.71 37.43,39.35"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-43.36,124.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(43.60)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/voltage_limits.svg
+++ b/network-area-diagram/src/test/resources/voltage_limits.svg
@@ -75,8 +75,8 @@
     <g class="nad-branch-edges">
         <g id="5">
             <g id="5.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="133.21,-81.17 82.84,-66.34 8.46,11.76"/>
-                <g class="nad-edge-infos" transform="translate(62.15,-44.62)">
+                <polyline class="nad-edge-path nad-stretchable" points="133.21,-81.17 82.84,-66.34 8.46,11.76"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(62.15,-44.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-136.40)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -94,8 +94,8 @@
                 </g>
             </g>
             <g id="5.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="-78.27,140.89 -65.92,89.87 8.46,11.76"/>
-                <g class="nad-edge-infos" transform="translate(-45.23,68.14)">
+                <polyline class="nad-edge-path nad-stretchable" points="-78.27,140.89 -65.92,89.87 8.46,11.76"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-45.23,68.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(43.60)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -115,8 +115,8 @@
         </g>
         <g id="6">
             <g id="6.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="146.06,-33.04 140.77,-11.17 66.39,66.93"/>
-                <g class="nad-edge-infos" transform="translate(120.08,10.55)">
+                <polyline class="nad-edge-path nad-stretchable" points="146.06,-33.04 140.77,-11.17 66.39,66.93"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(120.08,10.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-136.40)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -134,8 +134,8 @@
                 </g>
             </g>
             <g id="6.2" class="nad-disconnected nad-vl300to500">
-                <polyline class="nad-edge-path" points="-58.36,159.86 -7.99,145.04 66.39,66.93"/>
-                <g class="nad-edge-infos" transform="translate(12.70,123.31)">
+                <polyline class="nad-edge-path nad-stretchable" points="-58.36,159.86 -7.99,145.04 66.39,66.93"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(12.70,123.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(43.60)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>


### PR DESCRIPTION
Signed-off-by: Luma <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature

**What is the new behavior (if this is a feature change)?**
Some parts of the edge drawings are marked as `stretchable` or `glued`.
This information helps to update the diagram when the user interacts with it. 
In the basic use-case is a user wants to move some node locations and see the effects (immediately) in the diagram.
To provide this kind of interaction, we want to allow the user drag the nodes to their desired positions. The edges connected to the moved node must be updated (if possible, while the user is performing the drag operation).
To be able to properly update the different parts of the edge we label them using two classes:

- `stretchable`: this part of the edge drawing can be scaled to fill the new gap between end nodes.
- `glued`: this part of the edge is glued to one of the ends of the edge or to its center.

**Other information**:
Previously the symbol for the transformer was split in two drawings, each one contained in its half edge.
With this change the circle drawings for the transformer symbol are grouped together in an element that then is glued to center of the edge.