### PR TITLE
Add metadata for 3wt edges and nodes

### DIFF
--- a/network-area-diagram/src/main/java/com/powsybl/nad/model/Graph.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/model/Graph.java
@@ -21,7 +21,7 @@ public class Graph {
 
     private final Map<String, Node> nodes = new LinkedHashMap<>();
     private final Map<String, BusNode> busNodes = new LinkedHashMap<>();
-    private final Map<String, Edge> edges = new LinkedHashMap<>();
+    private final Map<String, BranchEdge> branchEdges = new LinkedHashMap<>();
     private double minX = 0;
     private double minY = 0;
     private double maxX = 0;
@@ -58,6 +58,7 @@ public class Graph {
 
     public void addEdge(VoltageLevelNode node1, BusNode busNode1,
                         VoltageLevelNode node2, BusNode busNode2, BranchEdge edge) {
+        branchEdges.put(edge.getEquipmentId(), edge);
         addVoltageLevelsEdge(node1, node2, edge);
         addBusesEdge(busNode1, busNode2, edge);
     }
@@ -78,7 +79,6 @@ public class Graph {
         Objects.requireNonNull(node1);
         Objects.requireNonNull(node2);
         Objects.requireNonNull(edge);
-        edges.put(edge.getEquipmentId(), edge);
         voltageLevelGraph.addEdge(node1, node2, edge);
     }
 
@@ -116,8 +116,12 @@ public class Graph {
         return Collections.unmodifiableCollection(textEdges.values());
     }
 
-    public Stream<Edge> getEdgesStream() {
-        return edges.values().stream();
+    public Stream<BranchEdge> getBranchEdgeStream() {
+        return branchEdges.values().stream();
+    }
+
+    public Collection<BranchEdge> getBranchEdges() {
+        return Collections.unmodifiableCollection(branchEdges.values());
     }
 
     public Collection<Edge> getEdges() {
@@ -140,16 +144,6 @@ public class Graph {
 
     public Collection<Edge> getBusEdges(BusNode busNode) {
         return busGraph.edgesOf(busNode);
-    }
-
-    public Stream<BranchEdge> getBranchEdgeStream() {
-        return voltageLevelGraph.edgeSet().stream()
-                .filter(BranchEdge.class::isInstance)
-                .map(BranchEdge.class::cast);
-    }
-
-    public List<BranchEdge> getBranchEdges() {
-        return getBranchEdgeStream().collect(Collectors.toList());
     }
 
     public Stream<TextEdge> getTextEdgesStream() {
@@ -308,7 +302,7 @@ public class Graph {
     }
 
     public boolean containsEdge(String equipmentId) {
-        return edges.containsKey(equipmentId);
+        return branchEdges.containsKey(equipmentId);
     }
 
     public boolean containsNode(String equipmentId) {

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/SvgWriter.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/SvgWriter.java
@@ -836,22 +836,12 @@ public class SvgWriter {
         graph.getBusNodesStream().forEach(busNode -> metadata.addBusNode(getPrefixedId(busNode.getDiagramId()), busNode.getEquipmentId()));
         graph.getNodesStream().forEach(node -> metadata.addNode(getPrefixedId(node.getDiagramId()), node.getEquipmentId(),
                 getFormattedValue(node.getX()), getFormattedValue(node.getY())));
-        graph.getEdgesStream().forEach(edge -> {
-            // For 3wt transformers we have one equipmentId and three edges in the graph.
-            // When we get the stream of edges we are iterating through values in a map by equipmentId.
-            // Only one of the edges has been placed in the graph edges map,
-            // although three edges have been added to the graph.
-            // Here we simply ignore the 3wt edges
-            if (!(edge instanceof ThreeWtEdge)) {
-                metadata.addEdge(getPrefixedId(edge.getDiagramId()), edge.getEquipmentId(),
-                        getPrefixedId(graph.getNode1(edge).getDiagramId()),
-                        getPrefixedId(graph.getNode2(edge).getDiagramId()));
-            }
-        });
-        // This stream contains all 3wt edges that have been added to the graph, not only the last one
+        graph.getBranchEdgeStream().forEach(edge -> metadata.addEdge(getPrefixedId(edge.getDiagramId()), edge.getEquipmentId(),
+                getPrefixedId(graph.getNode1(edge).getDiagramId()),
+                getPrefixedId(graph.getNode2(edge).getDiagramId())));
         graph.getThreeWtEdgesStream().forEach(edge -> metadata.addEdge(getPrefixedId(edge.getDiagramId()), edge.getEquipmentId(),
-            getPrefixedId(graph.getNode1(edge).getDiagramId()),
-            getPrefixedId(graph.getNode2(edge).getDiagramId())));
+                getPrefixedId(graph.getNode1(edge).getDiagramId()),
+                getPrefixedId(graph.getNode2(edge).getDiagramId())));
 
         writer.writeStartElement(METADATA_ELEMENT_NAME);
         metadata.writeXml(writer);

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/SvgWriter.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/SvgWriter.java
@@ -123,7 +123,7 @@ public class SvgWriter {
         writer.writeAttribute(CLASS_ATTRIBUTE, StyleProvider.BRANCH_EDGES_CLASS);
         for (BranchEdge edge : graph.getBranchEdges()) {
             writer.writeStartElement(GROUP_ELEMENT_NAME);
-            writer.writeAttribute(ID_ATTRIBUTE, getPrefixedId(edge.getDiagramId()));
+            writeId(writer, edge);
             writeStyleClasses(writer, styleProvider.getEdgeStyleClasses(edge));
             insertName(writer, edge::getName);
 
@@ -246,7 +246,7 @@ public class SvgWriter {
             return;
         }
         writer.writeStartElement(GROUP_ELEMENT_NAME);
-        writer.writeAttribute(ID_ATTRIBUTE, getPrefixedId(edge.getDiagramId()));
+        writeId(writer, edge);
         writeStyleClasses(writer, styleProvider.getEdgeStyleClasses(edge));
         insertName(writer, edge::getName);
 
@@ -269,7 +269,7 @@ public class SvgWriter {
         writer.writeAttribute(CLASS_ATTRIBUTE, StyleProvider.THREE_WT_NODES_CLASS);
         for (ThreeWtNode threeWtNode : threeWtNodes) {
             writer.writeStartElement(GROUP_ELEMENT_NAME);
-            writer.writeAttribute(ID_ATTRIBUTE, getPrefixedId(threeWtNode.getDiagramId()));
+            writeId(writer, threeWtNode);
             writeStyleClasses(writer, styleProvider.getNodeStyleClasses(threeWtNode));
             List<ThreeWtEdge> edges = graph.getThreeWtEdgeStream(threeWtNode).collect(Collectors.toList());
             for (ThreeWtEdge edge : edges) {
@@ -506,7 +506,7 @@ public class SvgWriter {
 
     private void writeDetailedTextNode(XMLStreamWriter writer, TextNode textNode, VoltageLevelNode vlNode, List<String> content) throws XMLStreamException {
         writer.writeStartElement(FOREIGN_OBJECT_ELEMENT_NAME);
-        writer.writeAttribute(ID_ATTRIBUTE, getPrefixedId(textNode.getDiagramId()));
+        writeId(writer, textNode);
         writer.writeAttribute(Y_ATTRIBUTE, getFormattedValue(textNode.getY() - svgParameters.getDetailedTextNodeYShift()));
         writer.writeAttribute(X_ATTRIBUTE, getFormattedValue(textNode.getX()));
 
@@ -560,7 +560,7 @@ public class SvgWriter {
 
     private void writeSimpleTextNode(XMLStreamWriter writer, TextNode textNode, List<String> content) throws XMLStreamException {
         writer.writeStartElement(TEXT_ELEMENT_NAME);
-        writer.writeAttribute(ID_ATTRIBUTE, getPrefixedId(textNode.getDiagramId()));
+        writeId(writer, textNode);
         writer.writeAttribute(Y_ATTRIBUTE, getFormattedValue(textNode.getY()));
         if (content.size() == 1) {
             writer.writeAttribute(X_ATTRIBUTE, getFormattedValue(textNode.getX()));
@@ -581,7 +581,7 @@ public class SvgWriter {
     }
 
     private void drawNode(Graph graph, XMLStreamWriter writer, VoltageLevelNode vlNode) throws XMLStreamException {
-        writer.writeAttribute(ID_ATTRIBUTE, getPrefixedId(vlNode.getDiagramId()));
+        writeId(writer, vlNode);
         writeStyleClasses(writer, styleProvider.getNodeStyleClasses(vlNode));
         insertName(writer, vlNode::getName);
 
@@ -611,7 +611,7 @@ public class SvgWriter {
                 writer.writeEmptyElement(PATH_ELEMENT_NAME);
                 writer.writeAttribute(PATH_D_ATTRIBUTE, getFragmentedAnnulusPath(busInnerRadius, busOuterRadius, traversingBusEdges, graph, vlNode, busNode));
             }
-            writer.writeAttribute(ID_ATTRIBUTE, getPrefixedId(busNode.getDiagramId()));
+            writeId(writer, busNode);
             writeStyleClasses(writer, styleProvider.getNodeStyleClasses(busNode), StyleProvider.BUSNODE_CLASS);
 
             traversingBusEdges.addAll(graph.getBusEdges(busNode));
@@ -732,7 +732,7 @@ public class SvgWriter {
 
     private void drawTextEdge(XMLStreamWriter writer, TextEdge edge, VoltageLevelNode vlNode) throws XMLStreamException {
         writer.writeEmptyElement(POLYLINE_ELEMENT_NAME);
-        writer.writeAttribute(ID_ATTRIBUTE, getPrefixedId(edge.getDiagramId()));
+        writeId(writer, edge);
         writeStyleClasses(writer, styleProvider.getEdgeStyleClasses(edge));
         List<Point> points = edge.getPoints();
         shiftEdgeStart(points, vlNode);
@@ -753,6 +753,10 @@ public class SvgWriter {
         List<String> allClasses = new ArrayList<>(edgeStyleClasses);
         allClasses.addAll(Arrays.asList(additionalClasses));
         writer.writeAttribute(CLASS_ATTRIBUTE, String.join(" ", allClasses));
+    }
+
+    private void writeId(XMLStreamWriter writer, Identifiable identifiable) throws XMLStreamException {
+        writer.writeAttribute(ID_ATTRIBUTE, getPrefixedId(identifiable.getDiagramId()));
     }
 
     private void shiftEdgeStart(List<Point> points, VoltageLevelNode vlNode) {

--- a/network-area-diagram/src/test/resources/3wt.svg
+++ b/network-area-diagram/src/test/resources/3wt.svg
@@ -61,6 +61,8 @@
                 <nad:node svgId="6" equipmentId="3WT" x="72.67" y="53.08"/>
             </nad:nodes>
             <nad:edges>
+                <nad:edge svgId="7" equipmentId="3WT" node1="0" node2="6"/>
+                <nad:edge svgId="8" equipmentId="3WT" node1="2" node2="6"/>
                 <nad:edge svgId="9" equipmentId="3WT" node1="4" node2="6"/>
             </nad:edges>
         </nad:nad>
@@ -83,8 +85,8 @@
     <g class="nad-3wt-edges">
         <g id="7" class="nad-vl0to30">
             <desc>3WT</desc>
-            <polyline class="nad-edge-path" points="-179.49,-203.13 49.18,31.35"/>
-            <g class="nad-edge-infos" transform="translate(-156.79,-179.86)">
+            <polyline class="nad-edge-path nad-stretchable" points="-179.49,-203.13 49.18,31.35"/>
+            <g class="nad-glued-1 nad-edge-infos" transform="translate(-156.79,-179.86)">
                 <g class="nad-active nad-state-out">
                     <g transform="rotate(135.72)">
                         <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -103,8 +105,8 @@
         </g>
         <g id="8" class="nad-vl120to180">
             <desc>3WT</desc>
-            <polyline class="nad-edge-path" points="-162.45,337.93 65.60,84.29"/>
-            <g class="nad-edge-infos" transform="translate(-140.72,313.77)">
+            <polyline class="nad-edge-path nad-stretchable" points="-162.45,337.93 65.60,84.29"/>
+            <g class="nad-glued-1 nad-edge-infos" transform="translate(-140.72,313.77)">
                 <g class="nad-active nad-state-out">
                     <g transform="rotate(41.96)">
                         <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -123,8 +125,8 @@
         </g>
         <g id="9" class="nad-vl30to50">
             <desc>3WT</desc>
-            <polyline class="nad-edge-path" points="428.47,-57.25 103.24,43.60"/>
-            <g class="nad-edge-infos" transform="translate(397.43,-47.62)">
+            <polyline class="nad-edge-path nad-stretchable" points="428.47,-57.25 103.24,43.60"/>
+            <g class="nad-glued-1 nad-edge-infos" transform="translate(397.43,-47.62)">
                 <g class="nad-active nad-state-out">
                     <g transform="rotate(-107.23)">
                         <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -143,7 +145,7 @@
         </g>
     </g>
     <g class="nad-3wt-nodes">
-        <g>
+        <g id="6">
             <circle class="nad-vl0to30 nad-winding" cx="63.86" cy="44.93" r="20.00"/>
             <circle class="nad-vl120to180 nad-winding" cx="70.02" cy="64.79" r="20.00"/>
             <circle class="nad-vl30to50 nad-winding" cx="84.13" cy="49.53" r="20.00"/>

--- a/network-area-diagram/src/test/resources/3wt_disconnected.svg
+++ b/network-area-diagram/src/test/resources/3wt_disconnected.svg
@@ -60,6 +60,8 @@
                 <nad:node svgId="5" equipmentId="3WT" x="72.67" y="53.08"/>
             </nad:nodes>
             <nad:edges>
+                <nad:edge svgId="6" equipmentId="3WT" node1="0" node2="5"/>
+                <nad:edge svgId="7" equipmentId="3WT" node1="2" node2="5"/>
                 <nad:edge svgId="8" equipmentId="3WT" node1="4" node2="5"/>
             </nad:edges>
         </nad:nad>
@@ -82,8 +84,8 @@
     <g class="nad-3wt-edges">
         <g id="6" class="nad-vl0to30">
             <desc>3WT</desc>
-            <polyline class="nad-edge-path" points="-179.49,-203.13 49.18,31.35"/>
-            <g class="nad-edge-infos" transform="translate(-156.79,-179.86)">
+            <polyline class="nad-edge-path nad-stretchable" points="-179.49,-203.13 49.18,31.35"/>
+            <g class="nad-glued-1 nad-edge-infos" transform="translate(-156.79,-179.86)">
                 <g class="nad-active nad-state-out">
                     <g transform="rotate(135.72)">
                         <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -102,8 +104,8 @@
         </g>
         <g id="7" class="nad-vl120to180">
             <desc>3WT</desc>
-            <polyline class="nad-edge-path" points="-162.45,337.93 65.60,84.29"/>
-            <g class="nad-edge-infos" transform="translate(-140.72,313.77)">
+            <polyline class="nad-edge-path nad-stretchable" points="-162.45,337.93 65.60,84.29"/>
+            <g class="nad-glued-1 nad-edge-infos" transform="translate(-140.72,313.77)">
                 <g class="nad-active nad-state-out">
                     <g transform="rotate(41.96)">
                         <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -122,8 +124,8 @@
         </g>
         <g id="8" class="nad-disconnected nad-vl30to50">
             <desc>3WT</desc>
-            <polyline class="nad-edge-path" points="416.54,-53.55 103.24,43.60"/>
-            <g class="nad-edge-infos" transform="translate(385.49,-43.92)">
+            <polyline class="nad-edge-path nad-stretchable" points="416.54,-53.55 103.24,43.60"/>
+            <g class="nad-glued-1 nad-edge-infos" transform="translate(385.49,-43.92)">
                 <g class="nad-active nad-state-out">
                     <g transform="rotate(-107.23)">
                         <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -142,7 +144,7 @@
         </g>
     </g>
     <g class="nad-3wt-nodes">
-        <g>
+        <g id="5">
             <circle class="nad-vl0to30 nad-winding" cx="63.86" cy="44.93" r="20.00"/>
             <circle class="nad-vl120to180 nad-winding" cx="70.02" cy="64.79" r="20.00"/>
             <circle class="nad-disconnected nad-vl30to50 nad-winding" cx="84.13" cy="49.53" r="20.00"/>

--- a/network-area-diagram/src/test/resources/3wt_disconnected_topological.svg
+++ b/network-area-diagram/src/test/resources/3wt_disconnected_topological.svg
@@ -125,6 +125,8 @@
                 <nad:node svgId="5" equipmentId="3WT" x="72.67" y="53.08"/>
             </nad:nodes>
             <nad:edges>
+                <nad:edge svgId="6" equipmentId="3WT" node1="0" node2="5"/>
+                <nad:edge svgId="7" equipmentId="3WT" node1="2" node2="5"/>
                 <nad:edge svgId="8" equipmentId="3WT" node1="4" node2="5"/>
             </nad:edges>
         </nad:nad>
@@ -147,8 +149,8 @@
     <g class="nad-3wt-edges">
         <g id="6" class="nad-vl0to30-line">
             <desc>3WT</desc>
-            <polyline class="nad-edge-path" points="-179.49,-203.13 49.18,31.35"/>
-            <g class="nad-edge-infos" transform="translate(-156.79,-179.86)">
+            <polyline class="nad-edge-path nad-stretchable" points="-179.49,-203.13 49.18,31.35"/>
+            <g class="nad-glued-1 nad-edge-infos" transform="translate(-156.79,-179.86)">
                 <g class="nad-active nad-state-out">
                     <g transform="rotate(135.72)">
                         <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -167,8 +169,8 @@
         </g>
         <g id="7" class="nad-vl120to180-line">
             <desc>3WT</desc>
-            <polyline class="nad-edge-path" points="-162.45,337.93 65.60,84.29"/>
-            <g class="nad-edge-infos" transform="translate(-140.72,313.77)">
+            <polyline class="nad-edge-path nad-stretchable" points="-162.45,337.93 65.60,84.29"/>
+            <g class="nad-glued-1 nad-edge-infos" transform="translate(-140.72,313.77)">
                 <g class="nad-active nad-state-out">
                     <g transform="rotate(41.96)">
                         <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -187,8 +189,8 @@
         </g>
         <g id="8" class="nad-disconnected nad-vl30to50-line">
             <desc>3WT</desc>
-            <polyline class="nad-edge-path" points="416.54,-53.55 103.24,43.60"/>
-            <g class="nad-edge-infos" transform="translate(385.49,-43.92)">
+            <polyline class="nad-edge-path nad-stretchable" points="416.54,-53.55 103.24,43.60"/>
+            <g class="nad-glued-1 nad-edge-infos" transform="translate(385.49,-43.92)">
                 <g class="nad-active nad-state-out">
                     <g transform="rotate(-107.23)">
                         <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -207,7 +209,7 @@
         </g>
     </g>
     <g class="nad-3wt-nodes">
-        <g>
+        <g id="5">
             <circle class="nad-vl0to30-line nad-winding" cx="63.86" cy="44.93" r="20.00"/>
             <circle class="nad-vl120to180-line nad-winding" cx="70.02" cy="64.79" r="20.00"/>
             <circle class="nad-disconnected nad-vl30to50-line nad-winding" cx="84.13" cy="49.53" r="20.00"/>

--- a/network-area-diagram/src/test/resources/3wt_partial.svg
+++ b/network-area-diagram/src/test/resources/3wt_partial.svg
@@ -61,6 +61,8 @@
                 <nad:node svgId="7" equipmentId="VL_33" x="261.19" y="-298.22"/>
             </nad:nodes>
             <nad:edges>
+                <nad:edge svgId="3" equipmentId="3WT" node1="0" node2="2"/>
+                <nad:edge svgId="6" equipmentId="3WT" node1="4" node2="2"/>
                 <nad:edge svgId="9" equipmentId="3WT" node1="7" node2="2"/>
             </nad:edges>
         </nad:nad>
@@ -75,8 +77,8 @@
     <g class="nad-3wt-edges">
         <g id="3" class="nad-vl0to30">
             <desc>3WT</desc>
-            <polyline class="nad-edge-path" points="-351.03,102.55 -24.91,12.69"/>
-            <g class="nad-edge-infos" transform="translate(-319.69,93.92)">
+            <polyline class="nad-edge-path nad-stretchable" points="-351.03,102.55 -24.91,12.69"/>
+            <g class="nad-glued-1 nad-edge-infos" transform="translate(-319.69,93.92)">
                 <g class="nad-active nad-state-out">
                     <g transform="rotate(74.59)">
                         <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -95,7 +97,7 @@
         </g>
     </g>
     <g class="nad-3wt-nodes">
-        <g>
+        <g id="2">
             <circle class="nad-vl0to30 nad-winding" cx="-5.63" cy="7.38" r="20.00"/>
             <circle class="nad-vl120to180 nad-winding" cx="14.49" cy="12.61" r="20.00"/>
             <circle class="nad-vl30to50 nad-winding" cx="8.97" cy="-7.42" r="20.00"/>

--- a/network-area-diagram/src/test/resources/edge_info_double_labels.svg
+++ b/network-area-diagram/src/test/resources/edge_info_double_labels.svg
@@ -61,6 +61,8 @@
                 <nad:node svgId="6" equipmentId="3WT" x="72.67" y="53.08"/>
             </nad:nodes>
             <nad:edges>
+                <nad:edge svgId="7" equipmentId="3WT" node1="0" node2="6"/>
+                <nad:edge svgId="8" equipmentId="3WT" node1="2" node2="6"/>
                 <nad:edge svgId="9" equipmentId="3WT" node1="4" node2="6"/>
             </nad:edges>
         </nad:nad>
@@ -79,8 +81,8 @@
     <g class="nad-branch-edges"></g>
     <g class="nad-3wt-edges">
         <g id="7" class="nad-vl0to30">
-            <polyline class="nad-edge-path" points="-179.49,-203.13 49.18,31.35"/>
-            <g class="nad-edge-infos" transform="translate(-135.85,-158.38)">
+            <polyline class="nad-edge-path nad-stretchable" points="-179.49,-203.13 49.18,31.35"/>
+            <g class="nad-glued-1 nad-edge-infos" transform="translate(-135.85,-158.38)">
                 <g class="nad-state-in">
                     <g transform="rotate(135.72)">
                         <path class="nad-arrow-in" transform="scale(10.00)" d="M-2 -1 H2 L0 1z"/>
@@ -92,8 +94,8 @@
             </g>
         </g>
         <g id="8" class="nad-vl120to180">
-            <polyline class="nad-edge-path" points="-162.45,337.93 65.60,84.29"/>
-            <g class="nad-edge-infos" transform="translate(-120.66,291.46)">
+            <polyline class="nad-edge-path nad-stretchable" points="-162.45,337.93 65.60,84.29"/>
+            <g class="nad-glued-1 nad-edge-infos" transform="translate(-120.66,291.46)">
                 <g class="nad-state-in">
                     <g transform="rotate(41.96)">
                         <path class="nad-arrow-in" transform="scale(10.00)" d="M-2 -1 H2 L0 1z"/>
@@ -105,8 +107,8 @@
             </g>
         </g>
         <g id="9" class="nad-vl30to50">
-            <polyline class="nad-edge-path" points="428.47,-57.25 103.24,43.60"/>
-            <g class="nad-edge-infos" transform="translate(368.78,-38.74)">
+            <polyline class="nad-edge-path nad-stretchable" points="428.47,-57.25 103.24,43.60"/>
+            <g class="nad-glued-1 nad-edge-infos" transform="translate(368.78,-38.74)">
                 <g class="nad-state-in">
                     <g transform="rotate(-107.23)">
                         <path class="nad-arrow-in" transform="scale(10.00)" d="M-2 -1 H2 L0 1z"/>
@@ -119,7 +121,7 @@
         </g>
     </g>
     <g class="nad-3wt-nodes">
-        <g>
+        <g id="6">
             <circle class="nad-vl0to30 nad-winding" cx="63.86" cy="44.93" r="20.00"/>
             <circle class="nad-vl120to180 nad-winding" cx="70.02" cy="64.79" r="20.00"/>
             <circle class="nad-vl30to50 nad-winding" cx="84.13" cy="49.53" r="20.00"/>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Not all edges of 3wt are written to the metadata (only the last one for each transformer).
The drawings for 3wt edges are not marked as stretchable.


**What is the new behavior (if this is a feature change)?**
All edges of 3wt are written to metadata. They have the same equipment identifier.
Drawings for these edges are marked as stretchable.


