### PR TITLE
add glued class to half edge drawings

### DIFF
--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/SvgWriter.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/SvgWriter.java
@@ -209,7 +209,10 @@ public class SvgWriter {
         if (edge.isVisible(side)) {
             if (!graph.isLoop(edge)) {
                 writer.writeEmptyElement(POLYLINE_ELEMENT_NAME);
-                writer.writeAttribute(CLASS_ATTRIBUTE, String.join(" ", StyleProvider.EDGE_PATH_CLASS, StyleProvider.STRETCHABLE_CLASS));
+                writer.writeAttribute(CLASS_ATTRIBUTE, String.join(" ",
+                        StyleProvider.EDGE_PATH_CLASS,
+                        StyleProvider.STRETCHABLE_CLASS,
+                        StyleProvider.GLUED_CLASS + "-" + side.getNum()));
                 writer.writeAttribute(POINTS_ATTRIBUTE, getPolylinePointsString(edge, side));
                 drawBranchEdgeInfo(graph, writer, edge, side, labelProvider.getEdgeInfos(graph, edge, side));
             } else {

--- a/network-area-diagram/src/test/resources/IEEE_118_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_118_bus.svg
@@ -1022,7 +1022,7 @@
         <g id="236">
             <desc>L1-2-1</desc>
             <g id="236.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="741.47,-2946.11 766.47,-2794.78"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="741.47,-2946.11 766.47,-2794.78"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(746.77,-2914.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(170.62)">
@@ -1041,7 +1041,7 @@
                 </g>
             </g>
             <g id="236.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="791.47,-2643.45 766.47,-2794.78"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="791.47,-2643.45 766.47,-2794.78"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(786.17,-2675.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-9.38)">
@@ -1063,7 +1063,7 @@
         <g id="237">
             <desc>L1-3-1</desc>
             <g id="237.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="714.74,-2957.07 542.93,-2832.17"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="714.74,-2957.07 542.93,-2832.17"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(688.46,-2937.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-126.02)">
@@ -1082,7 +1082,7 @@
                 </g>
             </g>
             <g id="237.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="371.12,-2707.26 542.93,-2832.17"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="371.12,-2707.26 542.93,-2832.17"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(397.41,-2726.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(53.98)">
@@ -1104,7 +1104,7 @@
         <g id="238">
             <desc>L9-10-1</desc>
             <g id="238.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1123.22,-2570.33 -1208.91,-2732.35"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1123.22,-2570.33 -1208.91,-2732.35"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1138.41,-2599.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-27.87)">
@@ -1123,7 +1123,7 @@
                 </g>
             </g>
             <g id="238.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1294.60,-2894.37 -1208.91,-2732.35"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1294.60,-2894.37 -1208.91,-2732.35"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1279.40,-2865.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(152.13)">
@@ -1145,7 +1145,7 @@
         <g id="239">
             <desc>L92-100-1</desc>
             <g id="239.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2680.60,263.30 2508.24,-90.81"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2680.60,263.30 2508.24,-90.81"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(2666.38,234.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-25.95)">
@@ -1164,7 +1164,7 @@
                 </g>
             </g>
             <g id="239.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2335.88,-444.93 2508.24,-90.81"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2335.88,-444.93 2508.24,-90.81"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(2350.10,-415.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(154.05)">
@@ -1186,7 +1186,7 @@
         <g id="240">
             <desc>L94-100-1</desc>
             <g id="240.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2203.64,116.63 2260.98,-163.04"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2203.64,116.63 2260.98,-163.04"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(2210.17,84.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(11.59)">
@@ -1205,7 +1205,7 @@
                 </g>
             </g>
             <g id="240.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2318.32,-442.72 2260.98,-163.04"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2318.32,-442.72 2260.98,-163.04"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(2311.79,-410.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-168.41)">
@@ -1227,7 +1227,7 @@
         <g id="241">
             <desc>L98-100-1</desc>
             <g id="241.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1661.77,-572.17 1979.22,-523.02"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1661.77,-572.17 1979.22,-523.02"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1693.89,-567.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(98.80)">
@@ -1246,7 +1246,7 @@
                 </g>
             </g>
             <g id="241.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2296.67,-473.87 1979.22,-523.02"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2296.67,-473.87 1979.22,-523.02"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(2264.55,-478.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-81.20)">
@@ -1268,7 +1268,7 @@
         <g id="242">
             <desc>L99-100-1</desc>
             <g id="242.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1820.91,-304.17 2059.32,-382.62"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1820.91,-304.17 2059.32,-382.62"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1851.78,-314.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(71.79)">
@@ -1287,7 +1287,7 @@
                 </g>
             </g>
             <g id="242.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2297.72,-461.06 2059.32,-382.62"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2297.72,-461.06 2059.32,-382.62"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(2266.85,-450.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-108.21)">
@@ -1309,7 +1309,7 @@
         <g id="243">
             <desc>L100-101-1</desc>
             <g id="243.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2349.71,-460.31 2555.79,-385.77"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2349.71,-460.31 2555.79,-385.77"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(2380.27,-449.25)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(109.88)">
@@ -1328,7 +1328,7 @@
                 </g>
             </g>
             <g id="243.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2761.88,-311.24 2555.79,-385.77"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2761.88,-311.24 2555.79,-385.77"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(2731.32,-322.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-70.12)">
@@ -1350,7 +1350,7 @@
         <g id="244">
             <desc>L100-103-1</desc>
             <g id="244.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2323.64,-497.16 2320.89,-858.25"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2323.64,-497.16 2320.89,-858.25"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(2323.39,-529.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-0.44)">
@@ -1369,7 +1369,7 @@
                 </g>
             </g>
             <g id="244.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2318.14,-1219.35 2320.89,-858.25"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2318.14,-1219.35 2320.89,-858.25"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(2318.38,-1186.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(179.56)">
@@ -1391,7 +1391,7 @@
         <g id="245">
             <desc>L100-104-1</desc>
             <g id="245.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2327.79,-496.87 2357.25,-700.06"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2327.79,-496.87 2357.25,-700.06"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(2332.46,-529.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(8.25)">
@@ -1410,7 +1410,7 @@
                 </g>
             </g>
             <g id="245.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2386.71,-903.24 2357.25,-700.06"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2386.71,-903.24 2357.25,-700.06"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(2382.05,-871.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-171.75)">
@@ -1432,7 +1432,7 @@
         <g id="246">
             <desc>L100-106-1</desc>
             <g id="246.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2345.94,-486.03 2570.70,-652.59"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2345.94,-486.03 2570.70,-652.59"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(2372.05,-505.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(53.46)">
@@ -1451,7 +1451,7 @@
                 </g>
             </g>
             <g id="246.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2795.46,-819.15 2570.70,-652.59"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2795.46,-819.15 2570.70,-652.59"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(2769.35,-799.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-126.54)">
@@ -1473,7 +1473,7 @@
         <g id="247">
             <desc>L101-102-1</desc>
             <g id="247.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2805.31,-280.73 2912.83,-151.25"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2805.31,-280.73 2912.83,-151.25"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(2826.07,-255.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(140.30)">
@@ -1492,7 +1492,7 @@
                 </g>
             </g>
             <g id="247.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="3020.34,-21.77 2912.83,-151.25"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="3020.34,-21.77 2912.83,-151.25"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(2999.58,-46.77)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-39.70)">
@@ -1514,7 +1514,7 @@
         <g id="248">
             <desc>L92-102-1</desc>
             <g id="248.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2713.73,270.39 2865.27,143.71"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2713.73,270.39 2865.27,143.71"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(2738.67,249.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(50.11)">
@@ -1533,7 +1533,7 @@
                 </g>
             </g>
             <g id="248.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="3016.81,17.03 2865.27,143.71"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="3016.81,17.03 2865.27,143.71"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(2991.88,37.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-129.89)">
@@ -1555,7 +1555,7 @@
         <g id="249">
             <desc>L103-104-1</desc>
             <g id="249.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2324.09,-1220.05 2354.29,-1088.65"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2324.09,-1220.05 2354.29,-1088.65"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(2331.37,-1188.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(167.05)">
@@ -1574,7 +1574,7 @@
                 </g>
             </g>
             <g id="249.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2384.50,-957.25 2354.29,-1088.65"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2384.50,-957.25 2354.29,-1088.65"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(2377.22,-988.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-12.95)">
@@ -1596,7 +1596,7 @@
         <g id="250">
             <desc>L103-105-1</desc>
             <g id="250.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2345.41,-1245.77 2529.69,-1238.49"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2345.41,-1245.77 2529.69,-1238.49"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(2377.88,-1244.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(92.26)">
@@ -1615,7 +1615,7 @@
                 </g>
             </g>
             <g id="250.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2713.97,-1231.22 2529.69,-1238.49"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2713.97,-1231.22 2529.69,-1238.49"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(2681.50,-1232.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-87.74)">
@@ -1637,7 +1637,7 @@
         <g id="251">
             <desc>L103-110-1</desc>
             <g id="251.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2314.98,-1274.19 2282.78,-1572.97"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2314.98,-1274.19 2282.78,-1572.97"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(2311.50,-1306.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-6.15)">
@@ -1656,7 +1656,7 @@
                 </g>
             </g>
             <g id="251.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2250.57,-1871.76 2282.78,-1572.97"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2250.57,-1871.76 2282.78,-1572.97"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(2254.06,-1839.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(173.85)">
@@ -1678,7 +1678,7 @@
         <g id="252">
             <desc>L104-105-1</desc>
             <g id="252.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2411.57,-948.32 2566.06,-1080.30"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2411.57,-948.32 2566.06,-1080.30"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(2436.28,-969.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(49.49)">
@@ -1697,7 +1697,7 @@
                 </g>
             </g>
             <g id="252.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2720.54,-1212.27 2566.06,-1080.30"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2720.54,-1212.27 2566.06,-1080.30"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(2695.83,-1191.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-130.51)">
@@ -1719,7 +1719,7 @@
         <g id="253">
             <desc>L105-106-1</desc>
             <g id="253.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2746.66,-1203.13 2779.50,-1032.83"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2746.66,-1203.13 2779.50,-1032.83"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(2752.81,-1171.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(169.08)">
@@ -1738,7 +1738,7 @@
                 </g>
             </g>
             <g id="253.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2812.35,-862.52 2779.50,-1032.83"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2812.35,-862.52 2779.50,-1032.83"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(2806.19,-894.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-10.92)">
@@ -1760,7 +1760,7 @@
         <g id="254">
             <desc>L105-107-1</desc>
             <g id="254.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2767.15,-1220.35 2934.23,-1156.75"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2767.15,-1220.35 2934.23,-1156.75"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(2797.53,-1208.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(110.84)">
@@ -1779,7 +1779,7 @@
                 </g>
             </g>
             <g id="254.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="3101.32,-1093.15 2934.23,-1156.75"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="3101.32,-1093.15 2934.23,-1156.75"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(3070.94,-1104.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-69.16)">
@@ -1801,7 +1801,7 @@
         <g id="255">
             <desc>L105-108-1</desc>
             <g id="255.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2750.20,-1256.21 2818.75,-1460.35"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2750.20,-1256.21 2818.75,-1460.35"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(2760.55,-1287.02)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(18.56)">
@@ -1820,7 +1820,7 @@
                 </g>
             </g>
             <g id="255.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2887.30,-1664.49 2818.75,-1460.35"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2887.30,-1664.49 2818.75,-1460.35"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(2876.95,-1633.68)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-161.44)">
@@ -1842,7 +1842,7 @@
         <g id="256">
             <desc>L106-107-1</desc>
             <g id="256.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2839.02,-852.71 2972.29,-959.44"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2839.02,-852.71 2972.29,-959.44"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(2864.39,-873.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(51.31)">
@@ -1861,7 +1861,7 @@
                 </g>
             </g>
             <g id="256.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="3105.55,-1066.18 2972.29,-959.44"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="3105.55,-1066.18 2972.29,-959.44"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(3080.19,-1045.86)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-128.69)">
@@ -1883,7 +1883,7 @@
         <g id="257">
             <desc>L108-109-1</desc>
             <g id="257.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2879.84,-1712.77 2780.68,-1848.59"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2879.84,-1712.77 2780.68,-1848.59"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(2860.67,-1739.02)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-36.13)">
@@ -1902,7 +1902,7 @@
                 </g>
             </g>
             <g id="257.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2681.52,-1984.41 2780.68,-1848.59"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2681.52,-1984.41 2780.68,-1848.59"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(2700.68,-1958.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(143.87)">
@@ -1924,7 +1924,7 @@
         <g id="258">
             <desc>L109-110-1</desc>
             <g id="258.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2638.67,-1999.77 2456.47,-1952.86"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2638.67,-1999.77 2456.47,-1952.86"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(2607.20,-1991.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-104.44)">
@@ -1943,7 +1943,7 @@
                 </g>
             </g>
             <g id="258.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2274.26,-1905.95 2456.47,-1952.86"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2274.26,-1905.95 2456.47,-1952.86"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(2305.73,-1914.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(75.56)">
@@ -1965,7 +1965,7 @@
         <g id="259">
             <desc>L4-11-1</desc>
             <g id="259.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-432.62,-2422.92 -261.80,-2324.23"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-432.62,-2422.92 -261.80,-2324.23"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-404.48,-2406.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(120.01)">
@@ -1984,7 +1984,7 @@
                 </g>
             </g>
             <g id="259.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-90.97,-2225.55 -261.80,-2324.23"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-90.97,-2225.55 -261.80,-2324.23"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-119.11,-2241.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-59.99)">
@@ -2006,7 +2006,7 @@
         <g id="260">
             <desc>L5-11-1</desc>
             <g id="260.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-215.66,-2572.00 -146.65,-2404.61"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-215.66,-2572.00 -146.65,-2404.61"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-203.27,-2541.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(157.60)">
@@ -2025,7 +2025,7 @@
                 </g>
             </g>
             <g id="260.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-77.64,-2237.22 -146.65,-2404.61"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-77.64,-2237.22 -146.65,-2404.61"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-90.03,-2267.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-22.40)">
@@ -2047,7 +2047,7 @@
         <g id="261">
             <desc>L11-12-1</desc>
             <g id="261.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-40.13,-2216.84 130.04,-2248.63"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-40.13,-2216.84 130.04,-2248.63"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-8.18,-2222.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(79.42)">
@@ -2066,7 +2066,7 @@
                 </g>
             </g>
             <g id="261.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="300.21,-2280.41 130.04,-2248.63"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="300.21,-2280.41 130.04,-2248.63"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(268.27,-2274.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-100.58)">
@@ -2088,7 +2088,7 @@
         <g id="262">
             <desc>L11-13-1</desc>
             <g id="262.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-64.66,-2184.41 -40.19,-1916.37"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-64.66,-2184.41 -40.19,-1916.37"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-61.71,-2152.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(174.78)">
@@ -2107,7 +2107,7 @@
                 </g>
             </g>
             <g id="262.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-15.73,-1648.34 -40.19,-1916.37"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-15.73,-1648.34 -40.19,-1916.37"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-18.68,-1680.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-5.22)">
@@ -2129,7 +2129,7 @@
         <g id="263">
             <desc>L110-111-1</desc>
             <g id="263.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2221.58,-1907.93 2053.03,-1965.10"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2221.58,-1907.93 2053.03,-1965.10"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(2190.81,-1918.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-71.26)">
@@ -2148,7 +2148,7 @@
                 </g>
             </g>
             <g id="263.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1884.48,-2022.27 2053.03,-1965.10"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1884.48,-2022.27 2053.03,-1965.10"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1915.26,-2011.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(108.74)">
@@ -2170,7 +2170,7 @@
         <g id="264">
             <desc>L110-112-1</desc>
             <g id="264.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2246.89,-1926.59 2241.32,-2135.72"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2246.89,-1926.59 2241.32,-2135.72"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(2246.03,-1959.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-1.53)">
@@ -2189,7 +2189,7 @@
                 </g>
             </g>
             <g id="264.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2235.74,-2344.85 2241.32,-2135.72"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2235.74,-2344.85 2241.32,-2135.72"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(2236.61,-2312.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(178.47)">
@@ -2211,7 +2211,7 @@
         <g id="265">
             <desc>L17-113-1</desc>
             <g id="265.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-839.12,-1469.00 -1098.76,-1496.41"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-839.12,-1469.00 -1098.76,-1496.41"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-871.44,-1472.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-83.98)">
@@ -2230,7 +2230,7 @@
                 </g>
             </g>
             <g id="265.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1358.41,-1523.81 -1098.76,-1496.41"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1358.41,-1523.81 -1098.76,-1496.41"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1326.09,-1520.40)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(96.02)">
@@ -2252,7 +2252,7 @@
         <g id="266">
             <desc>L32-113-1</desc>
             <g id="266.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1988.65,-1543.15 -1700.95,-1535.30"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1988.65,-1543.15 -1700.95,-1535.30"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1956.17,-1542.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(91.56)">
@@ -2271,7 +2271,7 @@
                 </g>
             </g>
             <g id="266.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1413.25,-1527.45 -1700.95,-1535.30"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1413.25,-1527.45 -1700.95,-1535.30"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1445.74,-1528.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-88.44)">
@@ -2293,7 +2293,7 @@
         <g id="267">
             <desc>L32-114-1</desc>
             <g id="267.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2041.07,-1555.52 -2315.77,-1683.48"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2041.07,-1555.52 -2315.77,-1683.48"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-2070.53,-1569.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-65.02)">
@@ -2312,7 +2312,7 @@
                 </g>
             </g>
             <g id="267.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2590.47,-1811.45 -2315.77,-1683.48"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2590.47,-1811.45 -2315.77,-1683.48"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-2561.01,-1797.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(114.98)">
@@ -2334,7 +2334,7 @@
         <g id="268">
             <desc>L114-115-1</desc>
             <g id="268.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2635.95,-1804.80 -2741.72,-1710.82"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2635.95,-1804.80 -2741.72,-1710.82"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-2660.25,-1783.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-131.62)">
@@ -2353,7 +2353,7 @@
                 </g>
             </g>
             <g id="268.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2847.49,-1616.85 -2741.72,-1710.82"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2847.49,-1616.85 -2741.72,-1710.82"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-2823.19,-1638.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.38)">
@@ -2375,7 +2375,7 @@
         <g id="269">
             <desc>L27-115-1</desc>
             <g id="269.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2423.50,-1577.06 -2632.04,-1587.16"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2423.50,-1577.06 -2632.04,-1587.16"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-2455.96,-1578.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-87.23)">
@@ -2394,7 +2394,7 @@
                 </g>
             </g>
             <g id="269.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2840.58,-1597.26 -2632.04,-1587.16"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2840.58,-1597.26 -2632.04,-1587.16"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-2808.12,-1595.68)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(92.77)">
@@ -2416,7 +2416,7 @@
         <g id="270">
             <desc>L68-116-1</desc>
             <g id="270.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-460.27,840.92 -751.79,859.68"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-460.27,840.92 -751.79,859.68"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-492.70,843.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-93.68)">
@@ -2435,7 +2435,7 @@
                 </g>
             </g>
             <g id="270.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1043.32,878.43 -751.79,859.68"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1043.32,878.43 -751.79,859.68"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1010.88,876.35)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(86.32)">
@@ -2457,7 +2457,7 @@
         <g id="271">
             <desc>L12-117-1</desc>
             <g id="271.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="353.27,-2276.58 555.32,-2207.69"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="353.27,-2276.58 555.32,-2207.69"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(384.04,-2266.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(108.83)">
@@ -2476,7 +2476,7 @@
                 </g>
             </g>
             <g id="271.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="757.36,-2138.80 555.32,-2207.69"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="757.36,-2138.80 555.32,-2207.69"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(726.60,-2149.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-71.17)">
@@ -2498,7 +2498,7 @@
         <g id="272">
             <desc>L75-118-1</desc>
             <g id="272.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-860.72,277.56 -771.02,108.98"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-860.72,277.56 -771.02,108.98"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-845.46,248.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(28.02)">
@@ -2517,7 +2517,7 @@
                 </g>
             </g>
             <g id="272.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-681.31,-59.60 -771.02,108.98"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-681.31,-59.60 -771.02,108.98"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-696.57,-30.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-151.98)">
@@ -2539,7 +2539,7 @@
         <g id="273">
             <desc>L76-118-1</desc>
             <g id="273.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-235.29,-91.89 -438.09,-88.14"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-235.29,-91.89 -438.09,-88.14"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-267.78,-91.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-91.06)">
@@ -2558,7 +2558,7 @@
                 </g>
             </g>
             <g id="273.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-640.89,-84.38 -438.09,-88.14"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-640.89,-84.38 -438.09,-88.14"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-608.40,-84.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(88.94)">
@@ -2580,7 +2580,7 @@
         <g id="274">
             <desc>L2-12-1</desc>
             <g id="274.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="773.49,-2600.46 561.60,-2450.89"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="773.49,-2600.46 561.60,-2450.89"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(746.94,-2581.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-125.22)">
@@ -2599,7 +2599,7 @@
                 </g>
             </g>
             <g id="274.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="349.71,-2301.32 561.60,-2450.89"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="349.71,-2301.32 561.60,-2450.89"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(376.26,-2320.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(54.78)">
@@ -2621,7 +2621,7 @@
         <g id="275">
             <desc>L3-12-1</desc>
             <g id="275.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="347.41,-2663.63 338.06,-2488.27"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="347.41,-2663.63 338.06,-2488.27"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(345.68,-2631.18)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-176.95)">
@@ -2640,7 +2640,7 @@
                 </g>
             </g>
             <g id="275.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="328.71,-2312.92 338.06,-2488.27"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="328.71,-2312.92 338.06,-2488.27"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(330.44,-2345.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(3.05)">
@@ -2662,7 +2662,7 @@
         <g id="276">
             <desc>L7-12-1</desc>
             <g id="276.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="127.78,-2924.27 223.42,-2617.99"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="127.78,-2924.27 223.42,-2617.99"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(137.47,-2893.25)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(162.66)">
@@ -2681,7 +2681,7 @@
                 </g>
             </g>
             <g id="276.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="319.05,-2311.71 223.42,-2617.99"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="319.05,-2311.71 223.42,-2617.99"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(309.36,-2342.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-17.34)">
@@ -2703,7 +2703,7 @@
         <g id="277">
             <desc>L12-14-1</desc>
             <g id="277.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="328.74,-2258.00 344.33,-1971.29"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="328.74,-2258.00 344.33,-1971.29"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(330.50,-2225.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(176.89)">
@@ -2722,7 +2722,7 @@
                 </g>
             </g>
             <g id="277.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="359.92,-1684.57 344.33,-1971.29"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="359.92,-1684.57 344.33,-1971.29"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(358.15,-1717.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-3.11)">
@@ -2744,7 +2744,7 @@
         <g id="278">
             <desc>L12-16-1</desc>
             <g id="278.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="304.20,-2270.45 7.32,-2077.10"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="304.20,-2270.45 7.32,-2077.10"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(276.97,-2252.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-123.07)">
@@ -2763,7 +2763,7 @@
                 </g>
             </g>
             <g id="278.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-289.56,-1883.75 7.32,-2077.10"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-289.56,-1883.75 7.32,-2077.10"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-262.33,-1901.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(56.93)">
@@ -2785,7 +2785,7 @@
         <g id="279">
             <desc>L13-15-1</desc>
             <g id="279.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-17.87,-1593.84 -54.07,-1382.36"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-17.87,-1593.84 -54.07,-1382.36"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-23.35,-1561.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-170.29)">
@@ -2804,7 +2804,7 @@
                 </g>
             </g>
             <g id="279.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-90.26,-1170.87 -54.07,-1382.36"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-90.26,-1170.87 -54.07,-1382.36"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-84.78,-1202.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(9.71)">
@@ -2826,7 +2826,7 @@
         <g id="280">
             <desc>L14-15-1</desc>
             <g id="280.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="343.14,-1636.56 133.25,-1400.44"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="343.14,-1636.56 133.25,-1400.44"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(321.55,-1612.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-138.37)">
@@ -2845,7 +2845,7 @@
                 </g>
             </g>
             <g id="280.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-76.63,-1164.32 133.25,-1400.44"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-76.63,-1164.32 133.25,-1400.44"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-55.04,-1188.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(41.63)">
@@ -2867,7 +2867,7 @@
         <g id="281">
             <desc>L15-17-1</desc>
             <g id="281.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-119.99,-1155.04 -453.34,-1304.94"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-119.99,-1155.04 -453.34,-1304.94"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-149.63,-1168.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-65.79)">
@@ -2886,7 +2886,7 @@
                 </g>
             </g>
             <g id="281.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-786.69,-1454.84 -453.34,-1304.94"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-786.69,-1454.84 -453.34,-1304.94"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-757.04,-1441.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(114.21)">
@@ -2908,7 +2908,7 @@
         <g id="282">
             <desc>L15-19-1</desc>
             <g id="282.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-108.16,-1119.67 -252.89,-856.57"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-108.16,-1119.67 -252.89,-856.57"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-123.82,-1091.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-151.18)">
@@ -2927,7 +2927,7 @@
                 </g>
             </g>
             <g id="282.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-397.63,-593.47 -252.89,-856.57"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-397.63,-593.47 -252.89,-856.57"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-381.97,-621.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(28.82)">
@@ -2949,7 +2949,7 @@
         <g id="283">
             <desc>L15-33-1</desc>
             <g id="283.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-85.98,-1117.75 23.00,-800.06"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-85.98,-1117.75 23.00,-800.06"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-75.44,-1087.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(161.07)">
@@ -2968,7 +2968,7 @@
                 </g>
             </g>
             <g id="283.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="131.97,-482.37 23.00,-800.06"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="131.97,-482.37 23.00,-800.06"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(121.43,-513.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-18.93)">
@@ -2990,7 +2990,7 @@
         <g id="284">
             <desc>L16-17-1</desc>
             <g id="284.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-334.01,-1851.48 -562.18,-1667.43"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-334.01,-1851.48 -562.18,-1667.43"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-359.30,-1831.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-128.89)">
@@ -3009,7 +3009,7 @@
                 </g>
             </g>
             <g id="284.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-790.36,-1483.38 -562.18,-1667.43"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-790.36,-1483.38 -562.18,-1667.43"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-765.07,-1503.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(51.11)">
@@ -3031,7 +3031,7 @@
         <g id="285">
             <desc>L17-18-1</desc>
             <g id="285.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-797.19,-1442.80 -680.14,-1255.53"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-797.19,-1442.80 -680.14,-1255.53"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-779.97,-1415.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(147.99)">
@@ -3050,7 +3050,7 @@
                 </g>
             </g>
             <g id="285.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-563.09,-1068.26 -680.14,-1255.53"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-563.09,-1068.26 -680.14,-1255.53"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-580.32,-1095.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-32.01)">
@@ -3072,7 +3072,7 @@
         <g id="286">
             <desc>L17-31-1</desc>
             <g id="286.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-836.24,-1478.66 -1187.55,-1658.70"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-836.24,-1478.66 -1187.55,-1658.70"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-865.16,-1493.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-62.87)">
@@ -3091,7 +3091,7 @@
                 </g>
             </g>
             <g id="286.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1538.87,-1838.73 -1187.55,-1658.70"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1538.87,-1838.73 -1187.55,-1658.70"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1509.94,-1823.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(117.13)">
@@ -3113,7 +3113,7 @@
         <g id="287">
             <desc>T30-17-1</desc>
             <g id="287.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-958.02,-1090.14 -900.75,-1237.35"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-958.02,-1090.14 -900.75,-1237.35"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-946.24,-1120.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(21.26)">
@@ -3132,7 +3132,7 @@
                 </g>
             </g>
             <g id="287.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-821.74,-1440.49 -879.00,-1293.27"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-821.74,-1440.49 -879.00,-1293.27"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-833.52,-1410.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-158.74)">
@@ -3158,7 +3158,7 @@
         <g id="288">
             <desc>L18-19-1</desc>
             <g id="288.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-540.87,-1018.53 -479.70,-807.16"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-540.87,-1018.53 -479.70,-807.16"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-531.83,-987.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(163.86)">
@@ -3177,7 +3177,7 @@
                 </g>
             </g>
             <g id="288.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-418.53,-595.79 -479.70,-807.16"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-418.53,-595.79 -479.70,-807.16"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-427.56,-627.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-16.14)">
@@ -3199,7 +3199,7 @@
         <g id="289">
             <desc>L19-20-1</desc>
             <g id="289.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-438.35,-568.05 -706.46,-555.11"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-438.35,-568.05 -706.46,-555.11"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-470.82,-566.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-92.76)">
@@ -3218,7 +3218,7 @@
                 </g>
             </g>
             <g id="289.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-974.57,-542.18 -706.46,-555.11"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-974.57,-542.18 -706.46,-555.11"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-942.11,-543.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(87.24)">
@@ -3240,7 +3240,7 @@
         <g id="290">
             <desc>L19-34-1</desc>
             <g id="290.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-402.93,-543.05 -249.35,-35.09"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-402.93,-543.05 -249.35,-35.09"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-393.52,-511.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(163.18)">
@@ -3259,7 +3259,7 @@
                 </g>
             </g>
             <g id="290.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-95.78,472.88 -249.35,-35.09"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-95.78,472.88 -249.35,-35.09"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-105.18,441.77)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-16.82)">
@@ -3281,7 +3281,7 @@
         <g id="291">
             <desc>L20-21-1</desc>
             <g id="291.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1029.48,-539.09 -1249.18,-524.97"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1029.48,-539.09 -1249.18,-524.97"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1061.92,-537.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-93.68)">
@@ -3300,7 +3300,7 @@
                 </g>
             </g>
             <g id="291.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1468.87,-510.85 -1249.18,-524.97"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1468.87,-510.85 -1249.18,-524.97"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1436.44,-512.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(86.32)">
@@ -3322,7 +3322,7 @@
         <g id="292">
             <desc>L21-22-1</desc>
             <g id="292.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1523.53,-513.06 -1711.44,-540.51"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1523.53,-513.06 -1711.44,-540.51"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1555.69,-517.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-81.69)">
@@ -3341,7 +3341,7 @@
                 </g>
             </g>
             <g id="292.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1899.36,-567.96 -1711.44,-540.51"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1899.36,-567.96 -1711.44,-540.51"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1867.20,-563.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(98.31)">
@@ -3363,7 +3363,7 @@
         <g id="293">
             <desc>L22-23-1</desc>
             <g id="293.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1947.34,-589.96 -2064.17,-691.32"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1947.34,-589.96 -2064.17,-691.32"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1971.89,-611.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-49.05)">
@@ -3382,7 +3382,7 @@
                 </g>
             </g>
             <g id="293.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2181.00,-792.68 -2064.17,-691.32"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2181.00,-792.68 -2064.17,-691.32"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-2156.45,-771.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(130.95)">
@@ -3404,7 +3404,7 @@
         <g id="294">
             <desc>L23-24-1</desc>
             <g id="294.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2198.60,-783.39 -2161.87,-467.14"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2198.60,-783.39 -2161.87,-467.14"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-2194.85,-751.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(173.38)">
@@ -3423,7 +3423,7 @@
                 </g>
             </g>
             <g id="294.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2125.14,-150.89 -2161.87,-467.14"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2125.14,-150.89 -2161.87,-467.14"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-2128.89,-183.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-6.62)">
@@ -3445,7 +3445,7 @@
         <g id="295">
             <desc>L23-25-1</desc>
             <g id="295.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2197.80,-837.92 -2176.10,-986.64"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2197.80,-837.92 -2176.10,-986.64"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-2193.11,-870.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(8.30)">
@@ -3464,7 +3464,7 @@
                 </g>
             </g>
             <g id="295.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2154.39,-1135.37 -2176.10,-986.64"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2154.39,-1135.37 -2176.10,-986.64"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-2159.08,-1103.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-171.70)">
@@ -3486,7 +3486,7 @@
         <g id="296">
             <desc>L23-32-1</desc>
             <g id="296.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2195.03,-837.36 -2108.96,-1177.30"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2195.03,-837.36 -2108.96,-1177.30"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-2187.05,-868.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(14.21)">
@@ -3505,7 +3505,7 @@
                 </g>
             </g>
             <g id="296.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2022.89,-1517.25 -2108.96,-1177.30"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2022.89,-1517.25 -2108.96,-1177.30"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-2030.87,-1485.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-165.79)">
@@ -3527,7 +3527,7 @@
         <g id="297">
             <desc>L24-70-1</desc>
             <g id="297.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2101.59,-105.11 -1845.96,126.53"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2101.59,-105.11 -1845.96,126.53"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-2077.51,-83.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(132.18)">
@@ -3546,7 +3546,7 @@
                 </g>
             </g>
             <g id="297.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1590.32,358.18 -1845.96,126.53"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1590.32,358.18 -1845.96,126.53"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1614.40,336.35)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-47.82)">
@@ -3568,7 +3568,7 @@
         <g id="298">
             <desc>L24-72-1</desc>
             <g id="298.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2145.83,-109.89 -2301.67,-20.50"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2145.83,-109.89 -2301.67,-20.50"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-2174.02,-93.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-119.84)">
@@ -3587,7 +3587,7 @@
                 </g>
             </g>
             <g id="298.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2457.51,68.88 -2301.67,-20.50"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2457.51,68.88 -2301.67,-20.50"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-2429.32,52.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(60.16)">
@@ -3609,7 +3609,7 @@
         <g id="299">
             <desc>L25-27-1</desc>
             <g id="299.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2164.47,-1186.22 -2273.22,-1369.16"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2164.47,-1186.22 -2273.22,-1369.16"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-2181.08,-1214.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-30.73)">
@@ -3628,7 +3628,7 @@
                 </g>
             </g>
             <g id="299.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2381.98,-1552.09 -2273.22,-1369.16"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2381.98,-1552.09 -2273.22,-1369.16"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-2365.37,-1524.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(149.27)">
@@ -3650,7 +3650,7 @@
         <g id="300">
             <desc>T26-25-1</desc>
             <g id="300.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1612.14,-1098.25 -1837.84,-1125.23"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1612.14,-1098.25 -1837.84,-1125.23"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1644.41,-1102.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-83.18)">
@@ -3669,7 +3669,7 @@
                 </g>
             </g>
             <g id="300.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2123.11,-1159.32 -1897.41,-1132.35"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2123.11,-1159.32 -1897.41,-1132.35"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-2090.84,-1155.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(96.82)">
@@ -3695,7 +3695,7 @@
         <g id="301">
             <desc>L26-30-1</desc>
             <g id="301.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1557.37,-1093.63 -1276.41,-1079.75"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1557.37,-1093.63 -1276.41,-1079.75"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1524.91,-1092.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(92.83)">
@@ -3714,7 +3714,7 @@
                 </g>
             </g>
             <g id="301.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-995.45,-1065.86 -1276.41,-1079.75"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-995.45,-1065.86 -1276.41,-1079.75"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1027.91,-1067.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-87.17)">
@@ -3736,7 +3736,7 @@
         <g id="302">
             <desc>L27-28-1</desc>
             <g id="302.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2390.34,-1602.64 -2339.07,-1845.18"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2390.34,-1602.64 -2339.07,-1845.18"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-2383.62,-1634.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(11.93)">
@@ -3755,7 +3755,7 @@
                 </g>
             </g>
             <g id="302.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2287.81,-2087.73 -2339.07,-1845.18"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2287.81,-2087.73 -2339.07,-1845.18"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-2294.53,-2055.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-168.07)">
@@ -3777,7 +3777,7 @@
         <g id="303">
             <desc>L27-32-1</desc>
             <g id="303.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2368.62,-1573.43 -2206.09,-1559.82"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2368.62,-1573.43 -2206.09,-1559.82"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-2336.24,-1570.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(94.79)">
@@ -3796,7 +3796,7 @@
                 </g>
             </g>
             <g id="303.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2043.55,-1546.20 -2206.09,-1559.82"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2043.55,-1546.20 -2206.09,-1559.82"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-2075.93,-1548.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-85.21)">
@@ -3818,7 +3818,7 @@
         <g id="304">
             <desc>L28-29-1</desc>
             <g id="304.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2255.53,-2121.66 -2088.85,-2165.65"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2255.53,-2121.66 -2088.85,-2165.65"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-2224.11,-2129.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(75.22)">
@@ -3837,7 +3837,7 @@
                 </g>
             </g>
             <g id="304.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1922.16,-2209.64 -2088.85,-2165.65"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1922.16,-2209.64 -2088.85,-2165.65"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1953.59,-2201.35)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-104.78)">
@@ -3859,7 +3859,7 @@
         <g id="305">
             <desc>L29-31-1</desc>
             <g id="305.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1877.07,-2196.31 -1729.46,-2033.97"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1877.07,-2196.31 -1729.46,-2033.97"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1855.21,-2172.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(137.72)">
@@ -3878,7 +3878,7 @@
                 </g>
             </g>
             <g id="305.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1581.84,-1871.62 -1729.46,-2033.97"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1581.84,-1871.62 -1729.46,-2033.97"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1603.71,-1895.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-42.28)">
@@ -3900,7 +3900,7 @@
         <g id="306">
             <desc>L3-5-1</desc>
             <g id="306.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="321.73,-2686.67 61.37,-2644.26"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="321.73,-2686.67 61.37,-2644.26"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(289.66,-2681.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-99.25)">
@@ -3919,7 +3919,7 @@
                 </g>
             </g>
             <g id="306.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-199.00,-2601.85 61.37,-2644.26"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-199.00,-2601.85 61.37,-2644.26"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-166.92,-2607.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(80.75)">
@@ -3941,7 +3941,7 @@
         <g id="307">
             <desc>L8-30-1</desc>
             <g id="307.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-826.69,-2045.41 -895.38,-1568.57"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-826.69,-2045.41 -895.38,-1568.57"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-831.33,-2013.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-171.80)">
@@ -3960,7 +3960,7 @@
                 </g>
             </g>
             <g id="307.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-964.07,-1091.73 -895.38,-1568.57"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-964.07,-1091.73 -895.38,-1568.57"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-959.43,-1123.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(8.20)">
@@ -3982,7 +3982,7 @@
         <g id="308">
             <desc>L30-38-1</desc>
             <g id="308.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-959.09,-1038.49 -741.99,-403.62"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-959.09,-1038.49 -741.99,-403.62"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-948.57,-1007.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(161.12)">
@@ -4001,7 +4001,7 @@
                 </g>
             </g>
             <g id="308.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-524.89,231.24 -741.99,-403.62"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-524.89,231.24 -741.99,-403.62"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-535.40,200.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-18.88)">
@@ -4023,7 +4023,7 @@
         <g id="309">
             <desc>L31-32-1</desc>
             <g id="309.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1586.09,-1835.83 -1789.74,-1697.59"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1586.09,-1835.83 -1789.74,-1697.59"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1612.98,-1817.58)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-124.17)">
@@ -4042,7 +4042,7 @@
                 </g>
             </g>
             <g id="309.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1993.39,-1559.35 -1789.74,-1697.59"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1993.39,-1559.35 -1789.74,-1697.59"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1966.50,-1577.60)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(55.83)">
@@ -4064,7 +4064,7 @@
         <g id="310">
             <desc>L33-37-1</desc>
             <g id="310.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="143.67,-429.00 191.27,41.07"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="143.67,-429.00 191.27,41.07"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(146.94,-396.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(174.22)">
@@ -4083,7 +4083,7 @@
                 </g>
             </g>
             <g id="310.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="238.88,511.14 191.27,41.07"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="238.88,511.14 191.27,41.07"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(235.60,478.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-5.78)">
@@ -4105,7 +4105,7 @@
         <g id="311">
             <desc>L34-36-1</desc>
             <g id="311.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-71.95,521.66 38.67,678.19"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-71.95,521.66 38.67,678.19"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-53.19,548.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(144.75)">
@@ -4124,7 +4124,7 @@
                 </g>
             </g>
             <g id="311.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="149.28,834.71 38.67,678.19"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="149.28,834.71 38.67,678.19"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(130.52,808.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-35.25)">
@@ -4146,7 +4146,7 @@
         <g id="312">
             <desc>L34-37-1</desc>
             <g id="312.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-60.51,502.46 76.91,518.85"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-60.51,502.46 76.91,518.85"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-28.24,506.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(96.80)">
@@ -4165,7 +4165,7 @@
                 </g>
             </g>
             <g id="312.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="214.34,535.24 76.91,518.85"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="214.34,535.24 76.91,518.85"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(182.07,531.39)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-83.20)">
@@ -4187,7 +4187,7 @@
         <g id="313">
             <desc>L34-43-1</desc>
             <g id="313.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-83.03,526.28 -16.39,902.95"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-83.03,526.28 -16.39,902.95"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-77.37,558.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(169.97)">
@@ -4206,7 +4206,7 @@
                 </g>
             </g>
             <g id="313.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="50.24,1279.62 -16.39,902.95"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="50.24,1279.62 -16.39,902.95"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(44.58,1247.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-10.03)">
@@ -4228,7 +4228,7 @@
         <g id="314">
             <desc>L35-36-1</desc>
             <g id="314.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="497.48,746.28 344.36,797.37"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="497.48,746.28 344.36,797.37"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(466.65,756.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-108.45)">
@@ -4247,7 +4247,7 @@
                 </g>
             </g>
             <g id="314.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="191.24,848.46 344.36,797.37"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="191.24,848.46 344.36,797.37"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(222.07,838.18)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(71.55)">
@@ -4269,7 +4269,7 @@
         <g id="315">
             <desc>L35-37-1</desc>
             <g id="315.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="501.11,721.72 382.61,638.04"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="501.11,721.72 382.61,638.04"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(474.56,702.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-54.77)">
@@ -4288,7 +4288,7 @@
                 </g>
             </g>
             <g id="315.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="264.11,554.36 382.61,638.04"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="264.11,554.36 382.61,638.04"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(290.66,573.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(125.23)">
@@ -4310,7 +4310,7 @@
         <g id="316">
             <desc>L37-39-1</desc>
             <g id="316.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="260.38,558.63 474.53,788.88"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="260.38,558.63 474.53,788.88"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(282.51,582.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(137.07)">
@@ -4329,7 +4329,7 @@
                 </g>
             </g>
             <g id="316.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="688.69,1019.13 474.53,788.88"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="688.69,1019.13 474.53,788.88"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(666.56,995.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-42.93)">
@@ -4351,7 +4351,7 @@
         <g id="317">
             <desc>L37-40-1</desc>
             <g id="317.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="250.48,564.54 377.19,938.11"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="250.48,564.54 377.19,938.11"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(260.92,595.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(161.26)">
@@ -4370,7 +4370,7 @@
                 </g>
             </g>
             <g id="317.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="503.91,1311.67 377.19,938.11"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="503.91,1311.67 377.19,938.11"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(493.47,1280.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-18.74)">
@@ -4392,7 +4392,7 @@
         <g id="318">
             <desc>T38-37-1</desc>
             <g id="318.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-490.21,266.84 -165.30,387.44"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-490.21,266.84 -165.30,387.44"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-459.74,278.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(110.36)">
@@ -4411,7 +4411,7 @@
                 </g>
             </g>
             <g id="318.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="215.87,528.93 -109.05,408.32"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="215.87,528.93 -109.05,408.32"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(185.40,517.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-69.64)">
@@ -4437,7 +4437,7 @@
         <g id="319">
             <desc>L38-65-1</desc>
             <g id="319.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-524.09,283.55 -677.00,779.87"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-524.09,283.55 -677.00,779.87"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-533.66,314.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-162.88)">
@@ -4456,7 +4456,7 @@
                 </g>
             </g>
             <g id="319.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-829.92,1276.19 -677.00,779.87"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-829.92,1276.19 -677.00,779.87"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-820.35,1245.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(17.12)">
@@ -4478,7 +4478,7 @@
         <g id="320">
             <desc>L39-40-1</desc>
             <g id="320.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="692.40,1062.30 610.08,1188.49"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="692.40,1062.30 610.08,1188.49"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(674.64,1089.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-146.88)">
@@ -4497,7 +4497,7 @@
                 </g>
             </g>
             <g id="320.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="527.77,1314.68 610.08,1188.49"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="527.77,1314.68 610.08,1188.49"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(545.52,1287.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(33.12)">
@@ -4519,7 +4519,7 @@
         <g id="321">
             <desc>L4-5-1</desc>
             <g id="321.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-433.89,-2452.41 -341.29,-2517.05"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-433.89,-2452.41 -341.29,-2517.05"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-407.24,-2471.02)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(55.08)">
@@ -4538,7 +4538,7 @@
                 </g>
             </g>
             <g id="321.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-248.69,-2581.69 -341.29,-2517.05"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-248.69,-2581.69 -341.29,-2517.05"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-275.34,-2563.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-124.92)">
@@ -4560,7 +4560,7 @@
         <g id="322">
             <desc>L40-41-1</desc>
             <g id="322.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="520.22,1364.18 573.48,1552.73"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="520.22,1364.18 573.48,1552.73"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(529.05,1395.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(164.23)">
@@ -4579,7 +4579,7 @@
                 </g>
             </g>
             <g id="322.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="626.74,1741.29 573.48,1552.73"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="626.74,1741.29 573.48,1552.73"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(617.90,1710.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-15.77)">
@@ -4601,7 +4601,7 @@
         <g id="323">
             <desc>L40-42-1</desc>
             <g id="323.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="493.32,1357.19 331.36,1519.60"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="493.32,1357.19 331.36,1519.60"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(470.37,1380.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-135.08)">
@@ -4620,7 +4620,7 @@
                 </g>
             </g>
             <g id="323.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="169.41,1682.01 331.36,1519.60"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="169.41,1682.01 331.36,1519.60"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(192.35,1658.99)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(44.92)">
@@ -4642,7 +4642,7 @@
         <g id="324">
             <desc>L41-42-1</desc>
             <g id="324.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="606.96,1764.02 392.10,1734.62"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="606.96,1764.02 392.10,1734.62"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(574.76,1759.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-82.21)">
@@ -4661,7 +4661,7 @@
                 </g>
             </g>
             <g id="324.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="177.23,1705.21 392.10,1734.62"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="177.23,1705.21 392.10,1734.62"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(209.43,1709.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(97.79)">
@@ -4683,7 +4683,7 @@
         <g id="325">
             <desc>L42-49-1</desc>
             <g id="325.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="124.92,1690.18 77.05,1668.61 -361.96,1712.72"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="124.92,1690.18 77.05,1668.61 -361.96,1712.72"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(47.20,1671.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-95.74)">
@@ -4702,7 +4702,7 @@
                 </g>
             </g>
             <g id="325.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-843.58,1787.50 -800.97,1756.83 -361.96,1712.72"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-843.58,1787.50 -800.97,1756.83 -361.96,1712.72"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-771.12,1753.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(84.26)">
@@ -4724,7 +4724,7 @@
         <g id="326">
             <desc>L42-49-2</desc>
             <g id="326.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="127.67,1717.54 85.05,1748.21 -353.96,1792.32"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="127.67,1717.54 85.05,1748.21 -353.96,1792.32"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(55.20,1751.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-95.74)">
@@ -4743,7 +4743,7 @@
                 </g>
             </g>
             <g id="326.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-840.83,1814.86 -792.97,1836.43 -353.96,1792.32"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-840.83,1814.86 -792.97,1836.43 -353.96,1792.32"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-763.12,1833.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(84.26)">
@@ -4765,7 +4765,7 @@
         <g id="327">
             <desc>L43-44-1</desc>
             <g id="327.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="60.36,1333.68 128.77,1680.25"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="60.36,1333.68 128.77,1680.25"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(66.65,1365.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(168.83)">
@@ -4784,7 +4784,7 @@
                 </g>
             </g>
             <g id="327.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="197.17,2026.83 128.77,1680.25"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="197.17,2026.83 128.77,1680.25"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(190.88,1994.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-11.17)">
@@ -4806,7 +4806,7 @@
         <g id="328">
             <desc>L44-45-1</desc>
             <g id="328.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="175.64,2059.70 -0.88,2098.41"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="175.64,2059.70 -0.88,2098.41"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(143.89,2066.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-102.37)">
@@ -4825,7 +4825,7 @@
                 </g>
             </g>
             <g id="328.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-177.39,2137.13 -0.88,2098.41"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-177.39,2137.13 -0.88,2098.41"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-145.64,2130.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(77.63)">
@@ -4847,7 +4847,7 @@
         <g id="329">
             <desc>L45-46-1</desc>
             <g id="329.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-212.20,2116.69 -255.95,1971.75"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-212.20,2116.69 -255.95,1971.75"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-221.59,2085.58)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-16.80)">
@@ -4866,7 +4866,7 @@
                 </g>
             </g>
             <g id="329.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-299.70,1826.81 -255.95,1971.75"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-299.70,1826.81 -255.95,1971.75"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-290.31,1857.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(163.20)">
@@ -4888,7 +4888,7 @@
         <g id="330">
             <desc>L45-49-1</desc>
             <g id="330.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-228.72,2130.46 -535.08,1973.29"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-228.72,2130.46 -535.08,1973.29"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-257.63,2115.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-62.84)">
@@ -4907,7 +4907,7 @@
                 </g>
             </g>
             <g id="330.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-841.44,1816.11 -535.08,1973.29"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-841.44,1816.11 -535.08,1973.29"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-812.52,1830.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(117.16)">
@@ -4929,7 +4929,7 @@
         <g id="331">
             <desc>L46-47-1</desc>
             <g id="331.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-323.55,1778.04 -434.67,1621.29"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-323.55,1778.04 -434.67,1621.29"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-342.34,1751.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-35.33)">
@@ -4948,7 +4948,7 @@
                 </g>
             </g>
             <g id="331.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-545.78,1464.54 -434.67,1621.29"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-545.78,1464.54 -434.67,1621.29"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-526.99,1491.05)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(144.67)">
@@ -4970,7 +4970,7 @@
         <g id="332">
             <desc>L46-48-1</desc>
             <g id="332.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-330.59,1815.63 -437.70,1886.37"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-330.59,1815.63 -437.70,1886.37"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-357.71,1833.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-123.44)">
@@ -4989,7 +4989,7 @@
                 </g>
             </g>
             <g id="332.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-544.80,1957.10 -437.70,1886.37"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-544.80,1957.10 -437.70,1886.37"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-517.68,1939.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(56.56)">
@@ -5011,7 +5011,7 @@
         <g id="333">
             <desc>L47-49-1</desc>
             <g id="333.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-579.39,1463.14 -713.80,1622.83"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-579.39,1463.14 -713.80,1622.83"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-600.32,1488.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-139.91)">
@@ -5030,7 +5030,7 @@
                 </g>
             </g>
             <g id="333.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-848.20,1782.52 -713.80,1622.83"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-848.20,1782.52 -713.80,1622.83"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-827.27,1757.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(40.09)">
@@ -5052,7 +5052,7 @@
         <g id="334">
             <desc>L47-69-1</desc>
             <g id="334.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-569.06,1415.61 -649.41,1126.92"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-569.06,1415.61 -649.41,1126.92"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-577.77,1384.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-15.55)">
@@ -5071,7 +5071,7 @@
                 </g>
             </g>
             <g id="334.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-729.75,838.23 -649.41,1126.92"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-729.75,838.23 -649.41,1126.92"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-721.04,869.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(164.45)">
@@ -5093,7 +5093,7 @@
         <g id="335">
             <desc>L48-49-1</desc>
             <g id="335.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-591.68,1958.71 -716.83,1887.91"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-591.68,1958.71 -716.83,1887.91"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-619.97,1942.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-60.50)">
@@ -5112,7 +5112,7 @@
                 </g>
             </g>
             <g id="335.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-841.97,1817.10 -716.83,1887.91"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-841.97,1817.10 -716.83,1887.91"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-813.68,1833.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(119.50)">
@@ -5134,7 +5134,7 @@
         <g id="336">
             <desc>L49-50-1</desc>
             <g id="336.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-880.78,1826.69 -1041.09,2075.99"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-880.78,1826.69 -1041.09,2075.99"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-898.36,1854.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-147.26)">
@@ -5153,7 +5153,7 @@
                 </g>
             </g>
             <g id="336.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1201.41,2325.29 -1041.09,2075.99"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1201.41,2325.29 -1041.09,2075.99"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1183.83,2297.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(32.74)">
@@ -5175,7 +5175,7 @@
         <g id="337">
             <desc>L49-51-1</desc>
             <g id="337.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-892.47,1796.45 -1300.80,1687.14"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-892.47,1796.45 -1300.80,1687.14"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-923.86,1788.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-75.01)">
@@ -5194,7 +5194,7 @@
                 </g>
             </g>
             <g id="337.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1709.13,1577.84 -1300.80,1687.14"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1709.13,1577.84 -1300.80,1687.14"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1677.74,1586.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.99)">
@@ -5216,7 +5216,7 @@
         <g id="338">
             <desc>L49-54-1</desc>
             <g id="338.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-892.97,1798.67 -944.63,1789.34 -1382.08,1946.52"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-892.97,1798.67 -944.63,1789.34 -1382.08,1946.52"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-972.86,1799.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-109.76)">
@@ -5235,7 +5235,7 @@
                 </g>
             </g>
             <g id="338.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1853.43,2143.78 -1819.52,2103.70 -1382.08,1946.52"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1853.43,2143.78 -1819.52,2103.70 -1382.08,1946.52"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1791.29,2093.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(70.24)">
@@ -5257,7 +5257,7 @@
         <g id="339">
             <desc>L49-54-2</desc>
             <g id="339.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-883.67,1824.55 -917.58,1864.63 -1355.02,2021.81"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-883.67,1824.55 -917.58,1864.63 -1355.02,2021.81"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-945.81,1874.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-109.76)">
@@ -5276,7 +5276,7 @@
                 </g>
             </g>
             <g id="339.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1844.13,2169.66 -1792.47,2178.98 -1355.02,2021.81"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1844.13,2169.66 -1792.47,2178.98 -1355.02,2021.81"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1764.23,2168.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(70.24)">
@@ -5298,7 +5298,7 @@
         <g id="340">
             <desc>L49-66-1</desc>
             <g id="340.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-872.50,1830.26 -885.08,1881.23 -833.85,2058.39"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-872.50,1830.26 -885.08,1881.23 -833.85,2058.39"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-876.75,1910.05)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(163.87)">
@@ -5317,7 +5317,7 @@
                 </g>
             </g>
             <g id="340.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-744.76,2271.94 -782.61,2235.56 -833.85,2058.39"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-744.76,2271.94 -782.61,2235.56 -833.85,2058.39"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-790.94,2206.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-16.13)">
@@ -5339,7 +5339,7 @@
         <g id="341">
             <desc>L49-66-2</desc>
             <g id="341.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-846.08,1822.62 -808.23,1859.00 -757.00,2036.17"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-846.08,1822.62 -808.23,1859.00 -757.00,2036.17"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-799.90,1887.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(163.87)">
@@ -5358,7 +5358,7 @@
                 </g>
             </g>
             <g id="341.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-718.34,2264.30 -705.76,2213.33 -757.00,2036.17"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-718.34,2264.30 -705.76,2213.33 -757.00,2036.17"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-714.09,2184.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-16.13)">
@@ -5380,7 +5380,7 @@
         <g id="342">
             <desc>L49-69-1</desc>
             <g id="342.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-862.36,1776.29 -801.52,1307.65"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-862.36,1776.29 -801.52,1307.65"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-858.18,1744.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(7.40)">
@@ -5399,7 +5399,7 @@
                 </g>
             </g>
             <g id="342.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-740.67,839.01 -801.52,1307.65"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-740.67,839.01 -801.52,1307.65"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-744.85,871.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-172.60)">
@@ -5421,7 +5421,7 @@
         <g id="343">
             <desc>L5-6-1</desc>
             <g id="343.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-226.23,-2624.93 -226.94,-2838.16"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-226.23,-2624.93 -226.94,-2838.16"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-226.34,-2657.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-0.19)">
@@ -5440,7 +5440,7 @@
                 </g>
             </g>
             <g id="343.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-227.66,-3051.39 -226.94,-2838.16"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-227.66,-3051.39 -226.94,-2838.16"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-227.55,-3018.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(179.81)">
@@ -5462,7 +5462,7 @@
         <g id="344">
             <desc>T8-5-1</desc>
             <g id="344.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-802.12,-2090.79 -546.98,-2315.22"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-802.12,-2090.79 -546.98,-2315.22"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-777.72,-2112.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.67)">
@@ -5481,7 +5481,7 @@
                 </g>
             </g>
             <g id="344.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-246.79,-2579.27 -501.93,-2354.84"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-246.79,-2579.27 -501.93,-2354.84"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-271.19,-2557.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-131.33)">
@@ -5507,7 +5507,7 @@
         <g id="345">
             <desc>L50-57-1</desc>
             <g id="345.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1236.73,2366.81 -1486.97,2591.77"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1236.73,2366.81 -1486.97,2591.77"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1260.90,2388.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-131.96)">
@@ -5526,7 +5526,7 @@
                 </g>
             </g>
             <g id="345.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1737.20,2816.74 -1486.97,2591.77"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1737.20,2816.74 -1486.97,2591.77"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1713.03,2795.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.04)">
@@ -5548,7 +5548,7 @@
         <g id="346">
             <desc>L51-52-1</desc>
             <g id="346.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1762.53,1564.72 -2002.97,1510.97"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1762.53,1564.72 -2002.97,1510.97"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1794.25,1557.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-77.40)">
@@ -5567,7 +5567,7 @@
                 </g>
             </g>
             <g id="346.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2243.41,1457.22 -2002.97,1510.97"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2243.41,1457.22 -2002.97,1510.97"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-2211.69,1464.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(102.60)">
@@ -5589,7 +5589,7 @@
         <g id="347">
             <desc>L51-58-1</desc>
             <g id="347.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1756.35,1588.88 -1907.88,1722.09"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1756.35,1588.88 -1907.88,1722.09"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1780.76,1610.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-131.32)">
@@ -5608,7 +5608,7 @@
                 </g>
             </g>
             <g id="347.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2059.41,1855.30 -1907.88,1722.09"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2059.41,1855.30 -1907.88,1722.09"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-2035.00,1833.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.68)">
@@ -5630,7 +5630,7 @@
         <g id="348">
             <desc>L52-53-1</desc>
             <g id="348.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2282.17,1476.00 -2360.45,1638.73"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2282.17,1476.00 -2360.45,1638.73"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-2296.26,1505.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-154.31)">
@@ -5649,7 +5649,7 @@
                 </g>
             </g>
             <g id="348.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2438.74,1801.46 -2360.45,1638.73"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2438.74,1801.46 -2360.45,1638.73"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-2424.65,1772.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(25.69)">
@@ -5671,7 +5671,7 @@
         <g id="349">
             <desc>L53-54-1</desc>
             <g id="349.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2426.92,1840.12 -2160.93,1995.51"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2426.92,1840.12 -2160.93,1995.51"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-2398.85,1856.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(120.29)">
@@ -5690,7 +5690,7 @@
                 </g>
             </g>
             <g id="349.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1894.94,2150.90 -2160.93,1995.51"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1894.94,2150.90 -2160.93,1995.51"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1923.00,2134.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-59.71)">
@@ -5712,7 +5712,7 @@
         <g id="350">
             <desc>L54-55-1</desc>
             <g id="350.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1886.07,2187.90 -2021.72,2398.78"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1886.07,2187.90 -2021.72,2398.78"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1903.65,2215.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-147.25)">
@@ -5731,7 +5731,7 @@
                 </g>
             </g>
             <g id="350.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2157.36,2609.67 -2021.72,2398.78"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2157.36,2609.67 -2021.72,2398.78"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-2139.78,2582.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(32.75)">
@@ -5753,7 +5753,7 @@
         <g id="351">
             <desc>L54-56-1</desc>
             <g id="351.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1887.55,2186.87 -1959.26,2283.77"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1887.55,2186.87 -1959.26,2283.77"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1906.89,2213.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-143.50)">
@@ -5772,7 +5772,7 @@
                 </g>
             </g>
             <g id="351.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2030.96,2380.67 -1959.26,2283.77"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2030.96,2380.67 -1959.26,2283.77"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-2011.63,2354.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(36.50)">
@@ -5794,7 +5794,7 @@
         <g id="352">
             <desc>L54-59-1</desc>
             <g id="352.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1859.08,2189.45 -1777.78,2355.09"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1859.08,2189.45 -1777.78,2355.09"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1844.76,2218.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(153.86)">
@@ -5813,7 +5813,7 @@
                 </g>
             </g>
             <g id="352.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1696.48,2520.72 -1777.78,2355.09"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1696.48,2520.72 -1777.78,2355.09"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1710.80,2491.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-26.14)">
@@ -5835,7 +5835,7 @@
         <g id="353">
             <desc>L55-56-1</desc>
             <g id="353.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2159.12,2608.63 -2109.78,2517.79"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2159.12,2608.63 -2109.78,2517.79"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-2143.61,2580.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(28.50)">
@@ -5854,7 +5854,7 @@
                 </g>
             </g>
             <g id="353.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2060.44,2426.94 -2109.78,2517.79"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2060.44,2426.94 -2109.78,2517.79"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-2075.95,2455.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-151.50)">
@@ -5876,7 +5876,7 @@
         <g id="354">
             <desc>L55-59-1</desc>
             <g id="354.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2145.17,2627.95 -1928.30,2589.10"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2145.17,2627.95 -1928.30,2589.10"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-2113.18,2622.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(79.84)">
@@ -5895,7 +5895,7 @@
                 </g>
             </g>
             <g id="354.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1711.43,2550.25 -1928.30,2589.10"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1711.43,2550.25 -1928.30,2589.10"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1743.42,2555.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-100.16)">
@@ -5917,7 +5917,7 @@
         <g id="355">
             <desc>L56-57-1</desc>
             <g id="355.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2032.01,2425.62 -1902.49,2618.95"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2032.01,2425.62 -1902.49,2618.95"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-2013.92,2452.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(146.18)">
@@ -5936,7 +5936,7 @@
                 </g>
             </g>
             <g id="355.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1772.96,2812.28 -1902.49,2618.95"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1772.96,2812.28 -1902.49,2618.95"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1791.05,2785.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-33.82)">
@@ -5958,7 +5958,7 @@
         <g id="356">
             <desc>L56-58-1</desc>
             <g id="356.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2049.02,2375.33 -2063.69,2138.11"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2049.02,2375.33 -2063.69,2138.11"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-2051.02,2342.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-3.54)">
@@ -5977,7 +5977,7 @@
                 </g>
             </g>
             <g id="356.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2078.37,1900.90 -2063.69,2138.11"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2078.37,1900.90 -2063.69,2138.11"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-2076.36,1933.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(176.46)">
@@ -5999,7 +5999,7 @@
         <g id="357">
             <desc>L56-59-1</desc>
             <g id="357.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2030.18,2424.28 -1997.47,2465.34 -1880.47,2511.32"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2030.18,2424.28 -1997.47,2465.34 -1880.47,2511.32"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1969.55,2476.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(111.45)">
@@ -6018,7 +6018,7 @@
                 </g>
             </g>
             <g id="357.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1711.56,2549.49 -1763.47,2557.29 -1880.47,2511.32"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1711.56,2549.49 -1763.47,2557.29 -1880.47,2511.32"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1791.39,2546.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-68.55)">
@@ -6040,7 +6040,7 @@
         <g id="358">
             <desc>L56-59-2</desc>
             <g id="358.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2020.13,2398.69 -1968.21,2390.88 -1851.21,2436.86"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2020.13,2398.69 -1968.21,2390.88 -1851.21,2436.86"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1940.29,2401.86)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(111.45)">
@@ -6059,7 +6059,7 @@
                 </g>
             </g>
             <g id="358.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1701.50,2523.90 -1734.21,2482.84 -1851.21,2436.86"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1701.50,2523.90 -1734.21,2482.84 -1851.21,2436.86"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1762.14,2471.86)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-68.55)">
@@ -6081,7 +6081,7 @@
         <g id="359">
             <desc>L59-60-1</desc>
             <g id="359.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1665.86,2565.75 -1478.60,2771.75"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1665.86,2565.75 -1478.60,2771.75"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1644.00,2589.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(137.73)">
@@ -6100,7 +6100,7 @@
                 </g>
             </g>
             <g id="359.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1291.34,2977.75 -1478.60,2771.75"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1291.34,2977.75 -1478.60,2771.75"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1313.20,2953.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-42.27)">
@@ -6122,7 +6122,7 @@
         <g id="360">
             <desc>L59-61-1</desc>
             <g id="360.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1657.76,2552.36 -1460.85,2603.81"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1657.76,2552.36 -1460.85,2603.81"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1626.31,2560.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.65)">
@@ -6141,7 +6141,7 @@
                 </g>
             </g>
             <g id="360.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1263.95,2655.27 -1460.85,2603.81"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1263.95,2655.27 -1460.85,2603.81"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1295.39,2647.05)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-75.35)">
@@ -6163,7 +6163,7 @@
         <g id="361">
             <desc>T63-59-1</desc>
             <g id="361.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1532.86,2164.19 -1592.46,2314.14"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1532.86,2164.19 -1592.46,2314.14"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1544.87,2194.39)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-158.33)">
@@ -6182,7 +6182,7 @@
                 </g>
             </g>
             <g id="361.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1674.21,2519.85 -1614.61,2369.90"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1674.21,2519.85 -1614.61,2369.90"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1662.20,2489.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(21.67)">
@@ -6208,7 +6208,7 @@
         <g id="362">
             <desc>L6-7-1</desc>
             <g id="362.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-201.95,-3069.36 -54.08,-3014.71"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-201.95,-3069.36 -54.08,-3014.71"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-171.47,-3058.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(110.28)">
@@ -6227,7 +6227,7 @@
                 </g>
             </g>
             <g id="362.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="93.79,-2960.05 -54.08,-3014.71"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="93.79,-2960.05 -54.08,-3014.71"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(63.30,-2971.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-69.72)">
@@ -6249,7 +6249,7 @@
         <g id="363">
             <desc>L60-61-1</desc>
             <g id="363.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1269.95,2970.75 -1255.09,2830.16"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1269.95,2970.75 -1255.09,2830.16"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1266.54,2938.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(6.03)">
@@ -6268,7 +6268,7 @@
                 </g>
             </g>
             <g id="363.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1240.23,2689.57 -1255.09,2830.16"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1240.23,2689.57 -1255.09,2830.16"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1243.65,2721.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-173.97)">
@@ -6290,7 +6290,7 @@
         <g id="364">
             <desc>L60-62-1</desc>
             <g id="364.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1247.26,2988.00 -1064.77,2915.99"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1247.26,2988.00 -1064.77,2915.99"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1217.03,2976.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(68.47)">
@@ -6309,7 +6309,7 @@
                 </g>
             </g>
             <g id="364.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-882.27,2843.98 -1064.77,2915.99"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-882.27,2843.98 -1064.77,2915.99"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-912.50,2855.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-111.53)">
@@ -6331,7 +6331,7 @@
         <g id="365">
             <desc>L61-62-1</desc>
             <g id="365.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1212.27,2673.53 -1047.02,2748.05"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1212.27,2673.53 -1047.02,2748.05"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1182.65,2686.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(114.27)">
@@ -6350,7 +6350,7 @@
                 </g>
             </g>
             <g id="365.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-881.76,2822.58 -1047.02,2748.05"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-881.76,2822.58 -1047.02,2748.05"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-911.39,2809.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-65.73)">
@@ -6372,7 +6372,7 @@
         <g id="366">
             <desc>T64-61-1</desc>
             <g id="366.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1223.60,1952.26 -1229.63,2263.50"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1223.60,1952.26 -1229.63,2263.50"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1224.23,1984.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-178.89)">
@@ -6391,7 +6391,7 @@
                 </g>
             </g>
             <g id="366.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1236.81,2634.73 -1230.79,2323.49"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1236.81,2634.73 -1230.79,2323.49"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1236.18,2602.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(1.11)">
@@ -6417,7 +6417,7 @@
         <g id="367">
             <desc>L62-66-1</desc>
             <g id="367.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-850.20,2807.16 -790.81,2562.44"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-850.20,2807.16 -790.81,2562.44"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-842.54,2775.58)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(13.64)">
@@ -6436,7 +6436,7 @@
                 </g>
             </g>
             <g id="367.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-731.42,2317.72 -790.81,2562.44"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-731.42,2317.72 -790.81,2562.44"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-739.09,2349.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-166.36)">
@@ -6458,7 +6458,7 @@
         <g id="368">
             <desc>L62-67-1</desc>
             <g id="368.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-829.30,2831.40 -671.08,2817.05"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-829.30,2831.40 -671.08,2817.05"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-796.94,2828.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(84.82)">
@@ -6477,7 +6477,7 @@
                 </g>
             </g>
             <g id="368.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-512.85,2802.69 -671.08,2817.05"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-512.85,2802.69 -671.08,2817.05"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-545.22,2805.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-95.18)">
@@ -6499,7 +6499,7 @@
         <g id="369">
             <desc>L63-64-1</desc>
             <g id="369.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1500.32,2122.66 -1372.89,2031.70"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1500.32,2122.66 -1372.89,2031.70"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1473.87,2103.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(54.48)">
@@ -6518,7 +6518,7 @@
                 </g>
             </g>
             <g id="369.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1245.45,1940.74 -1372.89,2031.70"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1245.45,1940.74 -1372.89,2031.70"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1271.91,1959.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-125.52)">
@@ -6540,7 +6540,7 @@
         <g id="370">
             <desc>L64-65-1</desc>
             <g id="370.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1208.60,1901.38 -1030.54,1613.62"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1208.60,1901.38 -1030.54,1613.62"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1191.50,1873.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(31.75)">
@@ -6559,7 +6559,7 @@
                 </g>
             </g>
             <g id="370.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-852.48,1325.86 -1030.54,1613.62"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-852.48,1325.86 -1030.54,1613.62"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-869.59,1353.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-148.25)">
@@ -6581,7 +6581,7 @@
         <g id="371">
             <desc>L65-68-1</desc>
             <g id="371.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-819.91,1281.77 -635.42,1070.82"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-819.91,1281.77 -635.42,1070.82"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-798.52,1257.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(41.17)">
@@ -6600,7 +6600,7 @@
                 </g>
             </g>
             <g id="371.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-450.93,859.86 -635.42,1070.82"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-450.93,859.86 -635.42,1070.82"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-472.32,884.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-138.83)">
@@ -6622,7 +6622,7 @@
         <g id="372">
             <desc>T65-66-1</desc>
             <g id="372.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-834.89,1329.80 -784.89,1766.93"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-834.89,1329.80 -784.89,1766.93"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-831.20,1362.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(173.47)">
@@ -6641,7 +6641,7 @@
                 </g>
             </g>
             <g id="372.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-728.06,2263.68 -778.07,1826.54"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-728.06,2263.68 -778.07,1826.54"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-731.76,2231.39)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-6.53)">
@@ -6667,7 +6667,7 @@
         <g id="373">
             <desc>L66-67-1</desc>
             <g id="373.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-713.23,2315.89 -605.20,2545.61"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-713.23,2315.89 -605.20,2545.61"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-699.40,2345.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(154.81)">
@@ -6686,7 +6686,7 @@
                 </g>
             </g>
             <g id="373.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-497.17,2775.33 -605.20,2545.61"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-497.17,2775.33 -605.20,2545.61"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-511.00,2745.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-25.19)">
@@ -6708,7 +6708,7 @@
         <g id="374">
             <desc>L68-81-1</desc>
             <g id="374.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-408.85,825.69 61.29,561.70"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-408.85,825.69 61.29,561.70"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-380.51,809.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(60.68)">
@@ -6727,7 +6727,7 @@
                 </g>
             </g>
             <g id="374.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="531.42,297.70 61.29,561.70"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="531.42,297.70 61.29,561.70"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(503.08,313.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-119.32)">
@@ -6749,7 +6749,7 @@
         <g id="375">
             <desc>T68-69-1</desc>
             <g id="375.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-460.21,836.69 -555.10,828.14"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-460.21,836.69 -555.10,828.14"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-492.58,833.77)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-84.85)">
@@ -6768,7 +6768,7 @@
                 </g>
             </g>
             <g id="375.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-709.74,814.21 -614.86,822.76"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-709.74,814.21 -614.86,822.76"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-677.37,817.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(95.15)">
@@ -6794,7 +6794,7 @@
         <g id="376">
             <desc>L69-70-1</desc>
             <g id="376.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-761.50,799.00 -1153.54,594.19"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-761.50,799.00 -1153.54,594.19"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-790.31,783.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-62.42)">
@@ -6813,7 +6813,7 @@
                 </g>
             </g>
             <g id="376.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1545.57,389.38 -1153.54,594.19"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1545.57,389.38 -1153.54,594.19"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1516.76,404.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(117.58)">
@@ -6835,7 +6835,7 @@
         <g id="377">
             <desc>L69-75-1</desc>
             <g id="377.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-744.24,785.17 -805.39,556.79"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-744.24,785.17 -805.39,556.79"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-752.65,753.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-14.99)">
@@ -6854,7 +6854,7 @@
                 </g>
             </g>
             <g id="377.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-866.53,328.40 -805.39,556.79"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-866.53,328.40 -805.39,556.79"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-858.13,359.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(165.01)">
@@ -6876,7 +6876,7 @@
         <g id="378">
             <desc>L69-77-1</desc>
             <g id="378.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-714.67,795.87 -276.97,486.61"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-714.67,795.87 -276.97,486.61"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-688.13,777.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(54.76)">
@@ -6895,7 +6895,7 @@
                 </g>
             </g>
             <g id="378.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="160.74,177.35 -276.97,486.61"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="160.74,177.35 -276.97,486.61"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(134.19,196.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-125.24)">
@@ -6917,7 +6917,7 @@
         <g id="379">
             <desc>L70-71-1</desc>
             <g id="379.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1597.37,378.67 -1916.20,402.29"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1597.37,378.67 -1916.20,402.29"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1629.78,381.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-94.24)">
@@ -6936,7 +6936,7 @@
                 </g>
             </g>
             <g id="379.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2235.04,425.91 -1916.20,402.29"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2235.04,425.91 -1916.20,402.29"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-2202.63,423.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(85.76)">
@@ -6958,7 +6958,7 @@
         <g id="380">
             <desc>L70-74-1</desc>
             <g id="380.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1545.64,363.78 -1430.56,302.87"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1545.64,363.78 -1430.56,302.87"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1516.91,348.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(62.11)">
@@ -6977,7 +6977,7 @@
                 </g>
             </g>
             <g id="380.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1315.49,241.96 -1430.56,302.87"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1315.49,241.96 -1430.56,302.87"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1344.21,257.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-117.89)">
@@ -6999,7 +6999,7 @@
         <g id="381">
             <desc>L70-75-1</desc>
             <g id="381.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1542.60,373.70 -1221.79,339.24"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1542.60,373.70 -1221.79,339.24"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1510.29,370.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(83.87)">
@@ -7018,7 +7018,7 @@
                 </g>
             </g>
             <g id="381.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-900.99,304.78 -1221.79,339.24"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-900.99,304.78 -1221.79,339.24"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-933.30,308.25)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-96.13)">
@@ -7040,7 +7040,7 @@
         <g id="382">
             <desc>L71-72-1</desc>
             <g id="382.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2277.19,404.71 -2371.92,255.25"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2277.19,404.71 -2371.92,255.25"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-2294.59,377.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-32.37)">
@@ -7059,7 +7059,7 @@
                 </g>
             </g>
             <g id="382.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2466.64,105.79 -2371.92,255.25"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2466.64,105.79 -2371.92,255.25"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-2449.25,133.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(147.63)">
@@ -7081,7 +7081,7 @@
         <g id="383">
             <desc>L71-73-1</desc>
             <g id="383.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2288.78,435.92 -2490.75,497.15"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2288.78,435.92 -2490.75,497.15"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-2319.89,445.35)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-106.87)">
@@ -7100,7 +7100,7 @@
                 </g>
             </g>
             <g id="383.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-2692.72,558.38 -2490.75,497.15"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2692.72,558.38 -2490.75,497.15"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-2661.61,548.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(73.13)">
@@ -7122,7 +7122,7 @@
         <g id="384">
             <desc>L74-75-1</desc>
             <g id="384.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1264.09,233.81 -1082.41,265.46"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1264.09,233.81 -1082.41,265.46"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1232.07,239.39)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(99.88)">
@@ -7141,7 +7141,7 @@
                 </g>
             </g>
             <g id="384.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-900.73,297.12 -1082.41,265.46"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-900.73,297.12 -1082.41,265.46"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-932.75,291.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-80.12)">
@@ -7163,7 +7163,7 @@
         <g id="385">
             <desc>L75-77-1</desc>
             <g id="385.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-846.38,298.22 -345.22,231.66"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-846.38,298.22 -345.22,231.66"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-814.17,293.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(82.44)">
@@ -7182,7 +7182,7 @@
                 </g>
             </g>
             <g id="385.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="155.94,165.11 -345.22,231.66"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="155.94,165.11 -345.22,231.66"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(123.72,169.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-97.56)">
@@ -7204,7 +7204,7 @@
         <g id="386">
             <desc>L76-77-1</desc>
             <g id="386.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-184.73,-77.42 -12.30,34.54"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-184.73,-77.42 -12.30,34.54"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-157.47,-59.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(123.00)">
@@ -7223,7 +7223,7 @@
                 </g>
             </g>
             <g id="386.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="160.13,146.51 -12.30,34.54"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="160.13,146.51 -12.30,34.54"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(132.88,128.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-57.00)">
@@ -7245,7 +7245,7 @@
         <g id="387">
             <desc>L77-78-1</desc>
             <g id="387.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="201.49,140.95 374.58,-53.27"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="201.49,140.95 374.58,-53.27"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(223.12,116.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(41.71)">
@@ -7264,7 +7264,7 @@
                 </g>
             </g>
             <g id="387.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="547.67,-247.49 374.58,-53.27"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="547.67,-247.49 374.58,-53.27"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(526.05,-223.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-138.29)">
@@ -7286,7 +7286,7 @@
         <g id="388">
             <desc>L77-80-1</desc>
             <g id="388.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="209.88,168.13 260.83,180.80 660.15,66.09"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="209.88,168.13 260.83,180.80 660.15,66.09"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(289.66,172.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(73.97)">
@@ -7305,7 +7305,7 @@
                 </g>
             </g>
             <g id="388.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1095.93,-86.40 1059.48,-48.62 660.15,66.09"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1095.93,-86.40 1059.48,-48.62 660.15,66.09"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1030.64,-40.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-106.03)">
@@ -7327,7 +7327,7 @@
         <g id="389">
             <desc>L77-80-2</desc>
             <g id="389.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="202.29,141.69 238.74,103.91 638.07,-10.80"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="202.29,141.69 238.74,103.91 638.07,-10.80"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(267.58,95.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(73.97)">
@@ -7346,7 +7346,7 @@
                 </g>
             </g>
             <g id="389.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1088.34,-112.83 1037.39,-125.51 638.07,-10.80"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1088.34,-112.83 1037.39,-125.51 638.07,-10.80"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1008.56,-117.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-106.03)">
@@ -7368,7 +7368,7 @@
         <g id="390">
             <desc>L77-82-1</desc>
             <g id="390.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="208.08,173.20 684.34,397.39"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="208.08,173.20 684.34,397.39"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(237.48,187.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(115.21)">
@@ -7387,7 +7387,7 @@
                 </g>
             </g>
             <g id="390.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1160.61,621.58 684.34,397.39"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1160.61,621.58 684.34,397.39"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1131.20,607.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-64.79)">
@@ -7409,7 +7409,7 @@
         <g id="391">
             <desc>L78-79-1</desc>
             <g id="391.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="589.39,-282.44 738.56,-374.30"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="589.39,-282.44 738.56,-374.30"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(617.06,-299.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(58.38)">
@@ -7428,7 +7428,7 @@
                 </g>
             </g>
             <g id="391.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="887.73,-466.16 738.56,-374.30"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="887.73,-466.16 738.56,-374.30"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(860.05,-449.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-121.62)">
@@ -7450,7 +7450,7 @@
         <g id="392">
             <desc>L79-80-1</desc>
             <g id="392.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="924.30,-456.43 1013.08,-293.38"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="924.30,-456.43 1013.08,-293.38"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(939.84,-427.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(151.43)">
@@ -7469,7 +7469,7 @@
                 </g>
             </g>
             <g id="392.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1101.87,-130.34 1013.08,-293.38"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1101.87,-130.34 1013.08,-293.38"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1086.33,-158.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-28.57)">
@@ -7491,7 +7491,7 @@
         <g id="393">
             <desc>L8-9-1</desc>
             <g id="393.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-837.05,-2096.13 -966.57,-2309.32"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-837.05,-2096.13 -966.57,-2309.32"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-853.93,-2123.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-31.28)">
@@ -7510,7 +7510,7 @@
                 </g>
             </g>
             <g id="393.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1096.08,-2522.51 -966.57,-2309.32"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1096.08,-2522.51 -966.57,-2309.32"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1079.21,-2494.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(148.72)">
@@ -7532,7 +7532,7 @@
         <g id="394">
             <desc>L80-96-1</desc>
             <g id="394.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1136.03,-88.44 1346.70,89.54"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1136.03,-88.44 1346.70,89.54"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1160.85,-67.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(130.19)">
@@ -7551,7 +7551,7 @@
                 </g>
             </g>
             <g id="394.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1557.36,267.53 1346.70,89.54"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1557.36,267.53 1346.70,89.54"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1532.54,246.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-49.81)">
@@ -7573,7 +7573,7 @@
         <g id="395">
             <desc>L80-97-1</desc>
             <g id="395.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1140.52,-95.90 1260.76,-47.38"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1140.52,-95.90 1260.76,-47.38"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1170.66,-83.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(111.98)">
@@ -7592,7 +7592,7 @@
                 </g>
             </g>
             <g id="395.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1380.99,1.15 1260.76,-47.38"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1380.99,1.15 1260.76,-47.38"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1350.85,-11.02)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-68.02)">
@@ -7614,7 +7614,7 @@
         <g id="396">
             <desc>L80-98-1</desc>
             <g id="396.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1135.41,-124.64 1374.81,-341.29"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1135.41,-124.64 1374.81,-341.29"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1159.51,-146.45)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(47.86)">
@@ -7633,7 +7633,7 @@
                 </g>
             </g>
             <g id="396.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1614.21,-557.93 1374.81,-341.29"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1614.21,-557.93 1374.81,-341.29"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1590.11,-536.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-132.14)">
@@ -7655,7 +7655,7 @@
         <g id="397">
             <desc>L80-99-1</desc>
             <g id="397.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1141.51,-113.57 1454.91,-200.88"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1141.51,-113.57 1454.91,-200.88"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1172.82,-122.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(74.43)">
@@ -7674,7 +7674,7 @@
                 </g>
             </g>
             <g id="397.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1768.30,-288.19 1454.91,-200.88"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1768.30,-288.19 1454.91,-200.88"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1736.99,-279.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-105.57)">
@@ -7696,7 +7696,7 @@
         <g id="398">
             <desc>T81-80-1</desc>
             <g id="398.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="577.95,268.50 810.61,106.19"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="577.95,268.50 810.61,106.19"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(604.61,249.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(55.10)">
@@ -7715,7 +7715,7 @@
                 </g>
             </g>
             <g id="398.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1092.47,-90.46 859.82,71.86"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1092.47,-90.46 859.82,71.86"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1065.81,-71.86)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-124.90)">
@@ -7741,7 +7741,7 @@
         <g id="399">
             <desc>L82-83-1</desc>
             <g id="399.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1203.93,653.69 1452.98,929.28"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1203.93,653.69 1452.98,929.28"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1225.72,677.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(137.90)">
@@ -7760,7 +7760,7 @@
                 </g>
             </g>
             <g id="399.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1702.03,1204.86 1452.98,929.28"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1702.03,1204.86 1452.98,929.28"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1680.24,1180.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-42.10)">
@@ -7782,7 +7782,7 @@
         <g id="400">
             <desc>L82-96-1</desc>
             <g id="400.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1206.07,615.06 1381.93,459.29"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1206.07,615.06 1381.93,459.29"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1230.40,593.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.47)">
@@ -7801,7 +7801,7 @@
                 </g>
             </g>
             <g id="400.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1557.78,303.51 1381.93,459.29"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1557.78,303.51 1381.93,459.29"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1533.46,325.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-131.53)">
@@ -7823,7 +7823,7 @@
         <g id="401">
             <desc>L83-84-1</desc>
             <g id="401.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1731.00,1250.67 1796.56,1408.75"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1731.00,1250.67 1796.56,1408.75"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1743.45,1280.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(157.48)">
@@ -7842,7 +7842,7 @@
                 </g>
             </g>
             <g id="401.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1862.12,1566.83 1796.56,1408.75"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1862.12,1566.83 1796.56,1408.75"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1849.67,1536.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-22.52)">
@@ -7864,7 +7864,7 @@
         <g id="402">
             <desc>L83-85-1</desc>
             <g id="402.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1744.82,1238.04 1987.39,1365.32"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1744.82,1238.04 1987.39,1365.32"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1773.60,1253.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(117.69)">
@@ -7883,7 +7883,7 @@
                 </g>
             </g>
             <g id="402.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2229.97,1492.60 1987.39,1365.32"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2229.97,1492.60 1987.39,1365.32"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(2201.19,1477.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-62.31)">
@@ -7905,7 +7905,7 @@
         <g id="403">
             <desc>L84-85-1</desc>
             <g id="403.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1899.47,1586.13 2063.49,1548.81"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1899.47,1586.13 2063.49,1548.81"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1931.16,1578.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(77.18)">
@@ -7924,7 +7924,7 @@
                 </g>
             </g>
             <g id="403.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2227.50,1511.48 2063.49,1548.81"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2227.50,1511.48 2063.49,1548.81"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(2195.81,1518.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-102.82)">
@@ -7946,7 +7946,7 @@
         <g id="404">
             <desc>L85-86-1</desc>
             <g id="404.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2256.46,1532.80 2275.87,1781.32"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2256.46,1532.80 2275.87,1781.32"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(2258.99,1565.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(175.53)">
@@ -7965,7 +7965,7 @@
                 </g>
             </g>
             <g id="404.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2295.29,2029.83 2275.87,1781.32"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2295.29,2029.83 2275.87,1781.32"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(2292.76,1997.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-4.47)">
@@ -7987,7 +7987,7 @@
         <g id="405">
             <desc>L85-88-1</desc>
             <g id="405.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2281.71,1502.97 2452.80,1487.93"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2281.71,1502.97 2452.80,1487.93"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(2314.09,1500.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(84.98)">
@@ -8006,7 +8006,7 @@
                 </g>
             </g>
             <g id="405.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2623.88,1472.89 2452.80,1487.93"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2623.88,1472.89 2452.80,1487.93"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(2591.51,1475.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-95.02)">
@@ -8028,7 +8028,7 @@
         <g id="406">
             <desc>L85-89-1</desc>
             <g id="406.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2273.30,1485.49 2467.13,1282.33"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2273.30,1485.49 2467.13,1282.33"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(2295.74,1461.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(43.65)">
@@ -8047,7 +8047,7 @@
                 </g>
             </g>
             <g id="406.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2660.95,1079.17 2467.13,1282.33"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2660.95,1079.17 2467.13,1282.33"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(2638.52,1102.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-136.35)">
@@ -8069,7 +8069,7 @@
         <g id="407">
             <desc>L86-87-1</desc>
             <g id="407.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2296.34,2084.73 2289.37,2261.37"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2296.34,2084.73 2289.37,2261.37"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(2295.06,2117.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-177.74)">
@@ -8088,7 +8088,7 @@
                 </g>
             </g>
             <g id="407.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2282.39,2438.00 2289.37,2261.37"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2282.39,2438.00 2289.37,2261.37"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(2283.67,2405.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(2.26)">
@@ -8110,7 +8110,7 @@
         <g id="408">
             <desc>L88-89-1</desc>
             <g id="408.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2653.19,1443.05 2665.61,1264.88"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2653.19,1443.05 2665.61,1264.88"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(2655.45,1410.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(3.99)">
@@ -8129,7 +8129,7 @@
                 </g>
             </g>
             <g id="408.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2678.02,1086.71 2665.61,1264.88"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2678.02,1086.71 2665.61,1264.88"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(2675.76,1119.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-176.01)">
@@ -8151,7 +8151,7 @@
         <g id="409">
             <desc>L89-90-1</desc>
             <g id="409.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2705.56,1069.27 2754.47,1088.34 2905.61,1065.22"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2705.56,1069.27 2754.47,1088.34 2905.61,1065.22"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(2784.13,1083.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(81.30)">
@@ -8170,7 +8170,7 @@
                 </g>
             </g>
             <g id="409.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="3097.72,1009.28 3056.75,1042.10 2905.61,1065.22"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="3097.72,1009.28 3056.75,1042.10 2905.61,1065.22"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(3027.09,1046.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-98.70)">
@@ -8192,7 +8192,7 @@
         <g id="410">
             <desc>L89-90-2</desc>
             <g id="410.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2701.40,1042.08 2742.37,1009.26 2893.51,986.14"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2701.40,1042.08 2742.37,1009.26 2893.51,986.14"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(2772.03,1004.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(81.30)">
@@ -8211,7 +8211,7 @@
                 </g>
             </g>
             <g id="410.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="3093.56,982.10 3044.65,963.02 2893.51,986.14"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="3093.56,982.10 3044.65,963.02 2893.51,986.14"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(3015.00,967.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-98.70)">
@@ -8233,7 +8233,7 @@
         <g id="411">
             <desc>L89-92-1</desc>
             <g id="411.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2694.08,1035.69 2721.07,990.66 2726.28,674.31"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2694.08,1035.69 2721.07,990.66 2726.28,674.31"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(2721.57,960.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(0.94)">
@@ -8252,7 +8252,7 @@
                 </g>
             </g>
             <g id="411.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2705.99,312.07 2731.49,357.96 2726.28,674.31"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2705.99,312.07 2731.49,357.96 2726.28,674.31"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(2731.00,387.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-179.06)">
@@ -8274,7 +8274,7 @@
         <g id="412">
             <desc>L89-92-2</desc>
             <g id="412.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2666.58,1035.24 2641.08,989.34 2646.29,672.99"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2666.58,1035.24 2641.08,989.34 2646.29,672.99"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(2641.58,959.35)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(0.94)">
@@ -8293,7 +8293,7 @@
                 </g>
             </g>
             <g id="412.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2678.49,311.61 2651.50,356.64 2646.29,672.99"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2678.49,311.61 2651.50,356.64 2646.29,672.99"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(2651.01,386.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-179.06)">
@@ -8315,7 +8315,7 @@
         <g id="413">
             <desc>L90-91-1</desc>
             <g id="413.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="3118.70,964.59 3115.71,794.70"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="3118.70,964.59 3115.71,794.70"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(3118.13,932.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-1.01)">
@@ -8334,7 +8334,7 @@
                 </g>
             </g>
             <g id="413.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="3112.73,624.80 3115.71,794.70"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="3112.73,624.80 3115.71,794.70"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(3113.30,657.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(178.99)">
@@ -8356,7 +8356,7 @@
         <g id="414">
             <desc>L91-92-1</desc>
             <g id="414.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="3090.11,580.99 2902.44,442.67"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="3090.11,580.99 2902.44,442.67"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(3063.94,561.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-53.61)">
@@ -8375,7 +8375,7 @@
                 </g>
             </g>
             <g id="414.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2714.77,304.35 2902.44,442.67"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2714.77,304.35 2902.44,442.67"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(2740.93,323.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(126.39)">
@@ -8397,7 +8397,7 @@
         <g id="415">
             <desc>L92-93-1</desc>
             <g id="415.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2669.60,303.05 2558.90,375.26"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2669.60,303.05 2558.90,375.26"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(2642.38,320.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-123.11)">
@@ -8416,7 +8416,7 @@
                 </g>
             </g>
             <g id="415.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2448.20,447.47 2558.90,375.26"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2448.20,447.47 2558.90,375.26"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(2475.42,429.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(56.89)">
@@ -8438,7 +8438,7 @@
         <g id="416">
             <desc>L92-94-1</desc>
             <g id="416.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2666.24,280.32 2445.38,215.80"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2666.24,280.32 2445.38,215.80"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(2635.04,271.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-73.72)">
@@ -8457,7 +8457,7 @@
                 </g>
             </g>
             <g id="416.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2224.52,151.28 2445.38,215.80"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2224.52,151.28 2445.38,215.80"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(2255.71,160.40)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(106.28)">
@@ -8479,7 +8479,7 @@
         <g id="417">
             <desc>L93-94-1</desc>
             <g id="417.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2409.21,440.09 2311.64,303.03"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2409.21,440.09 2311.64,303.03"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(2390.36,413.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-35.45)">
@@ -8498,7 +8498,7 @@
                 </g>
             </g>
             <g id="417.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2214.07,165.97 2311.64,303.03"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2214.07,165.97 2311.64,303.03"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(2232.92,192.45)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(144.55)">
@@ -8520,7 +8520,7 @@
         <g id="418">
             <desc>L94-95-1</desc>
             <g id="418.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2179.07,163.40 2061.10,286.17"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2179.07,163.40 2061.10,286.17"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(2156.55,186.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-136.14)">
@@ -8539,7 +8539,7 @@
                 </g>
             </g>
             <g id="418.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1943.12,408.94 2061.10,286.17"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1943.12,408.94 2061.10,286.17"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1965.64,385.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(43.86)">
@@ -8561,7 +8561,7 @@
         <g id="419">
             <desc>L94-96-1</desc>
             <g id="419.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="2171.31,149.70 1888.25,214.43"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2171.31,149.70 1888.25,214.43"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(2139.63,156.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-102.88)">
@@ -8580,7 +8580,7 @@
                 </g>
             </g>
             <g id="419.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1605.18,279.15 1888.25,214.43"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1605.18,279.15 1888.25,214.43"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1636.86,271.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(77.12)">
@@ -8602,7 +8602,7 @@
         <g id="420">
             <desc>L95-96-1</desc>
             <g id="420.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1898.67,418.23 1751.22,357.02"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1898.67,418.23 1751.22,357.02"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1868.65,405.77)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-67.46)">
@@ -8621,7 +8621,7 @@
                 </g>
             </g>
             <g id="420.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1603.77,295.82 1751.22,357.02"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1603.77,295.82 1751.22,357.02"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1633.79,308.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(112.54)">
@@ -8643,7 +8643,7 @@
         <g id="421">
             <desc>L96-97-1</desc>
             <g id="421.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1563.75,261.99 1492.43,148.36"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1563.75,261.99 1492.43,148.36"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1546.47,234.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-32.11)">
@@ -8662,7 +8662,7 @@
                 </g>
             </g>
             <g id="421.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1421.11,34.73 1492.43,148.36"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1421.11,34.73 1492.43,148.36"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1438.39,62.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(147.89)">

--- a/network-area-diagram/src/test/resources/IEEE_118_bus_partial.svg
+++ b/network-area-diagram/src/test/resources/IEEE_118_bus_partial.svg
@@ -320,7 +320,7 @@
         <g id="42">
             <desc>L40-42-1</desc>
             <g id="42.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-385.29,177.56 -388.07,40.20"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-385.29,177.56 -388.07,40.20"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-385.94,145.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-1.16)">
@@ -342,7 +342,7 @@
         <g id="45">
             <desc>L41-42-1</desc>
             <g id="45.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-409.97,194.13 -644.22,92.70"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-409.97,194.13 -644.22,92.70"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-439.79,181.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-66.59)">
@@ -364,7 +364,7 @@
         <g id="46">
             <desc>L42-49-1</desc>
             <g id="46.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-367.20,226.24 -333.73,266.69 -135.64,340.34"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-367.20,226.24 -333.73,266.69 -135.64,340.34"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-305.61,277.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(110.39)">
@@ -383,7 +383,7 @@
                 </g>
             </g>
             <g id="46.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="114.21,405.23 62.45,413.99 -135.64,340.34"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="114.21,405.23 62.45,413.99 -135.64,340.34"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(34.33,403.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-69.61)">
@@ -405,7 +405,7 @@
         <g id="47">
             <desc>L42-49-2</desc>
             <g id="47.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-357.61,200.47 -305.85,191.71 -107.76,265.35"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-357.61,200.47 -305.85,191.71 -107.76,265.35"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-277.73,202.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(110.39)">
@@ -424,7 +424,7 @@
                 </g>
             </g>
             <g id="47.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="123.80,379.45 90.33,339.00 -107.76,265.35"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="123.80,379.45 90.33,339.00 -107.76,265.35"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(62.21,328.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-69.61)">
@@ -446,7 +446,7 @@
         <g id="50">
             <desc>L44-45-1</desc>
             <g id="50.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="421.53,544.11 468.94,399.99"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="421.53,544.11 468.94,399.99"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(431.69,513.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(18.21)">
@@ -468,7 +468,7 @@
         <g id="53">
             <desc>L45-46-1</desc>
             <g id="53.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="407.77,597.24 376.45,760.94"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="407.77,597.24 376.45,760.94"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(401.67,629.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-169.17)">
@@ -490,7 +490,7 @@
         <g id="54">
             <desc>L45-49-1</desc>
             <g id="54.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="389.62,555.66 277.13,485.43"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="389.62,555.66 277.13,485.43"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(362.05,538.45)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-58.02)">
@@ -509,7 +509,7 @@
                 </g>
             </g>
             <g id="54.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="164.65,415.20 277.13,485.43"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="164.65,415.20 277.13,485.43"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(192.22,432.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(121.98)">
@@ -531,7 +531,7 @@
         <g id="55">
             <desc>L46-47-1</desc>
             <g id="55.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="4.12,895.75 158.48,921.45"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="4.12,895.75 158.48,921.45"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(36.17,901.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(99.45)">
@@ -553,7 +553,7 @@
         <g id="56">
             <desc>L47-49-1</desc>
             <g id="56.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-14.28,865.16 59.16,645.94"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-14.28,865.16 59.16,645.94"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-3.95,834.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(18.52)">
@@ -572,7 +572,7 @@
                 </g>
             </g>
             <g id="56.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="132.59,426.72 59.16,645.94"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="132.59,426.72 59.16,645.94"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(122.27,457.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-161.48)">
@@ -594,7 +594,7 @@
         <g id="57">
             <desc>L47-69-1</desc>
             <g id="57.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-26.14,918.56 -47.18,1102.56"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-26.14,918.56 -47.18,1102.56"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-29.83,950.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-173.47)">
@@ -613,7 +613,7 @@
                 </g>
             </g>
             <g id="57.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-68.23,1286.57 -47.18,1102.56"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-68.23,1286.57 -47.18,1102.56"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-64.54,1254.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(6.53)">
@@ -635,7 +635,7 @@
         <g id="58">
             <desc>L46-48-1</desc>
             <g id="58.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="612.80,872.34 489.59,908.16"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="612.80,872.34 489.59,908.16"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(581.59,881.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-106.21)">
@@ -657,7 +657,7 @@
         <g id="59">
             <desc>L48-49-1</desc>
             <g id="59.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="619.09,845.91 390.27,632.65"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="619.09,845.91 390.27,632.65"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(595.31,823.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-47.02)">
@@ -676,7 +676,7 @@
                 </g>
             </g>
             <g id="59.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="161.44,419.39 390.27,632.65"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="161.44,419.39 390.27,632.65"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(185.22,441.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(132.98)">
@@ -698,7 +698,7 @@
         <g id="60">
             <desc>L49-50-1</desc>
             <g id="60.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="168.83,400.36 516.02,396.79"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="168.83,400.36 516.02,396.79"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(201.32,400.02)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(89.41)">
@@ -717,7 +717,7 @@
                 </g>
             </g>
             <g id="60.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="863.22,393.22 516.02,396.79"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="863.22,393.22 516.02,396.79"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(830.72,393.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-90.59)">
@@ -739,7 +739,7 @@
         <g id="61">
             <desc>L49-51-1</desc>
             <g id="61.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="161.36,381.80 459.86,101.18"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="161.36,381.80 459.86,101.18"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(185.04,359.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(46.77)">
@@ -758,7 +758,7 @@
                 </g>
             </g>
             <g id="61.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="758.35,-179.45 459.86,101.18"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="758.35,-179.45 459.86,101.18"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(734.67,-157.18)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-133.23)">
@@ -780,7 +780,7 @@
         <g id="62">
             <desc>L49-54-1</desc>
             <g id="62.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="158.77,379.38 192.07,338.79 254.64,-40.45"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="158.77,379.38 192.07,338.79 254.64,-40.45"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(196.95,309.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(9.37)">
@@ -799,7 +799,7 @@
                 </g>
             </g>
             <g id="62.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="298.70,-468.82 317.20,-419.69 254.64,-40.45"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="298.70,-468.82 317.20,-419.69 254.64,-40.45"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(312.32,-390.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-170.63)">
@@ -821,7 +821,7 @@
         <g id="63">
             <desc>L49-54-2</desc>
             <g id="63.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="131.64,374.90 113.14,325.77 175.70,-53.47"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="131.64,374.90 113.14,325.77 175.70,-53.47"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(118.02,296.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(9.37)">
@@ -840,7 +840,7 @@
                 </g>
             </g>
             <g id="63.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="271.57,-473.30 238.27,-432.71 175.70,-53.47"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="271.57,-473.30 238.27,-432.71 175.70,-53.47"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(233.38,-403.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-170.63)">
@@ -862,7 +862,7 @@
         <g id="64">
             <desc>L49-66-1</desc>
             <g id="64.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="118.94,384.67 76.20,354.19 -325.61,315.52"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="118.94,384.67 76.20,354.19 -325.61,315.52"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(46.33,351.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-84.50)">
@@ -881,7 +881,7 @@
                 </g>
             </g>
             <g id="64.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-775.19,298.62 -727.42,276.85 -325.61,315.52"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-775.19,298.62 -727.42,276.85 -325.61,315.52"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-697.56,279.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(95.50)">
@@ -903,7 +903,7 @@
         <g id="65">
             <desc>L49-66-2</desc>
             <g id="65.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="116.30,412.05 68.53,433.82 -333.28,395.15"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="116.30,412.05 68.53,433.82 -333.28,395.15"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(38.67,430.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-84.50)">
@@ -922,7 +922,7 @@
                 </g>
             </g>
             <g id="65.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-777.83,326.00 -735.08,356.48 -333.28,395.15"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-777.83,326.00 -735.08,356.48 -333.28,395.15"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-705.22,359.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(95.50)">
@@ -944,7 +944,7 @@
         <g id="66">
             <desc>L49-69-1</desc>
             <g id="66.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="135.09,427.42 34.99,857.26"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="135.09,427.42 34.99,857.26"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(127.72,459.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-166.89)">
@@ -963,7 +963,7 @@
                 </g>
             </g>
             <g id="66.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-65.12,1287.11 34.99,857.26"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-65.12,1287.11 34.99,857.26"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-57.75,1255.45)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(13.11)">
@@ -985,7 +985,7 @@
         <g id="67">
             <desc>L50-57-1</desc>
             <g id="67.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="904.12,368.92 994.73,206.57"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="904.12,368.92 994.73,206.57"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(919.96,340.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(29.17)">
@@ -1004,7 +1004,7 @@
                 </g>
             </g>
             <g id="67.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1085.34,44.21 994.73,206.57"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1085.34,44.21 994.73,206.57"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1069.50,72.59)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-150.83)">
@@ -1026,7 +1026,7 @@
         <g id="68">
             <desc>L51-52-1</desc>
             <g id="68.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="792.26,-222.03 945.28,-483.87"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="792.26,-222.03 945.28,-483.87"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(808.66,-250.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(30.30)">
@@ -1045,7 +1045,7 @@
                 </g>
             </g>
             <g id="68.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1098.30,-745.71 945.28,-483.87"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1098.30,-745.71 945.28,-483.87"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1081.90,-717.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-149.70)">
@@ -1067,7 +1067,7 @@
         <g id="69">
             <desc>L51-58-1</desc>
             <g id="69.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="800.92,-214.05 928.58,-303.35"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="800.92,-214.05 928.58,-303.35"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(827.55,-232.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(55.03)">
@@ -1086,7 +1086,7 @@
                 </g>
             </g>
             <g id="69.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1056.24,-392.65 928.58,-303.35"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1056.24,-392.65 928.58,-303.35"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1029.61,-374.02)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-124.97)">
@@ -1108,7 +1108,7 @@
         <g id="70">
             <desc>L52-53-1</desc>
             <g id="70.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1088.20,-782.92 945.06,-863.37"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1088.20,-782.92 945.06,-863.37"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1059.86,-798.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-60.66)">
@@ -1127,7 +1127,7 @@
                 </g>
             </g>
             <g id="70.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="801.92,-943.81 945.06,-863.37"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="801.92,-943.81 945.06,-863.37"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(830.26,-927.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(119.34)">
@@ -1149,7 +1149,7 @@
         <g id="71">
             <desc>L53-54-1</desc>
             <g id="71.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="757.98,-938.38 533.48,-725.92"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="757.98,-938.38 533.48,-725.92"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(734.37,-916.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-133.42)">
@@ -1168,7 +1168,7 @@
                 </g>
             </g>
             <g id="71.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="308.98,-513.46 533.48,-725.92"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="308.98,-513.46 533.48,-725.92"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(332.59,-535.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(46.58)">
@@ -1190,7 +1190,7 @@
         <g id="72">
             <desc>L54-55-1</desc>
             <g id="72.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="291.97,-521.90 308.41,-674.00"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="291.97,-521.90 308.41,-674.00"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(295.46,-554.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(6.17)">
@@ -1209,7 +1209,7 @@
                 </g>
             </g>
             <g id="72.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="324.86,-826.11 308.41,-674.00"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="324.86,-826.11 308.41,-674.00"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(321.36,-793.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-173.83)">
@@ -1231,7 +1231,7 @@
         <g id="73">
             <desc>L54-56-1</desc>
             <g id="73.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="316.19,-498.73 450.52,-519.37"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="316.19,-498.73 450.52,-519.37"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(348.31,-503.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(81.27)">
@@ -1250,7 +1250,7 @@
                 </g>
             </g>
             <g id="73.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="584.84,-540.01 450.52,-519.37"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="584.84,-540.01 450.52,-519.37"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(552.72,-535.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-98.73)">
@@ -1272,7 +1272,7 @@
         <g id="74">
             <desc>L54-59-1</desc>
             <g id="74.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="271.03,-515.37 126.54,-682.60"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="271.03,-515.37 126.54,-682.60"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(249.78,-539.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-40.83)">
@@ -1291,7 +1291,7 @@
                 </g>
             </g>
             <g id="74.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-17.96,-849.83 126.54,-682.60"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-17.96,-849.83 126.54,-682.60"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(3.29,-825.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(139.17)">
@@ -1313,7 +1313,7 @@
         <g id="75">
             <desc>L55-56-1</desc>
             <g id="75.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="346.42,-833.20 469.92,-698.81"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="346.42,-833.20 469.92,-698.81"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(368.41,-809.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(137.42)">
@@ -1332,7 +1332,7 @@
                 </g>
             </g>
             <g id="75.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="593.42,-564.43 469.92,-698.81"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="593.42,-564.43 469.92,-698.81"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(571.42,-588.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-42.58)">
@@ -1354,7 +1354,7 @@
         <g id="76">
             <desc>L55-59-1</desc>
             <g id="76.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="300.35,-854.75 145.94,-862.04"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="300.35,-854.75 145.94,-862.04"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(267.88,-856.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-87.29)">
@@ -1373,7 +1373,7 @@
                 </g>
             </g>
             <g id="76.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-8.47,-869.34 145.94,-862.04"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-8.47,-869.34 145.94,-862.04"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(23.99,-867.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(92.71)">
@@ -1395,7 +1395,7 @@
         <g id="77">
             <desc>L56-57-1</desc>
             <g id="77.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="629.98,-523.36 855.38,-261.99"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="629.98,-523.36 855.38,-261.99"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(651.21,-498.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(139.23)">
@@ -1414,7 +1414,7 @@
                 </g>
             </g>
             <g id="77.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1080.78,-0.63 855.38,-261.99"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1080.78,-0.63 855.38,-261.99"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1059.56,-25.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-40.77)">
@@ -1436,7 +1436,7 @@
         <g id="78">
             <desc>L56-58-1</desc>
             <g id="78.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="638.43,-536.50 845.40,-476.30"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="638.43,-536.50 845.40,-476.30"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(669.64,-527.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(106.22)">
@@ -1455,7 +1455,7 @@
                 </g>
             </g>
             <g id="78.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1052.37,-416.09 845.40,-476.30"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1052.37,-416.09 845.40,-476.30"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1021.16,-425.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-73.78)">
@@ -1477,7 +1477,7 @@
         <g id="79">
             <desc>L56-59-1</desc>
             <g id="79.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="596.94,-567.18 568.15,-611.08 306.04,-743.13"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="596.94,-567.18 568.15,-611.08 306.04,-743.13"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(541.36,-624.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-63.26)">
@@ -1496,7 +1496,7 @@
                 </g>
             </g>
             <g id="79.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-8.48,-872.20 43.93,-875.19 306.04,-743.13"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-8.48,-872.20 43.93,-875.19 306.04,-743.13"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(70.72,-861.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(116.74)">
@@ -1518,7 +1518,7 @@
         <g id="80">
             <desc>L56-59-2</desc>
             <g id="80.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="584.57,-542.62 532.15,-539.63 270.04,-671.69"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="584.57,-542.62 532.15,-539.63 270.04,-671.69"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(505.36,-553.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-63.26)">
@@ -1537,7 +1537,7 @@
                 </g>
             </g>
             <g id="80.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-20.86,-847.64 7.94,-803.74 270.04,-671.69"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-20.86,-847.64 7.94,-803.74 270.04,-671.69"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(34.73,-790.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(116.74)">
@@ -1559,7 +1559,7 @@
         <g id="81">
             <desc>L59-60-1</desc>
             <g id="81.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-61.97,-861.77 -257.17,-795.29"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-61.97,-861.77 -257.17,-795.29"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-92.74,-851.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-108.81)">
@@ -1578,7 +1578,7 @@
                 </g>
             </g>
             <g id="81.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-452.37,-728.81 -257.17,-795.29"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-452.37,-728.81 -257.17,-795.29"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-421.61,-739.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(71.19)">
@@ -1600,7 +1600,7 @@
         <g id="82">
             <desc>L59-61-1</desc>
             <g id="82.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-62.90,-876.05 -322.82,-928.23"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-62.90,-876.05 -322.82,-928.23"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-94.77,-882.45)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-78.65)">
@@ -1619,7 +1619,7 @@
                 </g>
             </g>
             <g id="82.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-582.74,-980.40 -322.82,-928.23"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-582.74,-980.40 -322.82,-928.23"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-550.87,-974.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(101.35)">
@@ -1641,7 +1641,7 @@
         <g id="83">
             <desc>T63-59-1</desc>
             <g id="83.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-202.79,-1343.96 -133.91,-1148.56"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-202.79,-1343.96 -133.91,-1148.56"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-191.98,-1313.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(160.58)">
@@ -1660,7 +1660,7 @@
                 </g>
             </g>
             <g id="83.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-45.08,-896.57 -113.96,-1091.97"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-45.08,-896.57 -113.96,-1091.97"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-55.89,-927.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-19.42)">
@@ -1686,7 +1686,7 @@
         <g id="84">
             <desc>L60-61-1</desc>
             <g id="84.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-490.58,-744.60 -544.05,-852.88"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-490.58,-744.60 -544.05,-852.88"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-504.97,-773.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-26.28)">
@@ -1705,7 +1705,7 @@
                 </g>
             </g>
             <g id="84.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-597.52,-961.16 -544.05,-852.88"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-597.52,-961.16 -544.05,-852.88"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-583.13,-932.02)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(153.72)">
@@ -1727,7 +1727,7 @@
         <g id="87">
             <desc>L60-62-1</desc>
             <g id="87.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-500.70,-703.84 -644.79,-599.82"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-500.70,-703.84 -644.79,-599.82"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-527.05,-684.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-125.83)">
@@ -1749,7 +1749,7 @@
         <g id="88">
             <desc>L61-62-1</desc>
             <g id="88.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-619.87,-960.27 -710.44,-732.76"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-619.87,-960.27 -710.44,-732.76"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-631.89,-930.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-158.29)">
@@ -1772,7 +1772,7 @@
             <desc>T64-61-1</desc>
             <g id="91.1" class="nad-vl120to180-line"></g>
             <g id="91.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-609.64,-1013.32 -609.31,-1173.64"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-609.64,-1013.32 -609.31,-1173.64"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-609.57,-1045.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(0.12)">
@@ -1798,7 +1798,7 @@
         <g id="92">
             <desc>L63-64-1</desc>
             <g id="92.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-239.20,-1373.44 -410.36,-1395.68"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-239.20,-1373.44 -410.36,-1395.68"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-271.43,-1377.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-82.60)">
@@ -1820,7 +1820,7 @@
         <g id="93">
             <desc>L62-66-1</desc>
             <g id="93.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-800.60,282.53 -805.70,-84.84"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-800.60,282.53 -805.70,-84.84"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-801.05,250.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-0.80)">
@@ -1842,7 +1842,7 @@
         <g id="96">
             <desc>L66-67-1</desc>
             <g id="96.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-816.12,332.47 -940.23,507.63"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-816.12,332.47 -940.23,507.63"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-834.91,358.99)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-144.68)">
@@ -1865,7 +1865,7 @@
             <desc>T65-66-1</desc>
             <g id="99.1" class="nad-vl120to180-line"></g>
             <g id="99.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-827.71,310.40 -1039.95,313.21"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-827.71,310.40 -1039.95,313.21"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-860.21,310.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-90.76)">
@@ -1891,7 +1891,7 @@
         <g id="102">
             <desc>L69-70-1</desc>
             <g id="102.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-47.49,1327.55 151.41,1441.36"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-47.49,1327.55 151.41,1441.36"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-19.28,1343.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(119.78)">
@@ -1913,7 +1913,7 @@
         <g id="105">
             <desc>L69-75-1</desc>
             <g id="105.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-87.47,1336.18 -224.71,1526.05"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-87.47,1336.18 -224.71,1526.05"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-106.50,1362.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-144.14)">
@@ -1935,7 +1935,7 @@
         <g id="108">
             <desc>L69-77-1</desc>
             <g id="108.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-98.80,1315.68 -305.44,1329.15"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-98.80,1315.68 -305.44,1329.15"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-131.23,1317.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-93.73)">
@@ -1958,7 +1958,7 @@
             <desc>T68-69-1</desc>
             <g id="111.1" class="nad-vl120to180-line"></g>
             <g id="111.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-65.46,1340.75 -22.41,1536.90"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-65.46,1340.75 -22.41,1536.90"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-58.49,1372.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(167.62)">

--- a/network-area-diagram/src/test/resources/IEEE_118_bus_partial_non_connected.svg
+++ b/network-area-diagram/src/test/resources/IEEE_118_bus_partial_non_connected.svg
@@ -251,7 +251,7 @@
         <g id="22">
             <desc>L17-113-1</desc>
             <g id="22.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-180.33,380.11 -192.18,171.78"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-180.33,380.11 -192.18,171.78"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-182.17,347.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-3.26)">
@@ -273,7 +273,7 @@
         <g id="23">
             <desc>L32-113-1</desc>
             <g id="23.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-386.91,829.44 -288.92,630.83"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-386.91,829.44 -288.92,630.83"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-372.53,800.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(26.26)">
@@ -292,7 +292,7 @@
                 </g>
             </g>
             <g id="23.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-190.94,432.22 -288.92,630.83"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-190.94,432.22 -288.92,630.83"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-205.31,461.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-153.74)">
@@ -314,7 +314,7 @@
         <g id="24">
             <desc>L32-114-1</desc>
             <g id="24.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-410.18,879.26 -520.47,1129.28"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-410.18,879.26 -520.47,1129.28"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-423.30,909.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-156.20)">
@@ -333,7 +333,7 @@
                 </g>
             </g>
             <g id="24.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-630.77,1379.31 -520.47,1129.28"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-630.77,1379.31 -520.47,1129.28"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-617.65,1349.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(23.80)">
@@ -355,7 +355,7 @@
         <g id="27">
             <desc>L114-115-1</desc>
             <g id="27.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-669.14,1407.94 -816.46,1426.66"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-669.14,1407.94 -816.46,1426.66"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-701.39,1412.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-97.24)">
@@ -377,7 +377,7 @@
         <g id="30">
             <desc>L22-23-1</desc>
             <g id="30.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="107.18,1276.53 191.93,1461.58"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="107.18,1276.53 191.93,1461.58"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(120.71,1306.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.39)">
@@ -399,7 +399,7 @@
         <g id="33">
             <desc>L23-24-1</desc>
             <g id="33.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="123.21,1250.49 317.78,1243.13"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="123.21,1250.49 317.78,1243.13"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(155.69,1249.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(87.83)">
@@ -421,7 +421,7 @@
         <g id="36">
             <desc>L23-25-1</desc>
             <g id="36.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="68.37,1254.27 -92.86,1270.43"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="68.37,1254.27 -92.86,1270.43"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(36.03,1257.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-95.72)">
@@ -443,7 +443,7 @@
         <g id="37">
             <desc>L23-32-1</desc>
             <g id="37.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="74.29,1234.30 -151.68,1052.81"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="74.29,1234.30 -151.68,1052.81"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(48.95,1213.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-51.23)">
@@ -462,7 +462,7 @@
                 </g>
             </g>
             <g id="37.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-377.64,871.32 -151.68,1052.81"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-377.64,871.32 -151.68,1052.81"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-352.30,891.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(128.77)">
@@ -484,7 +484,7 @@
         <g id="38">
             <desc>L25-27-1</desc>
             <g id="38.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-752.12,1083.54 -529.38,1180.93"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-752.12,1083.54 -529.38,1180.93"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-722.34,1096.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(113.62)">
@@ -506,7 +506,7 @@
         <g id="41">
             <desc>L27-28-1</desc>
             <g id="41.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-803.44,1063.94 -995.33,1000.90"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-803.44,1063.94 -995.33,1000.90"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-834.31,1053.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-71.81)">
@@ -528,7 +528,7 @@
         <g id="42">
             <desc>L27-32-1</desc>
             <g id="42.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-753.50,1058.77 -588.20,963.31"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-753.50,1058.77 -588.20,963.31"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-725.35,1042.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(59.99)">
@@ -547,7 +547,7 @@
                 </g>
             </g>
             <g id="42.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-422.89,867.85 -588.20,963.31"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-422.89,867.85 -588.20,963.31"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-451.04,884.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-120.01)">
@@ -569,7 +569,7 @@
         <g id="43">
             <desc>L27-115-1</desc>
             <g id="43.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-790.89,1096.44 -884.19,1260.69"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-790.89,1096.44 -884.19,1260.69"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-806.94,1124.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-150.40)">
@@ -591,7 +591,7 @@
         <g id="46">
             <desc>L8-30-1</desc>
             <g id="46.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="161.47,-716.79 181.09,-925.10"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="161.47,-716.79 181.09,-925.10"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(164.52,-749.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(5.38)">
@@ -613,7 +613,7 @@
         <g id="49">
             <desc>L26-30-1</desc>
             <g id="49.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="181.89,-704.48 366.84,-825.70"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="181.89,-704.48 366.84,-825.70"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(209.07,-722.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(56.76)">
@@ -635,7 +635,7 @@
         <g id="50">
             <desc>L30-38-1</desc>
             <g id="50.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="179.59,-671.30 276.28,-586.74"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="179.59,-671.30 276.28,-586.74"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(204.05,-649.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(131.18)">
@@ -654,7 +654,7 @@
                 </g>
             </g>
             <g id="50.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="372.96,-502.17 276.28,-586.74"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="372.96,-502.17 276.28,-586.74"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(348.50,-523.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-48.82)">
@@ -676,7 +676,7 @@
         <g id="51">
             <desc>T30-17-1</desc>
             <g id="51.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="145.05,-665.65 -8.24,-402.63"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="145.05,-665.65 -8.24,-402.63"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(128.68,-637.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-149.77)">
@@ -703,7 +703,7 @@
         <g id="52">
             <desc>L17-31-1</desc>
             <g id="52.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-588.38,270.66 -407.34,112.38"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-588.38,270.66 -407.34,112.38"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-563.92,249.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.84)">
@@ -725,7 +725,7 @@
         <g id="55">
             <desc>L29-31-1</desc>
             <g id="55.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-635.05,279.68 -821.49,214.53"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-635.05,279.68 -821.49,214.53"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-665.73,268.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-70.74)">
@@ -747,7 +747,7 @@
         <g id="56">
             <desc>L31-32-1</desc>
             <g id="56.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-599.51,314.54 -504.08,571.43"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-599.51,314.54 -504.08,571.43"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-588.19,345.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(159.62)">
@@ -766,7 +766,7 @@
                 </g>
             </g>
             <g id="56.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-408.66,828.32 -504.08,571.43"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-408.66,828.32 -504.08,571.43"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-419.97,797.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-20.38)">
@@ -788,7 +788,7 @@
         <g id="59">
             <desc>L35-37-1</desc>
             <g id="59.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1102.38,-96.34 1048.86,100.04"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1102.38,-96.34 1048.86,100.04"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1093.84,-64.99)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-164.76)">
@@ -810,7 +810,7 @@
         <g id="62">
             <desc>L33-37-1</desc>
             <g id="62.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1126.57,-101.23 1267.79,79.00"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1126.57,-101.23 1267.79,79.00"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1146.62,-75.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(141.92)">
@@ -832,7 +832,7 @@
         <g id="65">
             <desc>L34-37-1</desc>
             <g id="65.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1082.13,-121.85 940.03,-116.57"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1082.13,-121.85 940.03,-116.57"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1049.65,-120.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-92.13)">
@@ -854,7 +854,7 @@
         <g id="68">
             <desc>L37-39-1</desc>
             <g id="68.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1122.48,-147.18 1215.57,-323.09"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1122.48,-147.18 1215.57,-323.09"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1137.68,-175.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(27.89)">
@@ -876,7 +876,7 @@
         <g id="71">
             <desc>L37-40-1</desc>
             <g id="71.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1137.10,-123.74 1350.67,-130.46"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1137.10,-123.74 1350.67,-130.46"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1169.58,-124.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(88.20)">
@@ -898,7 +898,7 @@
         <g id="72">
             <desc>T38-37-1</desc>
             <g id="72.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="418.21,-471.68 724.85,-316.98"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="418.21,-471.68 724.85,-316.98"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(447.23,-457.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(116.77)">
@@ -917,7 +917,7 @@
                 </g>
             </g>
             <g id="72.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1085.06,-135.26 778.42,-289.96"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1085.06,-135.26 778.42,-289.96"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1056.04,-149.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-63.23)">
@@ -943,7 +943,7 @@
         <g id="73">
             <desc>L38-65-1</desc>
             <g id="73.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="370.08,-498.21 29.13,-702.76"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="370.08,-498.21 29.13,-702.76"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(342.21,-514.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-59.04)">
@@ -962,7 +962,7 @@
                 </g>
             </g>
             <g id="73.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-311.82,-907.30 29.13,-702.76"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-311.82,-907.30 29.13,-702.76"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-283.95,-890.58)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(120.96)">
@@ -984,7 +984,7 @@
         <g id="76">
             <desc>L64-65-1</desc>
             <g id="76.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-336.28,-948.94 -342.74,-1151.32"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-336.28,-948.94 -342.74,-1151.32"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-337.32,-981.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-1.83)">
@@ -1006,7 +1006,7 @@
         <g id="79">
             <desc>L65-68-1</desc>
             <g id="79.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-359.51,-934.69 -551.17,-1039.95"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-359.51,-934.69 -551.17,-1039.95"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-388.00,-950.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-61.22)">
@@ -1028,7 +1028,7 @@
         <g id="82">
             <desc>T65-66-1</desc>
             <g id="82.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-359.27,-907.78 -495.05,-829.99"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-359.27,-907.78 -495.05,-829.99"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-387.47,-891.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-119.81)">

--- a/network-area-diagram/src/test/resources/IEEE_14_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus.svg
@@ -167,7 +167,7 @@
         <g id="28">
             <desc>L1-2-1</desc>
             <g id="28.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="522.21,-617.54 556.53,-452.92"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="522.21,-617.54 556.53,-452.92"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(528.85,-585.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(168.22)">
@@ -186,7 +186,7 @@
                 </g>
             </g>
             <g id="28.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="590.85,-288.31 556.53,-452.92"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="590.85,-288.31 556.53,-452.92"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(584.22,-320.13)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-11.78)">
@@ -208,7 +208,7 @@
         <g id="29">
             <desc>L1-5-1</desc>
             <g id="29.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="499.00,-624.45 371.07,-496.24"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="499.00,-624.45 371.07,-496.24"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(476.04,-601.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-135.06)">
@@ -227,7 +227,7 @@
                 </g>
             </g>
             <g id="29.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="243.15,-368.02 371.07,-496.24"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="243.15,-368.02 371.07,-496.24"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(266.10,-391.03)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(44.94)">
@@ -249,7 +249,7 @@
         <g id="30">
             <desc>L9-10-1</desc>
             <g id="30.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-48.76,421.74 -271.14,466.56"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-48.76,421.74 -271.14,466.56"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-80.62,428.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-101.40)">
@@ -268,7 +268,7 @@
                 </g>
             </g>
             <g id="30.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-493.51,511.39 -271.14,466.56"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-493.51,511.39 -271.14,466.56"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-461.65,504.96)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(78.60)">
@@ -290,7 +290,7 @@
         <g id="31">
             <desc>L10-11-1</desc>
             <g id="31.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-530.08,493.70 -619.73,317.52"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-530.08,493.70 -619.73,317.52"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-544.82,464.73)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-26.97)">
@@ -309,7 +309,7 @@
                 </g>
             </g>
             <g id="31.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-709.39,141.34 -619.73,317.52"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-709.39,141.34 -619.73,317.52"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-694.65,170.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(153.03)">
@@ -331,7 +331,7 @@
         <g id="32">
             <desc>L6-11-1</desc>
             <g id="32.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-351.70,-358.58 -528.52,-130.07"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-351.70,-358.58 -528.52,-130.07"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-371.59,-332.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-142.27)">
@@ -350,7 +350,7 @@
                 </g>
             </g>
             <g id="32.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-705.35,98.44 -528.52,-130.07"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-705.35,98.44 -528.52,-130.07"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-685.46,72.74)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(37.73)">
@@ -372,7 +372,7 @@
         <g id="33">
             <desc>L6-12-1</desc>
             <g id="33.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-354.60,-396.29 -485.88,-520.79"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-354.60,-396.29 -485.88,-520.79"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-378.18,-418.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-46.52)">
@@ -391,7 +391,7 @@
                 </g>
             </g>
             <g id="33.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-617.16,-645.28 -485.88,-520.79"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-617.16,-645.28 -485.88,-520.79"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-593.57,-622.92)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(133.48)">
@@ -413,7 +413,7 @@
         <g id="34">
             <desc>L12-13-1</desc>
             <g id="34.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-635.28,-637.33 -632.92,-480.33"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-635.28,-637.33 -632.92,-480.33"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-634.79,-604.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(179.14)">
@@ -432,7 +432,7 @@
                 </g>
             </g>
             <g id="34.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-630.57,-323.32 -632.92,-480.33"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-630.57,-323.32 -632.92,-480.33"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-631.05,-355.82)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-0.86)">
@@ -454,7 +454,7 @@
         <g id="35">
             <desc>L6-13-1</desc>
             <g id="35.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-360.68,-371.98 -483.14,-338.29"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-360.68,-371.98 -483.14,-338.29"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-392.02,-363.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-105.38)">
@@ -473,7 +473,7 @@
                 </g>
             </g>
             <g id="35.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-605.60,-304.59 -483.14,-338.29"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-605.60,-304.59 -483.14,-338.29"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-574.26,-313.21)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(74.62)">
@@ -495,7 +495,7 @@
         <g id="36">
             <desc>L13-14-1</desc>
             <g id="36.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-613.96,-278.15 -469.33,-102.81"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-613.96,-278.15 -469.33,-102.81"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-593.28,-253.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(140.48)">
@@ -514,7 +514,7 @@
                 </g>
             </g>
             <g id="36.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-324.70,72.53 -469.33,-102.81"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-324.70,72.53 -469.33,-102.81"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-345.38,47.46)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-39.52)">
@@ -536,7 +536,7 @@
         <g id="37">
             <desc>L9-14-1</desc>
             <g id="37.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-40.58,397.53 -166.12,254.45"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-40.58,397.53 -166.12,254.45"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-62.02,373.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-41.26)">
@@ -555,7 +555,7 @@
                 </g>
             </g>
             <g id="37.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-291.66,111.37 -166.12,254.45"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-291.66,111.37 -166.12,254.45"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-270.22,135.80)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(138.74)">
@@ -577,7 +577,7 @@
         <g id="38">
             <desc>L2-3-1</desc>
             <g id="38.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="612.02,-243.46 711.96,-118.97"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="612.02,-243.46 711.96,-118.97"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(632.36,-218.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(141.24)">
@@ -596,7 +596,7 @@
                 </g>
             </g>
             <g id="38.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="811.91,5.53 711.96,-118.97"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="811.91,5.53 711.96,-118.97"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(791.57,-19.81)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-38.76)">
@@ -618,7 +618,7 @@
         <g id="39">
             <desc>L2-4-1</desc>
             <g id="39.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="584.80,-240.46 501.00,-69.99"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="584.80,-240.46 501.00,-69.99"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(570.47,-211.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-153.82)">
@@ -637,7 +637,7 @@
                 </g>
             </g>
             <g id="39.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="417.20,100.49 501.00,-69.99"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="417.20,100.49 501.00,-69.99"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(431.54,71.32)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(26.18)">
@@ -659,7 +659,7 @@
         <g id="40">
             <desc>L2-5-1</desc>
             <g id="40.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="571.22,-269.15 410.59,-306.66"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="571.22,-269.15 410.59,-306.66"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(539.57,-276.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-76.85)">
@@ -678,7 +678,7 @@
                 </g>
             </g>
             <g id="40.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="249.97,-344.17 410.59,-306.66"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="249.97,-344.17 410.59,-306.66"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(281.62,-336.78)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(103.15)">
@@ -700,7 +700,7 @@
         <g id="41">
             <desc>L3-4-1</desc>
             <g id="41.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="803.04,31.18 616.91,74.40"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="803.04,31.18 616.91,74.40"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(771.38,38.53)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-103.07)">
@@ -719,7 +719,7 @@
                 </g>
             </g>
             <g id="41.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="430.79,117.61 616.91,74.40"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="430.79,117.61 616.91,74.40"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(462.45,110.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(76.93)">
@@ -741,7 +741,7 @@
         <g id="42">
             <desc>L4-5-1</desc>
             <g id="42.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="396.85,99.55 315.54,-113.30"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="396.85,99.55 315.54,-113.30"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(385.26,69.19)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-20.91)">
@@ -760,7 +760,7 @@
                 </g>
             </g>
             <g id="42.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="234.24,-326.15 315.54,-113.30"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="234.24,-326.15 315.54,-113.30"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(245.83,-295.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(159.09)">
@@ -782,7 +782,7 @@
         <g id="43">
             <desc>T4-7-1</desc>
             <g id="43.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="403.98,148.80 389.82,331.64"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="403.98,148.80 389.82,331.64"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(401.47,181.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-175.57)">
@@ -801,7 +801,7 @@
                 </g>
             </g>
             <g id="43.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="371.03,574.29 385.19,391.46"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="371.03,574.29 385.19,391.46"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(373.54,541.89)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(4.43)">
@@ -827,7 +827,7 @@
         <g id="44">
             <desc>T4-9-1</desc>
             <g id="44.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="384.89,137.75 215.87,253.12"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="384.89,137.75 215.87,253.12"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(358.05,156.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-124.32)">
@@ -846,7 +846,7 @@
                 </g>
             </g>
             <g id="44.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-2.70,402.32 166.32,286.95"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2.70,402.32 166.32,286.95"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(24.14,384.00)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(55.68)">
@@ -872,7 +872,7 @@
         <g id="45">
             <desc>T5-6-1</desc>
             <g id="45.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="199.67,-351.28 -25.52,-362.82"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="199.67,-351.28 -25.52,-362.82"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(167.21,-352.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-87.06)">
@@ -891,7 +891,7 @@
                 </g>
             </g>
             <g id="45.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-310.63,-377.44 -85.44,-365.90"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-310.63,-377.44 -85.44,-365.90"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-278.17,-375.78)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(92.94)">
@@ -917,7 +917,7 @@
         <g id="46">
             <desc>L7-8-1</desc>
             <g id="46.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="381.02,622.24 468.84,787.59"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="381.02,622.24 468.84,787.59"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(396.27,650.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(152.03)">
@@ -936,7 +936,7 @@
                 </g>
             </g>
             <g id="46.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="556.67,952.94 468.84,787.59"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="556.67,952.94 468.84,787.59"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(541.42,924.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-27.97)">
@@ -958,7 +958,7 @@
         <g id="47">
             <desc>L7-9-1</desc>
             <g id="47.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="345.94,588.95 172.65,508.21"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="345.94,588.95 172.65,508.21"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(316.48,575.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-65.02)">
@@ -977,7 +977,7 @@
                 </g>
             </g>
             <g id="47.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-0.65,427.47 172.65,508.21"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-0.65,427.47 172.65,508.21"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(28.81,441.19)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(114.98)">

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_disconnection.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_disconnection.svg
@@ -166,7 +166,7 @@
         <g id="27">
             <desc>L1-2-1</desc>
             <g id="27.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="522.21,-617.54 556.53,-452.92"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="522.21,-617.54 556.53,-452.92"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(528.85,-585.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(168.22)">
@@ -185,7 +185,7 @@
                 </g>
             </g>
             <g id="27.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="590.85,-288.31 556.53,-452.92"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="590.85,-288.31 556.53,-452.92"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(584.22,-320.13)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-11.78)">
@@ -207,7 +207,7 @@
         <g id="28">
             <desc>L1-5-1</desc>
             <g id="28.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="499.00,-624.45 371.07,-496.24"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="499.00,-624.45 371.07,-496.24"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(476.04,-601.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-135.06)">
@@ -226,7 +226,7 @@
                 </g>
             </g>
             <g id="28.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="243.15,-368.02 371.07,-496.24"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="243.15,-368.02 371.07,-496.24"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(266.10,-391.03)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(44.94)">
@@ -248,7 +248,7 @@
         <g id="29">
             <desc>L9-10-1</desc>
             <g id="29.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-48.76,421.74 -271.14,466.56"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-48.76,421.74 -271.14,466.56"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-80.62,428.16)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-101.40)">
@@ -267,7 +267,7 @@
                 </g>
             </g>
             <g id="29.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-493.51,511.39 -271.14,466.56"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-493.51,511.39 -271.14,466.56"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-461.65,504.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(78.60)">
@@ -289,7 +289,7 @@
         <g id="30">
             <desc>L10-11-1</desc>
             <g id="30.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-530.08,493.70 -619.73,317.52"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-530.08,493.70 -619.73,317.52"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-544.82,464.73)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-26.97)">
@@ -308,7 +308,7 @@
                 </g>
             </g>
             <g id="30.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-709.39,141.34 -619.73,317.52"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-709.39,141.34 -619.73,317.52"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-694.65,170.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(153.03)">
@@ -330,7 +330,7 @@
         <g id="31">
             <desc>L6-11-1</desc>
             <g id="31.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-351.70,-358.58 -528.52,-130.07"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-351.70,-358.58 -528.52,-130.07"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-371.59,-332.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-142.27)">
@@ -349,7 +349,7 @@
                 </g>
             </g>
             <g id="31.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-705.35,98.44 -528.52,-130.07"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-705.35,98.44 -528.52,-130.07"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-685.46,72.74)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(37.73)">
@@ -371,7 +371,7 @@
         <g id="32">
             <desc>L6-12-1</desc>
             <g id="32.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-354.60,-396.29 -485.88,-520.79"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-354.60,-396.29 -485.88,-520.79"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-378.18,-418.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-46.52)">
@@ -390,7 +390,7 @@
                 </g>
             </g>
             <g id="32.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-617.16,-645.28 -485.88,-520.79"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-617.16,-645.28 -485.88,-520.79"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-593.57,-622.92)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(133.48)">
@@ -412,7 +412,7 @@
         <g id="33">
             <desc>L12-13-1</desc>
             <g id="33.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-635.28,-637.33 -632.92,-480.33"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-635.28,-637.33 -632.92,-480.33"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-634.79,-604.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(179.14)">
@@ -431,7 +431,7 @@
                 </g>
             </g>
             <g id="33.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-630.57,-323.32 -632.92,-480.33"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-630.57,-323.32 -632.92,-480.33"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-631.05,-355.82)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-0.86)">
@@ -453,7 +453,7 @@
         <g id="34">
             <desc>L6-13-1</desc>
             <g id="34.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-360.68,-371.98 -483.14,-338.29"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-360.68,-371.98 -483.14,-338.29"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-392.02,-363.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-105.38)">
@@ -472,7 +472,7 @@
                 </g>
             </g>
             <g id="34.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-605.60,-304.59 -483.14,-338.29"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-605.60,-304.59 -483.14,-338.29"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-574.26,-313.21)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(74.62)">
@@ -494,7 +494,7 @@
         <g id="35" class="nad-disconnected">
             <desc>L13-14-1</desc>
             <g id="35.1" class="nad-disconnected nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-613.96,-278.15 -473.94,-108.41"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-613.96,-278.15 -473.94,-108.41"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-593.28,-253.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(140.48)">
@@ -513,7 +513,7 @@
                 </g>
             </g>
             <g id="35.2" class="nad-disconnected nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-333.93,61.34 -473.94,-108.41"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-333.93,61.34 -473.94,-108.41"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-354.61,36.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-39.52)">
@@ -535,7 +535,7 @@
         <g id="36" class="nad-disconnected">
             <desc>L9-14-1</desc>
             <g id="36.1" class="nad-disconnected nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-40.58,397.53 -161.34,259.90"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-40.58,397.53 -161.34,259.90"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-62.02,373.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-41.26)">
@@ -554,7 +554,7 @@
                 </g>
             </g>
             <g id="36.2" class="nad-disconnected nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-282.09,122.27 -161.34,259.90"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-282.09,122.27 -161.34,259.90"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-260.66,146.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(138.74)">
@@ -576,7 +576,7 @@
         <g id="37">
             <desc>L2-3-1</desc>
             <g id="37.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="612.02,-243.46 711.96,-118.97"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="612.02,-243.46 711.96,-118.97"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(632.36,-218.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(141.24)">
@@ -595,7 +595,7 @@
                 </g>
             </g>
             <g id="37.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="811.91,5.53 711.96,-118.97"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="811.91,5.53 711.96,-118.97"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(791.57,-19.81)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-38.76)">
@@ -617,7 +617,7 @@
         <g id="38">
             <desc>L2-4-1</desc>
             <g id="38.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="584.80,-240.46 501.00,-69.99"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="584.80,-240.46 501.00,-69.99"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(570.47,-211.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-153.82)">
@@ -636,7 +636,7 @@
                 </g>
             </g>
             <g id="38.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="417.20,100.49 501.00,-69.99"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="417.20,100.49 501.00,-69.99"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(431.54,71.32)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(26.18)">
@@ -658,7 +658,7 @@
         <g id="39">
             <desc>L2-5-1</desc>
             <g id="39.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="571.22,-269.15 410.59,-306.66"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="571.22,-269.15 410.59,-306.66"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(539.57,-276.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-76.85)">
@@ -677,7 +677,7 @@
                 </g>
             </g>
             <g id="39.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="249.97,-344.17 410.59,-306.66"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="249.97,-344.17 410.59,-306.66"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(281.62,-336.78)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(103.15)">
@@ -699,7 +699,7 @@
         <g id="40">
             <desc>L3-4-1</desc>
             <g id="40.1" class="nad-disconnected nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="803.04,31.18 616.91,74.40"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="803.04,31.18 616.91,74.40"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(771.38,38.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-103.07)">
@@ -718,7 +718,7 @@
                 </g>
             </g>
             <g id="40.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="430.79,117.61 616.91,74.40"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="430.79,117.61 616.91,74.40"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(462.45,110.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(76.93)">
@@ -740,7 +740,7 @@
         <g id="41">
             <desc>L4-5-1</desc>
             <g id="41.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="396.85,99.55 315.54,-113.30"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="396.85,99.55 315.54,-113.30"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(385.26,69.19)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-20.91)">
@@ -759,7 +759,7 @@
                 </g>
             </g>
             <g id="41.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="234.24,-326.15 315.54,-113.30"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="234.24,-326.15 315.54,-113.30"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(245.83,-295.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(159.09)">
@@ -781,7 +781,7 @@
         <g id="42">
             <desc>T4-7-1</desc>
             <g id="42.1" class="nad-disconnected nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="403.98,148.80 389.82,331.64"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="403.98,148.80 389.82,331.64"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(401.47,181.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-175.57)">
@@ -800,7 +800,7 @@
                 </g>
             </g>
             <g id="42.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="371.03,574.29 385.19,391.46"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="371.03,574.29 385.19,391.46"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(373.54,541.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(4.43)">
@@ -826,7 +826,7 @@
         <g id="43">
             <desc>T4-9-1</desc>
             <g id="43.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="384.89,137.75 215.87,253.12"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="384.89,137.75 215.87,253.12"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(358.05,156.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-124.32)">
@@ -845,7 +845,7 @@
                 </g>
             </g>
             <g id="43.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-2.70,402.32 166.32,286.95"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2.70,402.32 166.32,286.95"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(24.14,384.00)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(55.68)">
@@ -871,7 +871,7 @@
         <g id="44">
             <desc>T5-6-1</desc>
             <g id="44.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="199.67,-351.28 -25.52,-362.82"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="199.67,-351.28 -25.52,-362.82"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(167.21,-352.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-87.06)">
@@ -890,7 +890,7 @@
                 </g>
             </g>
             <g id="44.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-310.63,-377.44 -85.44,-365.90"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-310.63,-377.44 -85.44,-365.90"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-278.17,-375.78)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(92.94)">
@@ -916,7 +916,7 @@
         <g id="45">
             <desc>L7-8-1</desc>
             <g id="45.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="381.02,622.24 468.84,787.59"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="381.02,622.24 468.84,787.59"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(396.27,650.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(152.03)">
@@ -935,7 +935,7 @@
                 </g>
             </g>
             <g id="45.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="556.67,952.94 468.84,787.59"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="556.67,952.94 468.84,787.59"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(541.42,924.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-27.97)">
@@ -957,7 +957,7 @@
         <g id="46">
             <desc>L7-9-1</desc>
             <g id="46.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="345.94,588.95 172.65,508.21"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="345.94,588.95 172.65,508.21"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(316.48,575.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-65.02)">
@@ -976,7 +976,7 @@
                 </g>
             </g>
             <g id="46.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-0.65,427.47 172.65,508.21"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-0.65,427.47 172.65,508.21"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(28.81,441.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(114.98)">

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_fictitious.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_fictitious.svg
@@ -167,7 +167,7 @@
         <g id="28">
             <desc>L1-2-1</desc>
             <g id="28.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="522.21,-617.54 556.53,-452.92"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="522.21,-617.54 556.53,-452.92"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(528.85,-585.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(168.22)">
@@ -186,7 +186,7 @@
                 </g>
             </g>
             <g id="28.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="590.85,-288.31 556.53,-452.92"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="590.85,-288.31 556.53,-452.92"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(584.22,-320.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-11.78)">
@@ -208,7 +208,7 @@
         <g id="29">
             <desc>L1-5-1</desc>
             <g id="29.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="499.00,-624.45 371.07,-496.24"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="499.00,-624.45 371.07,-496.24"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(476.04,-601.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-135.06)">
@@ -227,7 +227,7 @@
                 </g>
             </g>
             <g id="29.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="243.15,-368.02 371.07,-496.24"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="243.15,-368.02 371.07,-496.24"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(266.10,-391.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(44.94)">
@@ -249,7 +249,7 @@
         <g id="30">
             <desc>L9-10-1</desc>
             <g id="30.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-48.76,421.74 -271.14,466.56"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-48.76,421.74 -271.14,466.56"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-80.62,428.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-101.40)">
@@ -268,7 +268,7 @@
                 </g>
             </g>
             <g id="30.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-493.51,511.39 -271.14,466.56"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-493.51,511.39 -271.14,466.56"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-461.65,504.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(78.60)">
@@ -290,7 +290,7 @@
         <g id="31">
             <desc>L10-11-1</desc>
             <g id="31.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-530.08,493.70 -619.73,317.52"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-530.08,493.70 -619.73,317.52"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-544.82,464.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-26.97)">
@@ -309,7 +309,7 @@
                 </g>
             </g>
             <g id="31.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-709.39,141.34 -619.73,317.52"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-709.39,141.34 -619.73,317.52"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-694.65,170.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(153.03)">
@@ -331,7 +331,7 @@
         <g id="32">
             <desc>L6-11-1</desc>
             <g id="32.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-351.70,-358.58 -528.52,-130.07"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-351.70,-358.58 -528.52,-130.07"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-371.59,-332.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-142.27)">
@@ -350,7 +350,7 @@
                 </g>
             </g>
             <g id="32.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-705.35,98.44 -528.52,-130.07"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-705.35,98.44 -528.52,-130.07"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-685.46,72.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(37.73)">
@@ -372,7 +372,7 @@
         <g id="33">
             <desc>L6-12-1</desc>
             <g id="33.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-354.60,-396.29 -491.32,-525.95"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-354.60,-396.29 -491.32,-525.95"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-378.18,-418.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-46.52)">
@@ -391,7 +391,7 @@
                 </g>
             </g>
             <g id="33.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-628.04,-655.60 -491.32,-525.95"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-628.04,-655.60 -491.32,-525.95"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-604.46,-633.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(133.48)">
@@ -413,7 +413,7 @@
         <g id="34">
             <desc>L12-13-1</desc>
             <g id="34.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-635.50,-652.33 -633.03,-487.83"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-635.50,-652.33 -633.03,-487.83"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-635.01,-619.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(179.14)">
@@ -432,7 +432,7 @@
                 </g>
             </g>
             <g id="34.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-630.57,-323.32 -633.03,-487.83"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-630.57,-323.32 -633.03,-487.83"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-631.05,-355.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-0.86)">
@@ -454,7 +454,7 @@
         <g id="35">
             <desc>L6-13-1</desc>
             <g id="35.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-360.68,-371.98 -483.14,-338.29"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-360.68,-371.98 -483.14,-338.29"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-392.02,-363.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-105.38)">
@@ -473,7 +473,7 @@
                 </g>
             </g>
             <g id="35.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-605.60,-304.59 -483.14,-338.29"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-605.60,-304.59 -483.14,-338.29"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-574.26,-313.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(74.62)">
@@ -495,7 +495,7 @@
         <g id="36">
             <desc>L13-14-1</desc>
             <g id="36.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-613.96,-278.15 -464.56,-97.03"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-613.96,-278.15 -464.56,-97.03"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-593.28,-253.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(140.48)">
@@ -514,7 +514,7 @@
                 </g>
             </g>
             <g id="36.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-315.16,84.10 -464.56,-97.03"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-315.16,84.10 -464.56,-97.03"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-335.84,59.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-39.52)">
@@ -536,7 +536,7 @@
         <g id="37">
             <desc>L9-14-1</desc>
             <g id="37.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-40.58,397.53 -171.07,248.81"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-40.58,397.53 -171.07,248.81"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-62.02,373.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-41.26)">
@@ -555,7 +555,7 @@
                 </g>
             </g>
             <g id="37.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-301.55,100.09 -171.07,248.81"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-301.55,100.09 -171.07,248.81"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-280.12,124.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(138.74)">
@@ -577,7 +577,7 @@
         <g id="38">
             <desc>L2-3-1</desc>
             <g id="38.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="612.02,-243.46 711.96,-118.97"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="612.02,-243.46 711.96,-118.97"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(632.36,-218.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(141.24)">
@@ -596,7 +596,7 @@
                 </g>
             </g>
             <g id="38.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="811.91,5.53 711.96,-118.97"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="811.91,5.53 711.96,-118.97"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(791.57,-19.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-38.76)">
@@ -618,7 +618,7 @@
         <g id="39">
             <desc>L2-4-1</desc>
             <g id="39.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="584.80,-240.46 501.00,-69.99"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="584.80,-240.46 501.00,-69.99"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(570.47,-211.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-153.82)">
@@ -637,7 +637,7 @@
                 </g>
             </g>
             <g id="39.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="417.20,100.49 501.00,-69.99"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="417.20,100.49 501.00,-69.99"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(431.54,71.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(26.18)">
@@ -659,7 +659,7 @@
         <g id="40">
             <desc>L2-5-1</desc>
             <g id="40.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="571.22,-269.15 410.59,-306.66"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="571.22,-269.15 410.59,-306.66"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(539.57,-276.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-76.85)">
@@ -678,7 +678,7 @@
                 </g>
             </g>
             <g id="40.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="249.97,-344.17 410.59,-306.66"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="249.97,-344.17 410.59,-306.66"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(281.62,-336.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(103.15)">
@@ -700,7 +700,7 @@
         <g id="41">
             <desc>L3-4-1</desc>
             <g id="41.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="803.04,31.18 616.91,74.40"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="803.04,31.18 616.91,74.40"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(771.38,38.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-103.07)">
@@ -719,7 +719,7 @@
                 </g>
             </g>
             <g id="41.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="430.79,117.61 616.91,74.40"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="430.79,117.61 616.91,74.40"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(462.45,110.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(76.93)">
@@ -741,7 +741,7 @@
         <g id="42">
             <desc>L4-5-1</desc>
             <g id="42.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="396.85,99.55 315.54,-113.30"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="396.85,99.55 315.54,-113.30"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(385.26,69.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-20.91)">
@@ -760,7 +760,7 @@
                 </g>
             </g>
             <g id="42.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="234.24,-326.15 315.54,-113.30"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="234.24,-326.15 315.54,-113.30"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(245.83,-295.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(159.09)">
@@ -782,7 +782,7 @@
         <g id="43">
             <desc>T4-7-1</desc>
             <g id="43.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="403.98,148.80 389.82,331.64"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="403.98,148.80 389.82,331.64"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(401.47,181.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-175.57)">
@@ -801,7 +801,7 @@
                 </g>
             </g>
             <g id="43.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="371.03,574.29 385.19,391.46"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="371.03,574.29 385.19,391.46"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(373.54,541.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(4.43)">
@@ -827,7 +827,7 @@
         <g id="44">
             <desc>T4-9-1</desc>
             <g id="44.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="384.89,137.75 215.87,253.12"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="384.89,137.75 215.87,253.12"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(358.05,156.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-124.32)">
@@ -846,7 +846,7 @@
                 </g>
             </g>
             <g id="44.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-2.70,402.32 166.32,286.95"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2.70,402.32 166.32,286.95"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(24.14,384.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(55.68)">
@@ -872,7 +872,7 @@
         <g id="45">
             <desc>T5-6-1</desc>
             <g id="45.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="199.67,-351.28 -25.52,-362.82"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="199.67,-351.28 -25.52,-362.82"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(167.21,-352.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-87.06)">
@@ -891,7 +891,7 @@
                 </g>
             </g>
             <g id="45.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-310.63,-377.44 -85.44,-365.90"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-310.63,-377.44 -85.44,-365.90"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-278.17,-375.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(92.94)">
@@ -917,7 +917,7 @@
         <g id="46">
             <desc>L7-8-1</desc>
             <g id="46.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="381.02,622.24 468.84,787.59"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="381.02,622.24 468.84,787.59"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(396.27,650.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(152.03)">
@@ -936,7 +936,7 @@
                 </g>
             </g>
             <g id="46.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="556.67,952.94 468.84,787.59"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="556.67,952.94 468.84,787.59"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(541.42,924.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-27.97)">
@@ -958,7 +958,7 @@
         <g id="47">
             <desc>L7-9-1</desc>
             <g id="47.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="345.94,588.95 172.65,508.21"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="345.94,588.95 172.65,508.21"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(316.48,575.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-65.02)">
@@ -977,7 +977,7 @@
                 </g>
             </g>
             <g id="47.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-0.65,427.47 172.65,508.21"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-0.65,427.47 172.65,508.21"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(28.81,441.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(114.98)">

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_text_nodes.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_text_nodes.svg
@@ -167,7 +167,7 @@
         <g id="28">
             <desc>L1-2-1</desc>
             <g id="28.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="974.70,470.51 934.52,257.19"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="974.70,470.51 934.52,257.19"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(968.69,438.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-10.67)">
@@ -186,7 +186,7 @@
                 </g>
             </g>
             <g id="28.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="894.33,43.87 934.52,257.19"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="894.33,43.87 934.52,257.19"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(900.34,75.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(169.33)">
@@ -208,7 +208,7 @@
         <g id="29">
             <desc>L1-5-1</desc>
             <g id="29.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="961.14,477.79 810.94,331.77"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="961.14,477.79 810.94,331.77"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(937.84,455.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-45.81)">
@@ -227,7 +227,7 @@
                 </g>
             </g>
             <g id="29.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="660.74,185.74 810.94,331.77"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="660.74,185.74 810.94,331.77"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(684.05,208.40)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(134.19)">
@@ -249,7 +249,7 @@
         <g id="30">
             <desc>L9-10-1</desc>
             <g id="30.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-330.09,463.57 -673.91,246.06"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-330.09,463.57 -673.91,246.06"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-357.55,446.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-57.68)">
@@ -268,7 +268,7 @@
                 </g>
             </g>
             <g id="30.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-1017.72,28.54 -673.91,246.06"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1017.72,28.54 -673.91,246.06"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-990.26,45.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(122.32)">
@@ -290,7 +290,7 @@
         <g id="31">
             <desc>L10-11-1</desc>
             <g id="31.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-1031.40,-9.35 -959.24,-231.81"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1031.40,-9.35 -959.24,-231.81"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1021.38,-40.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(17.97)">
@@ -309,7 +309,7 @@
                 </g>
             </g>
             <g id="31.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-887.07,-454.28 -959.24,-231.81"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-887.07,-454.28 -959.24,-231.81"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-897.10,-423.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-162.03)">
@@ -331,7 +331,7 @@
         <g id="32">
             <desc>L6-11-1</desc>
             <g id="32.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-225.48,-397.99 -539.69,-436.70"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-225.48,-397.99 -539.69,-436.70"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-257.74,-401.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-82.98)">
@@ -350,7 +350,7 @@
                 </g>
             </g>
             <g id="32.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-853.90,-475.41 -539.69,-436.70"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-853.90,-475.41 -539.69,-436.70"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-821.64,-471.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(97.02)">
@@ -372,7 +372,7 @@
         <g id="33">
             <desc>L6-12-1</desc>
             <g id="33.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-193.19,-419.39 -156.07,-549.82"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-193.19,-419.39 -156.07,-549.82"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-184.30,-450.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(15.89)">
@@ -391,7 +391,7 @@
                 </g>
             </g>
             <g id="33.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-118.95,-680.24 -156.07,-549.82"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-118.95,-680.24 -156.07,-549.82"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-127.85,-648.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-164.11)">
@@ -413,7 +413,7 @@
         <g id="34">
             <desc>L12-13-1</desc>
             <g id="34.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-123.43,-681.99 -255.81,-418.86"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-123.43,-681.99 -255.81,-418.86"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-138.03,-652.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-153.29)">
@@ -432,7 +432,7 @@
                 </g>
             </g>
             <g id="34.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-388.20,-155.73 -255.81,-418.86"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-388.20,-155.73 -255.81,-418.86"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-373.59,-184.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(26.71)">
@@ -454,7 +454,7 @@
         <g id="35">
             <desc>L6-13-1</desc>
             <g id="35.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-215.63,-374.58 -299.92,-263.91"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-215.63,-374.58 -299.92,-263.91"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-235.32,-348.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-142.71)">
@@ -473,7 +473,7 @@
                 </g>
             </g>
             <g id="35.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-384.21,-153.24 -299.92,-263.91"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-384.21,-153.24 -299.92,-263.91"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-364.52,-179.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(37.29)">
@@ -495,7 +495,7 @@
         <g id="36">
             <desc>L13-14-1</desc>
             <g id="36.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-411.53,-110.38 -555.78,163.99"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-411.53,-110.38 -555.78,163.99"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-426.65,-81.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-152.27)">
@@ -514,7 +514,7 @@
                 </g>
             </g>
             <g id="36.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-700.03,438.37 -555.78,163.99"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-700.03,438.37 -555.78,163.99"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-684.90,409.60)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(27.73)">
@@ -536,7 +536,7 @@
         <g id="37">
             <desc>L9-14-1</desc>
             <g id="37.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-334.02,476.18 -510.22,469.07"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-334.02,476.18 -510.22,469.07"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-366.49,474.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-87.69)">
@@ -555,7 +555,7 @@
                 </g>
             </g>
             <g id="37.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-686.41,461.97 -510.22,469.07"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-686.41,461.97 -510.22,469.07"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-653.94,463.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(92.31)">
@@ -577,7 +577,7 @@
         <g id="38">
             <desc>L2-3-1</desc>
             <g id="38.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="871.83,0.52 712.87,-163.04"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="871.83,0.52 712.87,-163.04"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(849.18,-22.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-44.18)">
@@ -596,7 +596,7 @@
                 </g>
             </g>
             <g id="38.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="553.90,-326.61 712.87,-163.04"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="553.90,-326.61 712.87,-163.04"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(576.56,-303.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(135.82)">
@@ -618,7 +618,7 @@
         <g id="39">
             <desc>L2-4-1</desc>
             <g id="39.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="864.87,24.99 623.87,85.21"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="864.87,24.99 623.87,85.21"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(833.34,32.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-104.03)">
@@ -637,7 +637,7 @@
                 </g>
             </g>
             <g id="39.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="382.88,145.43 623.87,85.21"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="382.88,145.43 623.87,85.21"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(414.41,137.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(75.97)">
@@ -659,7 +659,7 @@
         <g id="40">
             <desc>L2-5-1</desc>
             <g id="40.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="867.77,31.99 766.03,93.39"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="867.77,31.99 766.03,93.39"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(839.95,48.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-121.11)">
@@ -678,7 +678,7 @@
                 </g>
             </g>
             <g id="40.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="664.29,154.79 766.03,93.39"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="664.29,154.79 766.03,93.39"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(692.12,138.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(58.89)">
@@ -700,7 +700,7 @@
         <g id="41">
             <desc>L3-4-1</desc>
             <g id="41.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="527.53,-320.89 447.14,-96.64"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="527.53,-320.89 447.14,-96.64"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(516.56,-290.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-160.28)">
@@ -719,7 +719,7 @@
                 </g>
             </g>
             <g id="41.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="366.74,127.60 447.14,-96.64"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="366.74,127.60 447.14,-96.64"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(377.71,97.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(19.72)">
@@ -741,7 +741,7 @@
         <g id="42">
             <desc>L4-5-1</desc>
             <g id="42.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="383.60,153.07 500.30,159.79"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="383.60,153.07 500.30,159.79"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(416.04,154.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(93.29)">
@@ -760,7 +760,7 @@
                 </g>
             </g>
             <g id="42.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="617.00,166.50 500.30,159.79"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="617.00,166.50 500.30,159.79"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(584.56,164.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-86.71)">
@@ -782,7 +782,7 @@
         <g id="43">
             <desc>T4-7-1</desc>
             <g id="43.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="350.48,175.93 266.82,441.57"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="350.48,175.93 266.82,441.57"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(340.72,206.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-162.52)">
@@ -801,7 +801,7 @@
                 </g>
             </g>
             <g id="43.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="165.13,764.44 248.80,498.80"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="165.13,764.44 248.80,498.80"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(174.90,733.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(17.48)">
@@ -827,7 +827,7 @@
         <g id="44">
             <desc>T4-9-1</desc>
             <g id="44.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="335.23,162.80 51.76,301.24"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="335.23,162.80 51.76,301.24"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(306.02,177.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-116.03)">
@@ -846,7 +846,7 @@
                 </g>
             </g>
             <g id="44.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-285.63,466.02 -2.16,327.57"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-285.63,466.02 -2.16,327.57"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-256.42,451.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(63.97)">
@@ -872,7 +872,7 @@
         <g id="45">
             <desc>T5-6-1</desc>
             <g id="45.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="621.26,153.81 246.09,-96.79"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="621.26,153.81 246.09,-96.79"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(594.23,135.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-56.26)">
@@ -891,7 +891,7 @@
                 </g>
             </g>
             <g id="45.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-178.97,-380.70 196.20,-130.11"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-178.97,-380.70 196.20,-130.11"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-151.94,-362.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(123.74)">
@@ -917,7 +917,7 @@
         <g id="46">
             <desc>L7-8-1</desc>
             <g id="46.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="171.39,810.13 313.05,1027.61"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="171.39,810.13 313.05,1027.61"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(189.13,837.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(146.92)">
@@ -936,7 +936,7 @@
                 </g>
             </g>
             <g id="46.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="454.71,1245.09 313.05,1027.61"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="454.71,1245.09 313.05,1027.61"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(436.97,1217.86)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-33.08)">
@@ -958,7 +958,7 @@
         <g id="47">
             <desc>L7-9-1</desc>
             <g id="47.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="136.28,774.59 -75.53,632.98"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="136.28,774.59 -75.53,632.98"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(109.26,756.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-56.24)">
@@ -977,7 +977,7 @@
                 </g>
             </g>
             <g id="47.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-287.34,491.38 -75.53,632.98"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-287.34,491.38 -75.53,632.98"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-260.32,509.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(123.76)">

--- a/network-area-diagram/src/test/resources/IEEE_14_id_prefixed.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_id_prefixed.svg
@@ -167,7 +167,7 @@
         <g id="test_28">
             <desc>L1-2-1</desc>
             <g id="test_28.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="522.21,-617.54 556.53,-452.92"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="522.21,-617.54 556.53,-452.92"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(528.85,-585.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(168.22)">
@@ -186,7 +186,7 @@
                 </g>
             </g>
             <g id="test_28.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="590.85,-288.31 556.53,-452.92"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="590.85,-288.31 556.53,-452.92"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(584.22,-320.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-11.78)">
@@ -208,7 +208,7 @@
         <g id="test_29">
             <desc>L1-5-1</desc>
             <g id="test_29.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="499.00,-624.45 371.07,-496.24"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="499.00,-624.45 371.07,-496.24"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(476.04,-601.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-135.06)">
@@ -227,7 +227,7 @@
                 </g>
             </g>
             <g id="test_29.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="243.15,-368.02 371.07,-496.24"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="243.15,-368.02 371.07,-496.24"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(266.10,-391.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(44.94)">
@@ -249,7 +249,7 @@
         <g id="test_30">
             <desc>L9-10-1</desc>
             <g id="test_30.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-48.76,421.74 -271.14,466.56"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-48.76,421.74 -271.14,466.56"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-80.62,428.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-101.40)">
@@ -268,7 +268,7 @@
                 </g>
             </g>
             <g id="test_30.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-493.51,511.39 -271.14,466.56"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-493.51,511.39 -271.14,466.56"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-461.65,504.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(78.60)">
@@ -290,7 +290,7 @@
         <g id="test_31">
             <desc>L10-11-1</desc>
             <g id="test_31.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-530.08,493.70 -619.73,317.52"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-530.08,493.70 -619.73,317.52"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-544.82,464.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-26.97)">
@@ -309,7 +309,7 @@
                 </g>
             </g>
             <g id="test_31.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-709.39,141.34 -619.73,317.52"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-709.39,141.34 -619.73,317.52"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-694.65,170.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(153.03)">
@@ -331,7 +331,7 @@
         <g id="test_32">
             <desc>L6-11-1</desc>
             <g id="test_32.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-351.70,-358.58 -528.52,-130.07"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-351.70,-358.58 -528.52,-130.07"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-371.59,-332.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-142.27)">
@@ -350,7 +350,7 @@
                 </g>
             </g>
             <g id="test_32.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-705.35,98.44 -528.52,-130.07"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-705.35,98.44 -528.52,-130.07"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-685.46,72.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(37.73)">
@@ -372,7 +372,7 @@
         <g id="test_33">
             <desc>L6-12-1</desc>
             <g id="test_33.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-354.60,-396.29 -485.88,-520.79"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-354.60,-396.29 -485.88,-520.79"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-378.18,-418.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-46.52)">
@@ -391,7 +391,7 @@
                 </g>
             </g>
             <g id="test_33.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-617.16,-645.28 -485.88,-520.79"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-617.16,-645.28 -485.88,-520.79"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-593.57,-622.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(133.48)">
@@ -413,7 +413,7 @@
         <g id="test_34">
             <desc>L12-13-1</desc>
             <g id="test_34.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-635.28,-637.33 -632.92,-480.33"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-635.28,-637.33 -632.92,-480.33"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-634.79,-604.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(179.14)">
@@ -432,7 +432,7 @@
                 </g>
             </g>
             <g id="test_34.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-630.57,-323.32 -632.92,-480.33"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-630.57,-323.32 -632.92,-480.33"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-631.05,-355.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-0.86)">
@@ -454,7 +454,7 @@
         <g id="test_35">
             <desc>L6-13-1</desc>
             <g id="test_35.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-360.68,-371.98 -483.14,-338.29"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-360.68,-371.98 -483.14,-338.29"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-392.02,-363.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-105.38)">
@@ -473,7 +473,7 @@
                 </g>
             </g>
             <g id="test_35.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-605.60,-304.59 -483.14,-338.29"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-605.60,-304.59 -483.14,-338.29"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-574.26,-313.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(74.62)">
@@ -495,7 +495,7 @@
         <g id="test_36">
             <desc>L13-14-1</desc>
             <g id="test_36.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-613.96,-278.15 -469.33,-102.81"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-613.96,-278.15 -469.33,-102.81"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-593.28,-253.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(140.48)">
@@ -514,7 +514,7 @@
                 </g>
             </g>
             <g id="test_36.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-324.70,72.53 -469.33,-102.81"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-324.70,72.53 -469.33,-102.81"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-345.38,47.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-39.52)">
@@ -536,7 +536,7 @@
         <g id="test_37">
             <desc>L9-14-1</desc>
             <g id="test_37.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-40.58,397.53 -166.12,254.45"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-40.58,397.53 -166.12,254.45"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-62.02,373.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-41.26)">
@@ -555,7 +555,7 @@
                 </g>
             </g>
             <g id="test_37.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-291.66,111.37 -166.12,254.45"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-291.66,111.37 -166.12,254.45"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-270.22,135.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(138.74)">
@@ -577,7 +577,7 @@
         <g id="test_38">
             <desc>L2-3-1</desc>
             <g id="test_38.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="612.02,-243.46 711.96,-118.97"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="612.02,-243.46 711.96,-118.97"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(632.36,-218.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(141.24)">
@@ -596,7 +596,7 @@
                 </g>
             </g>
             <g id="test_38.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="811.91,5.53 711.96,-118.97"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="811.91,5.53 711.96,-118.97"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(791.57,-19.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-38.76)">
@@ -618,7 +618,7 @@
         <g id="test_39">
             <desc>L2-4-1</desc>
             <g id="test_39.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="584.80,-240.46 501.00,-69.99"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="584.80,-240.46 501.00,-69.99"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(570.47,-211.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-153.82)">
@@ -637,7 +637,7 @@
                 </g>
             </g>
             <g id="test_39.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="417.20,100.49 501.00,-69.99"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="417.20,100.49 501.00,-69.99"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(431.54,71.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(26.18)">
@@ -659,7 +659,7 @@
         <g id="test_40">
             <desc>L2-5-1</desc>
             <g id="test_40.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="571.22,-269.15 410.59,-306.66"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="571.22,-269.15 410.59,-306.66"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(539.57,-276.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-76.85)">
@@ -678,7 +678,7 @@
                 </g>
             </g>
             <g id="test_40.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="249.97,-344.17 410.59,-306.66"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="249.97,-344.17 410.59,-306.66"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(281.62,-336.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(103.15)">
@@ -700,7 +700,7 @@
         <g id="test_41">
             <desc>L3-4-1</desc>
             <g id="test_41.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="803.04,31.18 616.91,74.40"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="803.04,31.18 616.91,74.40"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(771.38,38.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-103.07)">
@@ -719,7 +719,7 @@
                 </g>
             </g>
             <g id="test_41.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="430.79,117.61 616.91,74.40"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="430.79,117.61 616.91,74.40"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(462.45,110.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(76.93)">
@@ -741,7 +741,7 @@
         <g id="test_42">
             <desc>L4-5-1</desc>
             <g id="test_42.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="396.85,99.55 315.54,-113.30"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="396.85,99.55 315.54,-113.30"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(385.26,69.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-20.91)">
@@ -760,7 +760,7 @@
                 </g>
             </g>
             <g id="test_42.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="234.24,-326.15 315.54,-113.30"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="234.24,-326.15 315.54,-113.30"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(245.83,-295.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(159.09)">
@@ -782,7 +782,7 @@
         <g id="test_43">
             <desc>T4-7-1</desc>
             <g id="test_43.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="403.98,148.80 389.82,331.64"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="403.98,148.80 389.82,331.64"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(401.47,181.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-175.57)">
@@ -801,7 +801,7 @@
                 </g>
             </g>
             <g id="test_43.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="371.03,574.29 385.19,391.46"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="371.03,574.29 385.19,391.46"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(373.54,541.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(4.43)">
@@ -827,7 +827,7 @@
         <g id="test_44">
             <desc>T4-9-1</desc>
             <g id="test_44.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="384.89,137.75 215.87,253.12"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="384.89,137.75 215.87,253.12"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(358.05,156.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-124.32)">
@@ -846,7 +846,7 @@
                 </g>
             </g>
             <g id="test_44.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-2.70,402.32 166.32,286.95"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2.70,402.32 166.32,286.95"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(24.14,384.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(55.68)">
@@ -872,7 +872,7 @@
         <g id="test_45">
             <desc>T5-6-1</desc>
             <g id="test_45.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="199.67,-351.28 -25.52,-362.82"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="199.67,-351.28 -25.52,-362.82"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(167.21,-352.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-87.06)">
@@ -891,7 +891,7 @@
                 </g>
             </g>
             <g id="test_45.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-310.63,-377.44 -85.44,-365.90"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-310.63,-377.44 -85.44,-365.90"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-278.17,-375.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(92.94)">
@@ -917,7 +917,7 @@
         <g id="test_46">
             <desc>L7-8-1</desc>
             <g id="test_46.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="381.02,622.24 468.84,787.59"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="381.02,622.24 468.84,787.59"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(396.27,650.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(152.03)">
@@ -936,7 +936,7 @@
                 </g>
             </g>
             <g id="test_46.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="556.67,952.94 468.84,787.59"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="556.67,952.94 468.84,787.59"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(541.42,924.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-27.97)">
@@ -958,7 +958,7 @@
         <g id="test_47">
             <desc>L7-9-1</desc>
             <g id="test_47.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="345.94,588.95 172.65,508.21"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="345.94,588.95 172.65,508.21"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(316.48,575.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-65.02)">
@@ -977,7 +977,7 @@
                 </g>
             </g>
             <g id="test_47.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-0.65,427.47 172.65,508.21"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-0.65,427.47 172.65,508.21"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(28.81,441.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(114.98)">

--- a/network-area-diagram/src/test/resources/IEEE_24_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_24_bus.svg
@@ -245,7 +245,7 @@
         <g id="48">
             <desc>L-1-2-1 </desc>
             <g id="48.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="-962.77,506.17 -969.83,784.96"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-962.77,506.17 -969.83,784.96"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-963.59,538.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-178.55)">
@@ -264,7 +264,7 @@
                 </g>
             </g>
             <g id="48.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="-976.89,1063.75 -969.83,784.96"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-976.89,1063.75 -969.83,784.96"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-976.06,1031.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(1.45)">
@@ -286,7 +286,7 @@
         <g id="49">
             <desc>L-3-1-1 </desc>
             <g id="49.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="-457.58,-17.26 -700.78,222.75"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-457.58,-17.26 -700.78,222.75"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-480.72,5.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-134.62)">
@@ -305,7 +305,7 @@
                 </g>
             </g>
             <g id="49.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="-943.98,462.77 -700.78,222.75"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-943.98,462.77 -700.78,222.75"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-920.84,439.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(45.38)">
@@ -327,7 +327,7 @@
         <g id="50">
             <desc>L-1-5-1 </desc>
             <g id="50.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="-979.71,499.15 -1065.61,589.38"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-979.71,499.15 -1065.61,589.38"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1002.12,522.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-136.41)">
@@ -346,7 +346,7 @@
                 </g>
             </g>
             <g id="50.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="-1151.52,679.60 -1065.61,589.38"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1151.52,679.60 -1065.61,589.38"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1129.11,656.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(43.59)">
@@ -368,7 +368,7 @@
         <g id="51">
             <desc>L-10-6-1 </desc>
             <g id="51.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="-498.14,717.83 -542.81,966.85"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-498.14,717.83 -542.81,966.85"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-503.88,749.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-169.83)">
@@ -387,7 +387,7 @@
                 </g>
             </g>
             <g id="51.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="-587.48,1215.86 -542.81,966.85"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-587.48,1215.86 -542.81,966.85"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-581.75,1183.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(10.17)">
@@ -409,7 +409,7 @@
         <g id="52">
             <desc>L-8-10-1 </desc>
             <g id="52.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="-832.66,147.96 -669.89,409.52"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-832.66,147.96 -669.89,409.52"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-815.49,175.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(148.11)">
@@ -428,7 +428,7 @@
                 </g>
             </g>
             <g id="52.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="-507.11,671.09 -669.89,409.52"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-507.11,671.09 -669.89,409.52"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-524.28,643.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-31.89)">
@@ -450,7 +450,7 @@
         <g id="53">
             <desc>T-5-10-1 </desc>
             <g id="53.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="-1143.60,697.87 -861.37,695.64"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1143.60,697.87 -861.37,695.64"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1111.11,697.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(89.55)">
@@ -469,7 +469,7 @@
                 </g>
             </g>
             <g id="53.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="-519.14,692.94 -801.37,695.17"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-519.14,692.94 -801.37,695.17"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-551.64,693.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-90.45)">
@@ -495,7 +495,7 @@
         <g id="54">
             <desc>T-11-10-1 </desc>
             <g id="54.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="21.56,654.67 -193.40,670.55"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="21.56,654.67 -193.40,670.55"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-10.85,657.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-94.23)">
@@ -514,7 +514,7 @@
                 </g>
             </g>
             <g id="54.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="-468.21,690.86 -253.24,674.97"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-468.21,690.86 -253.24,674.97"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-435.80,688.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(85.77)">
@@ -540,7 +540,7 @@
         <g id="55">
             <desc>T-12-10-1 </desc>
             <g id="55.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="-177.38,347.00 -306.65,488.32"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-177.38,347.00 -306.65,488.32"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-199.31,370.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-137.55)">
@@ -559,7 +559,7 @@
                 </g>
             </g>
             <g id="55.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="-476.43,673.92 -347.15,532.59"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-476.43,673.92 -347.15,532.59"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-454.49,649.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(42.45)">
@@ -585,7 +585,7 @@
         <g id="56">
             <desc>L-11-13-1 </desc>
             <g id="56.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="56.48,629.12 113.64,486.40"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="56.48,629.12 113.64,486.40"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(68.56,598.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(21.83)">
@@ -604,7 +604,7 @@
                 </g>
             </g>
             <g id="56.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="170.80,343.68 113.64,486.40"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="170.80,343.68 113.64,486.40"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(158.71,373.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-158.17)">
@@ -626,7 +626,7 @@
         <g id="57">
             <desc>L-11-14-1 </desc>
             <g id="57.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="70.85,643.78 345.64,539.97"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="70.85,643.78 345.64,539.97"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(101.25,632.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(69.31)">
@@ -645,7 +645,7 @@
                 </g>
             </g>
             <g id="57.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="620.44,436.17 345.64,539.97"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="620.44,436.17 345.64,539.97"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(590.04,447.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-110.69)">
@@ -667,7 +667,7 @@
         <g id="58">
             <desc>T-11-9-1 </desc>
             <g id="58.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="24.50,640.79 -188.79,526.96"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="24.50,640.79 -188.79,526.96"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-4.18,625.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-61.91)">
@@ -686,7 +686,7 @@
                 </g>
             </g>
             <g id="58.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="-455.02,384.89 -241.73,498.72"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-455.02,384.89 -241.73,498.72"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-426.35,400.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(118.09)">
@@ -712,7 +712,7 @@
         <g id="59">
             <desc>L-12-13-1 </desc>
             <g id="59.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="-134.67,327.57 10.06,324.09"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-134.67,327.57 10.06,324.09"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-102.18,326.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(88.62)">
@@ -731,7 +731,7 @@
                 </g>
             </g>
             <g id="59.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="154.78,320.62 10.06,324.09"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="154.78,320.62 10.06,324.09"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(122.29,321.40)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-91.38)">
@@ -753,7 +753,7 @@
         <g id="60">
             <desc>L-12-23-1 </desc>
             <g id="60.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="-150.34,304.65 -73.41,120.39"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-150.34,304.65 -73.41,120.39"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-137.82,274.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(22.66)">
@@ -772,7 +772,7 @@
                 </g>
             </g>
             <g id="60.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="3.53,-63.87 -73.41,120.39"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="3.53,-63.87 -73.41,120.39"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-9.00,-33.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-157.34)">
@@ -794,7 +794,7 @@
         <g id="61">
             <desc>T-9-12-1 </desc>
             <g id="61.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="-452.27,369.33 -348.55,354.72"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-452.27,369.33 -348.55,354.72"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-420.08,364.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(81.98)">
@@ -813,7 +813,7 @@
                 </g>
             </g>
             <g id="61.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="-185.42,331.74 -289.13,346.35"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-185.42,331.74 -289.13,346.35"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-217.60,336.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-98.02)">
@@ -839,7 +839,7 @@
         <g id="62">
             <desc>L-23-13-1 </desc>
             <g id="62.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="23.02,-63.80 96.81,116.30"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="23.02,-63.80 96.81,116.30"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(35.34,-33.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(157.72)">
@@ -858,7 +858,7 @@
                 </g>
             </g>
             <g id="62.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="170.61,296.41 96.81,116.30"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="170.61,296.41 96.81,116.30"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(158.29,266.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-22.28)">
@@ -880,7 +880,7 @@
         <g id="63">
             <desc>L-14-16-1 </desc>
             <g id="63.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="654.05,403.59 758.13,152.23"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="654.05,403.59 758.13,152.23"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(666.48,373.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(22.49)">
@@ -899,7 +899,7 @@
                 </g>
             </g>
             <g id="63.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="862.21,-99.14 758.13,152.23"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="862.21,-99.14 758.13,152.23"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(849.77,-69.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-157.51)">
@@ -921,7 +921,7 @@
         <g id="64">
             <desc>L-16-15-1 </desc>
             <g id="64.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="872.49,-148.20 875.93,-313.74"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="872.49,-148.20 875.93,-313.74"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(873.16,-180.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(1.19)">
@@ -940,7 +940,7 @@
                 </g>
             </g>
             <g id="64.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="879.36,-479.29 875.93,-313.74"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="879.36,-479.29 875.93,-313.74"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(878.69,-446.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-178.81)">
@@ -962,7 +962,7 @@
         <g id="65">
             <desc>L-15-21-1 </desc>
             <g id="65.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="904.96,-500.10 958.53,-490.10 1142.95,-555.13"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="904.96,-500.10 958.53,-490.10 1142.95,-555.13"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(986.83,-500.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(70.57)">
@@ -981,7 +981,7 @@
                 </g>
             </g>
             <g id="65.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="1362.81,-661.56 1327.36,-620.17 1142.95,-555.13"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1362.81,-661.56 1327.36,-620.17 1142.95,-555.13"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1299.07,-610.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-109.43)">
@@ -1003,7 +1003,7 @@
         <g id="66">
             <desc>L-21-15-2 </desc>
             <g id="66.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="1354.33,-685.61 1300.76,-695.61 1116.34,-630.58"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1354.33,-685.61 1300.76,-695.61 1116.34,-630.58"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1272.46,-685.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-109.43)">
@@ -1022,7 +1022,7 @@
                 </g>
             </g>
             <g id="66.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="896.48,-524.15 931.93,-565.54 1116.34,-630.58"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="896.48,-524.15 931.93,-565.54 1116.34,-630.58"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(960.22,-575.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(70.57)">
@@ -1044,7 +1044,7 @@
         <g id="67">
             <desc>L-15-24-1 </desc>
             <g id="67.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="855.55,-497.18 582.08,-411.85"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="855.55,-497.18 582.08,-411.85"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(824.52,-487.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-107.33)">
@@ -1063,7 +1063,7 @@
                 </g>
             </g>
             <g id="67.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="308.60,-326.51 582.08,-411.85"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="308.60,-326.51 582.08,-411.85"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(339.63,-336.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(72.67)">
@@ -1085,7 +1085,7 @@
         <g id="68">
             <desc>L-16-17-1 </desc>
             <g id="68.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="897.27,-119.58 1135.31,-90.23"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="897.27,-119.58 1135.31,-90.23"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(929.52,-115.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(97.03)">
@@ -1104,7 +1104,7 @@
                 </g>
             </g>
             <g id="68.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="1373.34,-60.88 1135.31,-90.23"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1373.34,-60.88 1135.31,-90.23"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1341.09,-64.86)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-82.97)">
@@ -1126,7 +1126,7 @@
         <g id="69">
             <desc>L-16-19-1 </desc>
             <g id="69.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="857.67,-143.83 688.76,-393.57"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="857.67,-143.83 688.76,-393.57"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(839.47,-170.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-34.07)">
@@ -1145,7 +1145,7 @@
                 </g>
             </g>
             <g id="69.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="519.85,-643.31 688.76,-393.57"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="519.85,-643.31 688.76,-393.57"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(538.06,-616.39)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(145.93)">
@@ -1167,7 +1167,7 @@
         <g id="70">
             <desc>L-17-18-1 </desc>
             <g id="70.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="1400.74,-83.17 1411.84,-218.72"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1400.74,-83.17 1411.84,-218.72"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1403.39,-115.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(4.68)">
@@ -1186,7 +1186,7 @@
                 </g>
             </g>
             <g id="70.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="1422.95,-354.28 1411.84,-218.72"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1422.95,-354.28 1411.84,-218.72"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1420.30,-321.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-175.32)">
@@ -1208,7 +1208,7 @@
         <g id="71">
             <desc>L-17-22-1 </desc>
             <g id="71.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="1418.09,-74.26 1576.36,-208.63"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1418.09,-74.26 1576.36,-208.63"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1442.87,-95.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(49.67)">
@@ -1227,7 +1227,7 @@
                 </g>
             </g>
             <g id="71.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="1734.63,-343.00 1576.36,-208.63"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1734.63,-343.00 1576.36,-208.63"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1709.86,-321.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-130.33)">
@@ -1249,7 +1249,7 @@
         <g id="72">
             <desc>L-18-21-1 </desc>
             <g id="72.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="1434.33,-403.43 1454.20,-454.18 1441.76,-536.30"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1434.33,-403.43 1454.20,-454.18 1441.76,-536.30"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1449.71,-483.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-8.61)">
@@ -1268,7 +1268,7 @@
                 </g>
             </g>
             <g id="72.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="1395.31,-661.01 1429.32,-618.42 1441.76,-536.30"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1395.31,-661.01 1429.32,-618.42 1441.76,-536.30"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1433.82,-588.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(171.39)">
@@ -1290,7 +1290,7 @@
         <g id="73">
             <desc>L-18-21-2 </desc>
             <g id="73.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="1409.12,-399.62 1375.11,-442.20 1362.67,-524.32"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1409.12,-399.62 1375.11,-442.20 1362.67,-524.32"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1370.61,-471.86)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-8.61)">
@@ -1309,7 +1309,7 @@
                 </g>
             </g>
             <g id="73.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="1370.10,-657.19 1350.23,-606.44 1362.67,-524.32"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1370.10,-657.19 1350.23,-606.44 1362.67,-524.32"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1354.72,-576.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(171.39)">
@@ -1331,7 +1331,7 @@
         <g id="74">
             <desc>L-19-20-1 </desc>
             <g id="74.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="483.09,-676.47 435.04,-702.19 283.62,-697.34"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="483.09,-676.47 435.04,-702.19 283.62,-697.34"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(405.05,-701.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-91.84)">
@@ -1350,7 +1350,7 @@
                 </g>
             </g>
             <g id="74.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="85.91,-663.73 132.21,-692.48 283.62,-697.34"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="85.91,-663.73 132.21,-692.48 283.62,-697.34"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(162.20,-693.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(88.16)">
@@ -1372,7 +1372,7 @@
         <g id="75">
             <desc>L-19-20-2 </desc>
             <g id="75.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="483.91,-650.99 437.60,-622.24 286.19,-617.38"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="483.91,-650.99 437.60,-622.24 286.19,-617.38"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(407.62,-621.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-91.84)">
@@ -1391,7 +1391,7 @@
                 </g>
             </g>
             <g id="75.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="86.73,-638.24 134.78,-612.52 286.19,-617.38"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="86.73,-638.24 134.78,-612.52 286.19,-617.38"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(164.76,-613.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(88.16)">
@@ -1413,7 +1413,7 @@
         <g id="76">
             <desc>L-2-4-1 </desc>
             <g id="76.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="-959.46,1071.25 -865.04,977.27"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-959.46,1071.25 -865.04,977.27"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-936.42,1048.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(45.13)">
@@ -1432,7 +1432,7 @@
                 </g>
             </g>
             <g id="76.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="-770.63,883.29 -865.04,977.27"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-770.63,883.29 -865.04,977.27"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-793.66,906.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-134.87)">
@@ -1454,7 +1454,7 @@
         <g id="77">
             <desc>L-2-6-1 </desc>
             <g id="77.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="-953.80,1098.58 -784.76,1165.10"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-953.80,1098.58 -784.76,1165.10"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-923.56,1110.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(111.48)">
@@ -1473,7 +1473,7 @@
                 </g>
             </g>
             <g id="77.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="-615.72,1231.62 -784.76,1165.10"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-615.72,1231.62 -784.76,1165.10"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-645.96,1219.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-68.52)">
@@ -1495,7 +1495,7 @@
         <g id="78">
             <desc>L-20-23-1 </desc>
             <g id="78.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="49.56,-629.43 18.17,-584.88 -1.04,-372.44"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="49.56,-629.43 18.17,-584.88 -1.04,-372.44"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(15.47,-555.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-174.83)">
@@ -1514,7 +1514,7 @@
                 </g>
             </g>
             <g id="78.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="2.64,-110.54 -20.25,-160.00 -1.04,-372.44"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2.64,-110.54 -20.25,-160.00 -1.04,-372.44"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-17.54,-189.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(5.17)">
@@ -1536,7 +1536,7 @@
         <g id="79">
             <desc>L-20-23-2 </desc>
             <g id="79.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="74.96,-627.14 97.85,-577.68 78.64,-365.24"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="74.96,-627.14 97.85,-577.68 78.64,-365.24"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(95.14,-547.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-174.83)">
@@ -1555,7 +1555,7 @@
                 </g>
             </g>
             <g id="79.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="28.04,-108.25 59.43,-152.80 78.64,-365.24"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="28.04,-108.25 59.43,-152.80 78.64,-365.24"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(62.13,-182.68)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(5.17)">
@@ -1577,7 +1577,7 @@
         <g id="80">
             <desc>L-21-22-1 </desc>
             <g id="80.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="1398.75,-664.33 1566.74,-520.22"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1398.75,-664.33 1566.74,-520.22"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1423.42,-643.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(130.63)">
@@ -1596,7 +1596,7 @@
                 </g>
             </g>
             <g id="80.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="1734.72,-376.11 1566.74,-520.22"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1734.72,-376.11 1566.74,-520.22"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1710.05,-397.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-49.37)">
@@ -1618,7 +1618,7 @@
         <g id="81">
             <desc>T-24-3-1 </desc>
             <g id="81.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="260.52,-309.61 -49.66,-187.99"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="260.52,-309.61 -49.66,-187.99"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(230.26,-297.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-111.41)">
@@ -1637,7 +1637,7 @@
                 </g>
             </g>
             <g id="81.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="-415.69,-44.48 -105.52,-166.09"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-415.69,-44.48 -105.52,-166.09"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-385.44,-56.35)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(68.59)">
@@ -1663,7 +1663,7 @@
         <g id="82">
             <desc>L-3-9-1 </desc>
             <g id="82.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="-441.80,-9.78 -458.48,168.86"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-441.80,-9.78 -458.48,168.86"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-444.82,22.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-174.67)">
@@ -1682,7 +1682,7 @@
                 </g>
             </g>
             <g id="82.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="-475.15,347.50 -458.48,168.86"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-475.15,347.50 -458.48,168.86"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-472.13,315.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(5.33)">
@@ -1704,7 +1704,7 @@
         <g id="83">
             <desc>L-4-9-1 </desc>
             <g id="83.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="-740.12,843.04 -615.03,619.10"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-740.12,843.04 -615.03,619.10"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-724.27,814.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(29.19)">
@@ -1723,7 +1723,7 @@
                 </g>
             </g>
             <g id="83.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="-489.95,395.15 -615.03,619.10"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-489.95,395.15 -615.03,619.10"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-505.80,423.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-150.81)">
@@ -1745,7 +1745,7 @@
         <g id="84">
             <desc>L-7-8-1 </desc>
             <g id="84.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="-1160.53,-219.25 -1011.91,-55.90"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1160.53,-219.25 -1011.91,-55.90"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1138.66,-195.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(137.70)">
@@ -1764,7 +1764,7 @@
                 </g>
             </g>
             <g id="84.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="-863.30,107.45 -1011.91,-55.90"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-863.30,107.45 -1011.91,-55.90"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-885.17,83.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-42.30)">
@@ -1786,7 +1786,7 @@
         <g id="85">
             <desc>L-8-9-1 </desc>
             <g id="85.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="-824.94,140.49 -661.83,249.60"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-824.94,140.49 -661.83,249.60"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-797.93,158.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(123.78)">
@@ -1805,7 +1805,7 @@
                 </g>
             </g>
             <g id="85.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="-498.71,358.71 -661.83,249.60"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-498.71,358.71 -661.83,249.60"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-525.72,340.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-56.22)">

--- a/network-area-diagram/src/test/resources/IEEE_30_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_30_bus.svg
@@ -284,7 +284,7 @@
         <g id="60">
             <desc>L1-2-1</desc>
             <g id="60.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="550.53,-796.88 372.88,-540.62"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="550.53,-796.88 372.88,-540.62"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(532.02,-770.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-145.27)">
@@ -303,7 +303,7 @@
                 </g>
             </g>
             <g id="60.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="195.23,-284.35 372.88,-540.62"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="195.23,-284.35 372.88,-540.62"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(213.75,-311.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(34.73)">
@@ -325,7 +325,7 @@
         <g id="61">
             <desc>L1-3-1</desc>
             <g id="61.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="589.47,-810.47 733.28,-767.08"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="589.47,-810.47 733.28,-767.08"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(620.59,-801.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(106.79)">
@@ -344,7 +344,7 @@
                 </g>
             </g>
             <g id="61.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="877.09,-723.69 733.28,-767.08"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="877.09,-723.69 733.28,-767.08"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(845.98,-733.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-73.21)">
@@ -366,7 +366,7 @@
         <g id="62">
             <desc>L9-10-1</desc>
             <g id="62.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-191.18,555.03 1.30,322.26"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-191.18,555.03 1.30,322.26"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-170.47,529.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(39.59)">
@@ -385,7 +385,7 @@
                 </g>
             </g>
             <g id="62.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="193.79,89.50 1.30,322.26"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="193.79,89.50 1.30,322.26"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(173.07,114.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-140.41)">
@@ -407,7 +407,7 @@
         <g id="63">
             <desc>L10-20-1</desc>
             <g id="63.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="202.63,45.45 87.78,-332.78"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="202.63,45.45 87.78,-332.78"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(193.18,14.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-16.89)">
@@ -426,7 +426,7 @@
                 </g>
             </g>
             <g id="63.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="-27.07,-711.02 87.78,-332.78"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-27.07,-711.02 87.78,-332.78"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-17.63,-679.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(163.11)">
@@ -448,7 +448,7 @@
         <g id="64">
             <desc>L10-17-1</desc>
             <g id="64.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="232.64,58.04 566.00,-116.15"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="232.64,58.04 566.00,-116.15"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(261.44,42.99)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(62.41)">
@@ -467,7 +467,7 @@
                 </g>
             </g>
             <g id="64.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="899.36,-290.34 566.00,-116.15"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="899.36,-290.34 566.00,-116.15"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(870.55,-275.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-117.59)">
@@ -489,7 +489,7 @@
         <g id="65">
             <desc>L10-21-1</desc>
             <g id="65.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="221.98,92.38 298.99,237.67"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="221.98,92.38 298.99,237.67"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(237.20,121.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(152.07)">
@@ -508,7 +508,7 @@
                 </g>
             </g>
             <g id="65.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="376.00,382.96 298.99,237.67"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="376.00,382.96 298.99,237.67"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(360.78,354.25)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-27.93)">
@@ -530,7 +530,7 @@
         <g id="66">
             <desc>L10-22-1</desc>
             <g id="66.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="184.87,73.98 34.73,98.58"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="184.87,73.98 34.73,98.58"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(152.80,79.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-99.31)">
@@ -549,7 +549,7 @@
                 </g>
             </g>
             <g id="66.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="-115.40,123.18 34.73,98.58"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-115.40,123.18 34.73,98.58"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-83.33,117.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(80.69)">
@@ -571,7 +571,7 @@
         <g id="67">
             <desc>T6-10-1</desc>
             <g id="67.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="80.79,405.11 130.03,277.37"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="80.79,405.11 130.03,277.37"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(92.48,374.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(21.08)">
@@ -590,7 +590,7 @@
                 </g>
             </g>
             <g id="67.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="200.86,93.65 151.62,221.39"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="200.86,93.65 151.62,221.39"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(189.17,123.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-158.92)">
@@ -616,7 +616,7 @@
         <g id="68">
             <desc>L9-11-1</desc>
             <g id="68.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-230.87,584.73 -408.83,661.04"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-230.87,584.73 -408.83,661.04"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-260.74,597.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-113.21)">
@@ -635,7 +635,7 @@
                 </g>
             </g>
             <g id="68.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-586.80,737.35 -408.83,661.04"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-586.80,737.35 -408.83,661.04"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-556.93,724.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(66.79)">
@@ -657,7 +657,7 @@
         <g id="69">
             <desc>L12-13-1</desc>
             <g id="69.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="1166.96,-67.83 1367.00,56.45"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1166.96,-67.83 1367.00,56.45"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1194.57,-50.68)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(121.85)">
@@ -676,7 +676,7 @@
                 </g>
             </g>
             <g id="69.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="1567.04,180.73 1367.00,56.45"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1567.04,180.73 1367.00,56.45"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1539.44,163.58)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-58.15)">
@@ -698,7 +698,7 @@
         <g id="70">
             <desc>L12-14-1</desc>
             <g id="70.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="1126.16,-64.44 1029.41,20.70"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1126.16,-64.44 1029.41,20.70"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1101.76,-42.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-131.35)">
@@ -717,7 +717,7 @@
                 </g>
             </g>
             <g id="70.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="932.66,105.85 1029.41,20.70"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="932.66,105.85 1029.41,20.70"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(957.06,84.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.65)">
@@ -739,7 +739,7 @@
         <g id="71">
             <desc>L12-15-1</desc>
             <g id="71.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="1123.42,-94.38 816.31,-278.10"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1123.42,-94.38 816.31,-278.10"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1095.53,-111.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-59.11)">
@@ -758,7 +758,7 @@
                 </g>
             </g>
             <g id="71.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="509.20,-461.82 816.31,-278.10"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="509.20,-461.82 816.31,-278.10"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(537.09,-445.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(120.89)">
@@ -780,7 +780,7 @@
         <g id="72">
             <desc>L12-16-1</desc>
             <g id="72.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="1162.14,-100.44 1271.09,-224.40"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1162.14,-100.44 1271.09,-224.40"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1183.59,-124.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(41.31)">
@@ -799,7 +799,7 @@
                 </g>
             </g>
             <g id="72.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="1380.04,-348.36 1271.09,-224.40"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1380.04,-348.36 1271.09,-224.40"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1358.58,-323.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-138.69)">
@@ -821,7 +821,7 @@
         <g id="73">
             <desc>T4-12-1</desc>
             <g id="73.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="630.88,-101.54 845.38,-93.09"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="630.88,-101.54 845.38,-93.09"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(663.36,-100.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(92.25)">
@@ -840,7 +840,7 @@
                 </g>
             </g>
             <g id="73.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="1119.82,-82.29 905.33,-90.73"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1119.82,-82.29 905.33,-90.73"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1087.35,-83.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-87.75)">
@@ -866,7 +866,7 @@
         <g id="74">
             <desc>L14-15-1</desc>
             <g id="74.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="898.71,101.93 700.42,-176.11"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="898.71,101.93 700.42,-176.11"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(879.84,75.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-35.50)">
@@ -885,7 +885,7 @@
                 </g>
             </g>
             <g id="74.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="502.13,-454.15 700.42,-176.11"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="502.13,-454.15 700.42,-176.11"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(521.00,-427.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(144.50)">
@@ -907,7 +907,7 @@
         <g id="75">
             <desc>L15-18-1</desc>
             <g id="75.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="479.99,-499.33 388.89,-802.78"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="479.99,-499.33 388.89,-802.78"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(470.64,-530.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-16.71)">
@@ -926,7 +926,7 @@
                 </g>
             </g>
             <g id="75.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="297.78,-1106.23 388.89,-802.78"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="297.78,-1106.23 388.89,-802.78"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(307.13,-1075.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(163.29)">
@@ -948,7 +948,7 @@
         <g id="76">
             <desc>L15-23-1</desc>
             <g id="76.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="461.88,-476.63 39.74,-505.30"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="461.88,-476.63 39.74,-505.30"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(429.45,-478.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-86.12)">
@@ -967,7 +967,7 @@
                 </g>
             </g>
             <g id="76.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="-382.39,-533.97 39.74,-505.30"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-382.39,-533.97 39.74,-505.30"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-349.97,-531.77)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(93.88)">
@@ -989,7 +989,7 @@
         <g id="77">
             <desc>L16-17-1</desc>
             <g id="77.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="1371.61,-364.03 1159.42,-334.83"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1371.61,-364.03 1159.42,-334.83"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1339.41,-359.60)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-97.84)">
@@ -1008,7 +1008,7 @@
                 </g>
             </g>
             <g id="77.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="947.22,-305.63 1159.42,-334.83"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="947.22,-305.63 1159.42,-334.83"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(979.42,-310.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(82.16)">
@@ -1030,7 +1030,7 @@
         <g id="78">
             <desc>L18-19-1</desc>
             <g id="78.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="265.63,-1136.49 103.80,-1174.55"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="265.63,-1136.49 103.80,-1174.55"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(233.99,-1143.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-76.77)">
@@ -1049,7 +1049,7 @@
                 </g>
             </g>
             <g id="78.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="-58.02,-1212.60 103.80,-1174.55"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-58.02,-1212.60 103.80,-1174.55"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-26.38,-1205.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(103.23)">
@@ -1071,7 +1071,7 @@
         <g id="79">
             <desc>L19-20-1</desc>
             <g id="79.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="-80.30,-1193.06 -58.66,-976.93"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-80.30,-1193.06 -58.66,-976.93"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-77.07,-1160.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(174.28)">
@@ -1090,7 +1090,7 @@
                 </g>
             </g>
             <g id="79.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="-37.02,-760.79 -58.66,-976.93"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-37.02,-760.79 -58.66,-976.93"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-40.26,-793.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-5.72)">
@@ -1112,7 +1112,7 @@
         <g id="80">
             <desc>L2-4-1</desc>
             <g id="80.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="204.55,-254.36 393.05,-182.97"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="204.55,-254.36 393.05,-182.97"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(234.94,-242.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(110.74)">
@@ -1131,7 +1131,7 @@
                 </g>
             </g>
             <g id="80.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="581.56,-111.57 393.05,-182.97"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="581.56,-111.57 393.05,-182.97"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(551.16,-123.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-69.26)">
@@ -1153,7 +1153,7 @@
         <g id="81">
             <desc>L2-5-1</desc>
             <g id="81.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="155.41,-260.17 -72.27,-231.11"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="155.41,-260.17 -72.27,-231.11"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(123.17,-256.05)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-97.27)">
@@ -1172,7 +1172,7 @@
                 </g>
             </g>
             <g id="81.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="-299.95,-202.06 -72.27,-231.11"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-299.95,-202.06 -72.27,-231.11"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-267.71,-206.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(82.73)">
@@ -1194,7 +1194,7 @@
         <g id="82">
             <desc>L2-6-1</desc>
             <g id="82.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="176.74,-238.21 126.16,82.75"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="176.74,-238.21 126.16,82.75"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(171.68,-206.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-171.05)">
@@ -1213,7 +1213,7 @@
                 </g>
             </g>
             <g id="82.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="75.58,403.71 126.16,82.75"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="75.58,403.71 126.16,82.75"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(80.64,371.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(8.95)">
@@ -1235,7 +1235,7 @@
         <g id="83">
             <desc>L21-22-1</desc>
             <g id="83.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="365.38,393.62 123.69,266.40"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="365.38,393.62 123.69,266.40"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(336.62,378.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-62.24)">
@@ -1254,7 +1254,7 @@
                 </g>
             </g>
             <g id="83.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="-118.00,139.18 123.69,266.40"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-118.00,139.18 123.69,266.40"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-89.24,154.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(117.76)">
@@ -1276,7 +1276,7 @@
         <g id="84">
             <desc>L22-24-1</desc>
             <g id="84.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="-165.21,120.76 -463.23,41.59"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-165.21,120.76 -463.23,41.59"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-196.62,112.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-75.12)">
@@ -1295,7 +1295,7 @@
                 </g>
             </g>
             <g id="84.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="-761.25,-37.59 -463.23,41.59"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-761.25,-37.59 -463.23,41.59"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-729.84,-29.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.88)">
@@ -1317,7 +1317,7 @@
         <g id="85">
             <desc>L23-24-1</desc>
             <g id="85.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="-423.38,-515.48 -596.86,-289.91"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-423.38,-515.48 -596.86,-289.91"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-443.19,-489.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-142.44)">
@@ -1336,7 +1336,7 @@
                 </g>
             </g>
             <g id="85.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="-770.35,-64.35 -596.86,-289.91"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-770.35,-64.35 -596.86,-289.91"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-750.53,-90.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(37.56)">
@@ -1358,7 +1358,7 @@
         <g id="86">
             <desc>L24-25-1</desc>
             <g id="86.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="-799.33,-22.46 -961.18,238.73"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-799.33,-22.46 -961.18,238.73"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-816.44,5.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-148.21)">
@@ -1377,7 +1377,7 @@
                 </g>
             </g>
             <g id="86.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="-1123.03,499.91 -961.18,238.73"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1123.03,499.91 -961.18,238.73"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1105.91,472.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(31.79)">
@@ -1399,7 +1399,7 @@
         <g id="87">
             <desc>L25-26-1</desc>
             <g id="87.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="-1160.96,514.53 -1348.75,460.44"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1160.96,514.53 -1348.75,460.44"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1192.19,505.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-73.93)">
@@ -1418,7 +1418,7 @@
                 </g>
             </g>
             <g id="87.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="-1536.54,406.35 -1348.75,460.44"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1536.54,406.35 -1348.75,460.44"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1505.31,415.35)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(106.07)">
@@ -1440,7 +1440,7 @@
         <g id="88">
             <desc>L25-27-1</desc>
             <g id="88.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="-1125.59,544.65 -984.04,845.16"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1125.59,544.65 -984.04,845.16"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1111.74,574.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(154.78)">
@@ -1459,7 +1459,7 @@
                 </g>
             </g>
             <g id="88.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="-842.50,1145.66 -984.04,845.16"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-842.50,1145.66 -984.04,845.16"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-856.35,1116.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-25.22)">
@@ -1481,7 +1481,7 @@
         <g id="89">
             <desc>L27-29-1</desc>
             <g id="89.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="-827.48,1193.89 -795.48,1388.11"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-827.48,1193.89 -795.48,1388.11"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-822.20,1225.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(170.64)">
@@ -1500,7 +1500,7 @@
                 </g>
             </g>
             <g id="89.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="-763.48,1582.32 -795.48,1388.11"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-763.48,1582.32 -795.48,1388.11"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-768.76,1550.25)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-9.36)">
@@ -1522,7 +1522,7 @@
         <g id="90">
             <desc>L27-30-1</desc>
             <g id="90.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="-846.27,1189.61 -953.64,1342.75"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-846.27,1189.61 -953.64,1342.75"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-864.93,1216.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-144.96)">
@@ -1541,7 +1541,7 @@
                 </g>
             </g>
             <g id="90.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="-1061.01,1495.89 -953.64,1342.75"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1061.01,1495.89 -953.64,1342.75"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1042.35,1469.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(35.04)">
@@ -1563,7 +1563,7 @@
         <g id="91">
             <desc>T28-27-1</desc>
             <g id="91.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="-238.98,1054.89 -493.32,1103.75"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-238.98,1054.89 -493.32,1103.75"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-270.90,1061.02)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-100.87)">
@@ -1582,7 +1582,7 @@
                 </g>
             </g>
             <g id="91.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="-806.59,1163.92 -552.24,1115.07"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-806.59,1163.92 -552.24,1115.07"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-774.67,1157.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(79.13)">
@@ -1608,7 +1608,7 @@
         <g id="92">
             <desc>L8-28-1</desc>
             <g id="92.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="148.67,998.99 -20.01,1022.76"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="148.67,998.99 -20.01,1022.76"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(116.49,1003.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-98.02)">
@@ -1627,7 +1627,7 @@
                 </g>
             </g>
             <g id="92.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="-188.69,1046.52 -20.01,1022.76"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-188.69,1046.52 -20.01,1022.76"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-156.50,1041.99)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(81.98)">
@@ -1649,7 +1649,7 @@
         <g id="93">
             <desc>L6-28-1</desc>
             <g id="93.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="60.96,452.07 -71.16,739.49"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="60.96,452.07 -71.16,739.49"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(47.39,481.60)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-155.31)">
@@ -1668,7 +1668,7 @@
                 </g>
             </g>
             <g id="93.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="-203.29,1026.91 -71.16,739.49"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-203.29,1026.91 -71.16,739.49"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-189.71,997.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(24.69)">
@@ -1690,7 +1690,7 @@
         <g id="94">
             <desc>L29-30-1</desc>
             <g id="94.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="-783.85,1600.45 -917.49,1562.13"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-783.85,1600.45 -917.49,1562.13"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-815.09,1591.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-74.00)">
@@ -1709,7 +1709,7 @@
                 </g>
             </g>
             <g id="94.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable" points="-1051.14,1523.80 -917.49,1562.13"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1051.14,1523.80 -917.49,1562.13"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1019.90,1532.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(106.00)">
@@ -1731,7 +1731,7 @@
         <g id="95">
             <desc>L3-4-1</desc>
             <g id="95.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="890.43,-693.36 753.46,-409.43"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="890.43,-693.36 753.46,-409.43"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(876.31,-664.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-154.25)">
@@ -1750,7 +1750,7 @@
                 </g>
             </g>
             <g id="95.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="616.48,-125.51 753.46,-409.43"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="616.48,-125.51 753.46,-409.43"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(630.61,-154.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(25.75)">
@@ -1772,7 +1772,7 @@
         <g id="96">
             <desc>L4-6-1</desc>
             <g id="96.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="587.33,-84.55 338.51,163.18"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="587.33,-84.55 338.51,163.18"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(564.30,-61.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-134.87)">
@@ -1791,7 +1791,7 @@
                 </g>
             </g>
             <g id="96.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="89.68,410.91 338.51,163.18"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="89.68,410.91 338.51,163.18"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(112.72,387.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(45.13)">
@@ -1813,7 +1813,7 @@
         <g id="97">
             <desc>L5-7-1</desc>
             <g id="97.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="-333.31,-174.64 -391.98,1.43"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-333.31,-174.64 -391.98,1.43"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-343.58,-143.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-161.57)">
@@ -1832,7 +1832,7 @@
                 </g>
             </g>
             <g id="97.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="-450.66,177.50 -391.98,1.43"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-450.66,177.50 -391.98,1.43"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-440.38,146.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(18.43)">
@@ -1854,7 +1854,7 @@
         <g id="98">
             <desc>L6-7-1</desc>
             <g id="98.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="48.17,418.86 -193.55,315.30"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="48.17,418.86 -193.55,315.30"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(18.30,406.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-66.81)">
@@ -1873,7 +1873,7 @@
                 </g>
             </g>
             <g id="98.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="-435.28,211.74 -193.55,315.30"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-435.28,211.74 -193.55,315.30"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-405.41,224.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(113.19)">
@@ -1895,7 +1895,7 @@
         <g id="99">
             <desc>L6-8-1</desc>
             <g id="99.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="76.15,454.00 122.77,712.17"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="76.15,454.00 122.77,712.17"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(81.92,485.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(169.76)">
@@ -1914,7 +1914,7 @@
                 </g>
             </g>
             <g id="99.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="169.39,970.34 122.77,712.17"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="169.39,970.34 122.77,712.17"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(163.62,938.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-10.24)">
@@ -1936,7 +1936,7 @@
         <g id="100">
             <desc>T6-9-1</desc>
             <g id="100.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable" points="49.01,440.71 -41.32,487.90"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="49.01,440.71 -41.32,487.90"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(20.21,455.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-117.58)">
@@ -1955,7 +1955,7 @@
                 </g>
             </g>
             <g id="100.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-184.83,562.87 -94.50,515.68"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-184.83,562.87 -94.50,515.68"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-156.03,547.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(62.42)">

--- a/network-area-diagram/src/test/resources/IEEE_57_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_57_bus.svg
@@ -490,7 +490,7 @@
         <g id="99">
             <desc>L1-2-1</desc>
             <g id="99.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-296.81,-88.92 -503.09,-54.25"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-296.81,-88.92 -503.09,-54.25"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-328.86,-83.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-99.54)">
@@ -509,7 +509,7 @@
                 </g>
             </g>
             <g id="99.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-709.36,-19.58 -503.09,-54.25"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-709.36,-19.58 -503.09,-54.25"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-677.31,-24.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(80.46)">
@@ -531,7 +531,7 @@
         <g id="100">
             <desc>L1-15-1</desc>
             <g id="100.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-243.19,-86.13 -77.73,-40.30"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-243.19,-86.13 -77.73,-40.30"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-211.87,-77.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(105.48)">
@@ -550,7 +550,7 @@
                 </g>
             </g>
             <g id="100.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="87.73,5.53 -77.73,-40.30"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="87.73,5.53 -77.73,-40.30"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(56.41,-3.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-74.52)">
@@ -572,7 +572,7 @@
         <g id="101">
             <desc>L1-16-1</desc>
             <g id="101.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-255.96,-69.65 -134.85,140.48"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-255.96,-69.65 -134.85,140.48"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-239.73,-41.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(150.04)">
@@ -591,7 +591,7 @@
                 </g>
             </g>
             <g id="101.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-13.74,350.60 -134.85,140.48"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-13.74,350.60 -134.85,140.48"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-29.97,322.45)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-29.96)">
@@ -613,7 +613,7 @@
         <g id="102">
             <desc>L1-17-1</desc>
             <g id="102.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-244.58,-104.68 -131.90,-154.95"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-244.58,-104.68 -131.90,-154.95"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-214.90,-117.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(65.96)">
@@ -632,7 +632,7 @@
                 </g>
             </g>
             <g id="102.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-19.23,-205.21 -131.90,-154.95"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-19.23,-205.21 -131.90,-154.95"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-48.91,-191.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-114.04)">
@@ -654,7 +654,7 @@
         <g id="103">
             <desc>L9-10-1</desc>
             <g id="103.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="604.90,750.12 698.39,782.42"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="604.90,750.12 698.39,782.42"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(635.62,760.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(109.06)">
@@ -673,7 +673,7 @@
                 </g>
             </g>
             <g id="103.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="791.88,814.71 698.39,782.42"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="791.88,814.71 698.39,782.42"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(761.16,804.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-70.94)">
@@ -695,7 +695,7 @@
         <g id="104">
             <desc>L10-12-1</desc>
             <g id="104.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="804.05,794.40 616.39,620.49"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="804.05,794.40 616.39,620.49"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(780.22,772.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-47.18)">
@@ -714,7 +714,7 @@
                 </g>
             </g>
             <g id="104.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="428.72,446.59 616.39,620.49"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="428.72,446.59 616.39,620.49"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(452.56,468.68)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(132.82)">
@@ -736,7 +736,7 @@
         <g id="105">
             <desc>L50-51-1</desc>
             <g id="105.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1128.69,677.24 999.49,748.71"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1128.69,677.24 999.49,748.71"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1100.25,692.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-118.95)">
@@ -755,7 +755,7 @@
                 </g>
             </g>
             <g id="105.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="870.29,820.17 999.49,748.71"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="870.29,820.17 999.49,748.71"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(924.98,789.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(61.05)">
@@ -822,7 +822,7 @@
         <g id="107">
             <desc>L9-11-1</desc>
             <g id="107.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="594.09,693.80 903.82,426.63"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="594.09,693.80 903.82,426.63"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(618.70,672.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(49.22)">
@@ -841,7 +841,7 @@
                 </g>
             </g>
             <g id="107.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1213.56,159.46 903.82,426.63"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1213.56,159.46 903.82,426.63"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1173.80,193.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-130.78)">
@@ -863,7 +863,7 @@
         <g id="108">
             <desc>L11-13-1</desc>
             <g id="108.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1205.18,142.34 1000.94,183.26"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1205.18,142.34 1000.94,183.26"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1153.71,152.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-101.33)">
@@ -882,7 +882,7 @@
                 </g>
             </g>
             <g id="108.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="796.69,224.19 1000.94,183.26"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="796.69,224.19 1000.94,183.26"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(828.55,217.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(78.67)">
@@ -904,7 +904,7 @@
         <g id="109">
             <desc>L41-42-1</desc>
             <g id="109.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1289.35,102.42 1460.45,-15.05"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1289.35,102.42 1460.45,-15.05"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1316.15,84.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(55.53)">
@@ -923,7 +923,7 @@
                 </g>
             </g>
             <g id="109.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1631.55,-132.52 1460.45,-15.05"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1631.55,-132.52 1460.45,-15.05"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1604.75,-114.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-124.47)">
@@ -986,7 +986,7 @@
         <g id="111">
             <desc>L56-41-1</desc>
             <g id="111.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1424.75,-506.87 1341.23,-213.60"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1424.75,-506.87 1341.23,-213.60"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1415.85,-475.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-164.10)">
@@ -1005,7 +1005,7 @@
                 </g>
             </g>
             <g id="111.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1257.70,79.67 1341.23,-213.60"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1257.70,79.67 1341.23,-213.60"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1266.60,48.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(15.90)">
@@ -1117,7 +1117,7 @@
         <g id="114">
             <desc>L9-12-1</desc>
             <g id="114.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="526.18,679.27 473.19,566.04"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="526.18,679.27 473.19,566.04"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(512.41,649.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-25.08)">
@@ -1136,7 +1136,7 @@
                 </g>
             </g>
             <g id="114.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="420.21,452.80 473.19,566.04"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="420.21,452.80 473.19,566.04"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(433.98,482.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(154.92)">
@@ -1158,7 +1158,7 @@
         <g id="115">
             <desc>L12-13-1</desc>
             <g id="115.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="432.34,414.10 561.45,339.21"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="432.34,414.10 561.45,339.21"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(460.45,397.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(59.89)">
@@ -1177,7 +1177,7 @@
                 </g>
             </g>
             <g id="115.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="690.57,264.33 561.45,339.21"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="690.57,264.33 561.45,339.21"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(662.45,280.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-120.11)">
@@ -1199,7 +1199,7 @@
         <g id="116">
             <desc>L12-16-1</desc>
             <g id="116.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="381.28,424.32 204.27,401.16"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="381.28,424.32 204.27,401.16"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(349.06,420.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-82.54)">
@@ -1218,7 +1218,7 @@
                 </g>
             </g>
             <g id="116.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="27.26,378.00 204.27,401.16"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="27.26,378.00 204.27,401.16"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(59.48,382.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(97.46)">
@@ -1240,7 +1240,7 @@
         <g id="117">
             <desc>L12-17-1</desc>
             <g id="117.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="393.98,404.57 207.22,105.74"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="393.98,404.57 207.22,105.74"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(376.75,377.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-32.00)">
@@ -1259,7 +1259,7 @@
                 </g>
             </g>
             <g id="117.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="20.46,-193.10 207.22,105.74"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="20.46,-193.10 207.22,105.74"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(37.68,-165.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(148.00)">
@@ -1281,7 +1281,7 @@
         <g id="118">
             <desc>L9-13-1</desc>
             <g id="118.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="571.10,677.65 645.43,483.42"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="571.10,677.65 645.43,483.42"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(582.72,647.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(20.94)">
@@ -1300,7 +1300,7 @@
                 </g>
             </g>
             <g id="118.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="719.76,289.19 645.43,483.42"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="719.76,289.19 645.43,483.42"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(708.14,319.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-159.06)">
@@ -1322,7 +1322,7 @@
         <g id="119">
             <desc>L13-14-1</desc>
             <g id="119.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="716.84,182.99 673.11,85.16"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="716.84,182.99 673.11,85.16"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(703.58,153.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.08)">
@@ -1341,7 +1341,7 @@
                 </g>
             </g>
             <g id="119.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="629.38,-12.67 673.11,85.16"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="629.38,-12.67 673.11,85.16"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(642.65,17.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.92)">
@@ -1363,7 +1363,7 @@
         <g id="120">
             <desc>L13-15-1</desc>
             <g id="120.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="686.20,216.04 441.73,128.18"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="686.20,216.04 441.73,128.18"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(655.61,205.05)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-70.23)">
@@ -1382,7 +1382,7 @@
                 </g>
             </g>
             <g id="120.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="197.26,40.33 441.73,128.18"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="197.26,40.33 441.73,128.18"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(227.84,51.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(109.77)">
@@ -1404,7 +1404,7 @@
         <g id="121">
             <desc>L48-49-1</desc>
             <g id="121.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="904.69,-104.11 828.49,53.31"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="904.69,-104.11 828.49,53.31"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(890.53,-74.86)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-154.17)">
@@ -1423,7 +1423,7 @@
                 </g>
             </g>
             <g id="121.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="752.29,210.73 828.49,53.31"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="752.29,210.73 828.49,53.31"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(779.52,154.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(25.83)">
@@ -1445,7 +1445,7 @@
         <g id="122">
             <desc>L49-50-1</desc>
             <g id="122.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="759.38,255.30 946.53,449.71"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="759.38,255.30 946.53,449.71"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(802.73,300.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(136.09)">
@@ -1464,7 +1464,7 @@
                 </g>
             </g>
             <g id="122.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1133.68,644.12 946.53,449.71"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1133.68,644.12 946.53,449.71"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1111.14,620.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-43.91)">
@@ -1486,7 +1486,7 @@
         <g id="123">
             <desc>L38-49-1</desc>
             <g id="123.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="483.80,-320.83 606.30,-55.16"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="483.80,-320.83 606.30,-55.16"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(497.41,-291.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.25)">
@@ -1505,7 +1505,7 @@
                 </g>
             </g>
             <g id="123.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="728.79,210.51 606.30,-55.16"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="728.79,210.51 606.30,-55.16"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(702.62,153.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.75)">
@@ -1572,7 +1572,7 @@
         <g id="125">
             <desc>L14-15-1</desc>
             <g id="125.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="549.39,-54.65 374.53,-22.14"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="549.39,-54.65 374.53,-22.14"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(517.44,-48.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-100.53)">
@@ -1591,7 +1591,7 @@
                 </g>
             </g>
             <g id="125.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="199.68,10.37 374.53,-22.14"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="199.68,10.37 374.53,-22.14"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(231.63,4.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(79.47)">
@@ -1613,7 +1613,7 @@
         <g id="126">
             <desc>L46-47-1</desc>
             <g id="126.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="626.02,-83.93 789.69,-236.72"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="626.02,-83.93 789.69,-236.72"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(671.71,-126.58)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(46.97)">
@@ -1632,7 +1632,7 @@
                 </g>
             </g>
             <g id="126.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="953.37,-389.50 789.69,-236.72"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="953.37,-389.50 789.69,-236.72"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(929.61,-367.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-133.03)">
@@ -1699,7 +1699,7 @@
         <g id="128">
             <desc>L3-15-1</desc>
             <g id="128.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-668.71,388.37 -288.98,216.48"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-668.71,388.37 -288.98,216.48"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-639.11,374.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(65.65)">
@@ -1718,7 +1718,7 @@
                 </g>
             </g>
             <g id="128.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="90.76,44.59 -288.98,216.48"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="90.76,44.59 -288.98,216.48"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(61.16,57.99)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-114.35)">
@@ -1740,7 +1740,7 @@
         <g id="129">
             <desc>L44-45-1</desc>
             <g id="129.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="186.31,-550.63 165.76,-278.59"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="186.31,-550.63 165.76,-278.59"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(183.86,-518.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-175.68)">
@@ -1759,7 +1759,7 @@
                 </g>
             </g>
             <g id="129.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="145.22,-6.54 165.76,-278.59"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="145.22,-6.54 165.76,-278.59"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(149.92,-68.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(4.32)">
@@ -1826,7 +1826,7 @@
         <g id="131">
             <desc>L18-19-1</desc>
             <g id="131.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1146.04,1108.12 -1052.22,1264.54"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1146.04,1108.12 -1052.22,1264.54"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1113.90,1161.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(149.04)">
@@ -1845,7 +1845,7 @@
                 </g>
             </g>
             <g id="131.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-958.41,1420.95 -1052.22,1264.54"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-958.41,1420.95 -1052.22,1264.54"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-975.12,1393.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-30.96)">
@@ -1867,7 +1867,7 @@
         <g id="132">
             <desc>L19-20-1</desc>
             <g id="132.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-924.82,1425.08 -766.51,1266.73"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-924.82,1425.08 -766.51,1266.73"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-901.84,1402.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(44.99)">
@@ -1886,7 +1886,7 @@
                 </g>
             </g>
             <g id="132.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-608.21,1108.37 -766.51,1266.73"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-608.21,1108.37 -766.51,1266.73"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-652.40,1152.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-135.01)">
@@ -1908,7 +1908,7 @@
         <g id="133">
             <desc>L2-3-1</desc>
             <g id="133.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-733.67,12.34 -715.12,192.35"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-733.67,12.34 -715.12,192.35"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-730.34,44.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(174.12)">
@@ -1927,7 +1927,7 @@
                 </g>
             </g>
             <g id="133.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-696.58,372.36 -715.12,192.35"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-696.58,372.36 -715.12,192.35"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-699.91,340.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-5.88)">
@@ -1949,7 +1949,7 @@
         <g id="134">
             <desc>L21-22-1</desc>
             <g id="134.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-576.87,1032.66 -489.25,618.30"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-576.87,1032.66 -489.25,618.30"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-570.15,1000.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(11.94)">
@@ -1968,7 +1968,7 @@
                 </g>
             </g>
             <g id="134.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-401.62,203.93 -489.25,618.30"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-401.62,203.93 -489.25,618.30"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-408.34,235.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-168.06)">
@@ -2035,7 +2035,7 @@
         <g id="136">
             <desc>L22-23-1</desc>
             <g id="136.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-414.02,156.31 -653.34,-117.74"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-414.02,156.31 -653.34,-117.74"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-435.39,131.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-41.13)">
@@ -2054,7 +2054,7 @@
                 </g>
             </g>
             <g id="136.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-892.67,-391.80 -653.34,-117.74"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-892.67,-391.80 -653.34,-117.74"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-871.29,-367.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(138.87)">
@@ -2076,7 +2076,7 @@
         <g id="137">
             <desc>L22-38-1</desc>
             <g id="137.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-372.37,162.84 38.18,-84.39"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-372.37,162.84 38.18,-84.39"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-344.53,146.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(58.94)">
@@ -2095,7 +2095,7 @@
                 </g>
             </g>
             <g id="137.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="448.73,-331.61 38.18,-84.39"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="448.73,-331.61 38.18,-84.39"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(420.89,-314.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-121.06)">
@@ -2117,7 +2117,7 @@
         <g id="138">
             <desc>L23-24-1</desc>
             <g id="138.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-931.99,-429.98 -1084.34,-555.34"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-931.99,-429.98 -1084.34,-555.34"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-957.09,-450.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-50.55)">
@@ -2136,7 +2136,7 @@
                 </g>
             </g>
             <g id="138.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1236.69,-680.70 -1084.34,-555.34"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1236.69,-680.70 -1084.34,-555.34"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1211.59,-660.05)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(129.45)">
@@ -2158,7 +2158,7 @@
         <g id="139">
             <desc>L25-30-1</desc>
             <g id="139.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1266.29,-751.69 -1169.60,-976.85"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1266.29,-751.69 -1169.60,-976.85"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1245.58,-799.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(23.24)">
@@ -2177,7 +2177,7 @@
                 </g>
             </g>
             <g id="139.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1072.91,-1202.01 -1169.60,-976.85"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1072.91,-1202.01 -1169.60,-976.85"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1085.73,-1172.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-156.76)">
@@ -2199,7 +2199,7 @@
         <g id="140">
             <desc>L26-27-1</desc>
             <g id="140.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1289.38,-701.82 -1405.71,-485.40"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1289.38,-701.82 -1405.71,-485.40"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1323.70,-637.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-151.74)">
@@ -2218,7 +2218,7 @@
                 </g>
             </g>
             <g id="140.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1522.05,-268.98 -1405.71,-485.40"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1522.05,-268.98 -1405.71,-485.40"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1506.66,-297.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(28.26)">
@@ -2375,7 +2375,7 @@
         <g id="144">
             <desc>L27-28-1</desc>
             <g id="144.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1526.00,-218.80 -1441.61,22.81"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1526.00,-218.80 -1441.61,22.81"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1515.28,-188.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(160.75)">
@@ -2394,7 +2394,7 @@
                 </g>
             </g>
             <g id="144.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1357.22,264.41 -1441.61,22.81"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1357.22,264.41 -1441.61,22.81"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1367.94,233.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-19.25)">
@@ -2416,7 +2416,7 @@
         <g id="145">
             <desc>L28-29-1</desc>
             <g id="145.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1327.67,308.73 -1056.78,551.44"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1327.67,308.73 -1056.78,551.44"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1303.46,330.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(131.86)">
@@ -2435,7 +2435,7 @@
                 </g>
             </g>
             <g id="145.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-785.90,794.16 -1056.78,551.44"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-785.90,794.16 -1056.78,551.44"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-810.11,772.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-48.14)">
@@ -2457,7 +2457,7 @@
         <g id="146">
             <desc>L3-4-1</desc>
             <g id="146.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-709.25,422.44 -918.53,729.73"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-709.25,422.44 -918.53,729.73"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-727.54,449.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-145.74)">
@@ -2476,7 +2476,7 @@
                 </g>
             </g>
             <g id="146.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1127.82,1037.02 -918.53,729.73"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1127.82,1037.02 -918.53,729.73"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1109.53,1010.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(34.26)">
@@ -2498,7 +2498,7 @@
         <g id="147">
             <desc>L30-31-1</desc>
             <g id="147.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1040.33,-1244.14 -851.44,-1390.77"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1040.33,-1244.14 -851.44,-1390.77"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1014.66,-1264.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(52.18)">
@@ -2517,7 +2517,7 @@
                 </g>
             </g>
             <g id="147.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-662.54,-1537.39 -851.44,-1390.77"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-662.54,-1537.39 -851.44,-1390.77"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-688.22,-1517.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-127.82)">
@@ -2539,7 +2539,7 @@
         <g id="148">
             <desc>L31-32-1</desc>
             <g id="148.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-614.74,-1562.99 -386.26,-1639.49"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-614.74,-1562.99 -386.26,-1639.49"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-583.92,-1573.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(71.49)">
@@ -2558,7 +2558,7 @@
                 </g>
             </g>
             <g id="148.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-157.79,-1715.99 -386.26,-1639.49"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-157.79,-1715.99 -386.26,-1639.49"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-188.61,-1705.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-108.51)">
@@ -2580,7 +2580,7 @@
         <g id="149">
             <desc>L32-33-1</desc>
             <g id="149.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-111.56,-1791.14 -134.15,-1946.09"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-111.56,-1791.14 -134.15,-1946.09"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-116.25,-1823.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-8.30)">
@@ -2599,7 +2599,7 @@
                 </g>
             </g>
             <g id="149.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-156.74,-2101.05 -134.15,-1946.09"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-156.74,-2101.05 -134.15,-1946.09"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-152.05,-2068.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(171.70)">
@@ -2621,7 +2621,7 @@
         <g id="150">
             <desc>L34-35-1</desc>
             <g id="150.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-76.65,-1727.30 184.70,-1659.14"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-76.65,-1727.30 184.70,-1659.14"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-16.17,-1711.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.62)">
@@ -2640,7 +2640,7 @@
                 </g>
             </g>
             <g id="150.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="446.06,-1590.98 184.70,-1659.14"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="446.06,-1590.98 184.70,-1659.14"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(414.61,-1599.18)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-75.38)">
@@ -2707,7 +2707,7 @@
         <g id="152">
             <desc>L35-36-1</desc>
             <g id="152.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="495.16,-1568.21 731.41,-1402.05"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="495.16,-1568.21 731.41,-1402.05"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(521.75,-1549.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(125.12)">
@@ -2726,7 +2726,7 @@
                 </g>
             </g>
             <g id="152.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="967.66,-1235.89 731.41,-1402.05"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="967.66,-1235.89 731.41,-1402.05"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(941.07,-1254.58)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-54.88)">
@@ -2748,7 +2748,7 @@
         <g id="153">
             <desc>L36-37-1</desc>
             <g id="153.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="984.88,-1193.08 957.06,-1050.78"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="984.88,-1193.08 957.06,-1050.78"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(978.64,-1161.18)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-168.94)">
@@ -2767,7 +2767,7 @@
                 </g>
             </g>
             <g id="153.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="929.25,-908.49 957.06,-1050.78"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="929.25,-908.49 957.06,-1050.78"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(935.48,-940.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(11.06)">
@@ -2789,7 +2789,7 @@
         <g id="154">
             <desc>L36-40-1</desc>
             <g id="154.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1005.68,-1197.37 1215.33,-891.12"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1005.68,-1197.37 1215.33,-891.12"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1024.04,-1170.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(145.61)">
@@ -2808,7 +2808,7 @@
                 </g>
             </g>
             <g id="154.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1424.97,-584.87 1215.33,-891.12"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1424.97,-584.87 1215.33,-891.12"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1389.66,-636.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-34.39)">
@@ -2830,7 +2830,7 @@
         <g id="155">
             <desc>L37-38-1</desc>
             <g id="155.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="906.25,-860.47 698.13,-613.65"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="906.25,-860.47 698.13,-613.65"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(885.30,-835.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-139.86)">
@@ -2849,7 +2849,7 @@
                 </g>
             </g>
             <g id="155.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="490.02,-366.83 698.13,-613.65"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="490.02,-366.83 698.13,-613.65"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(510.97,-391.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(40.14)">
@@ -2871,7 +2871,7 @@
         <g id="156">
             <desc>L37-39-1</desc>
             <g id="156.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="951.19,-885.43 1171.30,-917.25"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="951.19,-885.43 1171.30,-917.25"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(983.36,-890.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(81.77)">
@@ -2890,7 +2890,7 @@
                 </g>
             </g>
             <g id="156.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1391.42,-949.08 1171.30,-917.25"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1391.42,-949.08 1171.30,-917.25"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1329.56,-940.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-98.23)">
@@ -2912,7 +2912,7 @@
         <g id="157">
             <desc>L38-44-1</desc>
             <g id="157.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="451.00,-363.21 330.33,-461.93"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="451.00,-363.21 330.33,-461.93"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(425.85,-383.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-50.71)">
@@ -2931,7 +2931,7 @@
                 </g>
             </g>
             <g id="157.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="209.66,-560.64 330.33,-461.93"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="209.66,-560.64 330.33,-461.93"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(234.82,-540.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(129.29)">
@@ -2953,7 +2953,7 @@
         <g id="158">
             <desc>L38-48-1</desc>
             <g id="158.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="497.00,-333.74 694.48,-237.33"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="497.00,-333.74 694.48,-237.33"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(526.21,-319.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(116.02)">
@@ -2972,7 +2972,7 @@
                 </g>
             </g>
             <g id="158.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="891.96,-140.93 694.48,-237.33"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="891.96,-140.93 694.48,-237.33"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(862.75,-155.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-63.98)">
@@ -2994,7 +2994,7 @@
         <g id="159">
             <desc>L57-56-1</desc>
             <g id="159.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1421.85,-895.60 1429.57,-757.59"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1421.85,-895.60 1429.57,-757.59"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1423.66,-863.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(176.80)">
@@ -3013,7 +3013,7 @@
                 </g>
             </g>
             <g id="159.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1437.29,-619.59 1429.57,-757.59"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1437.29,-619.59 1429.57,-757.59"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1435.47,-652.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-3.20)">
@@ -3080,7 +3080,7 @@
         <g id="161">
             <desc>L4-5-1</desc>
             <g id="161.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1217.03,1075.84 -1347.52,1055.87"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1217.03,1075.84 -1347.52,1055.87"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1249.15,1070.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-81.30)">
@@ -3099,7 +3099,7 @@
                 </g>
             </g>
             <g id="161.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1478.02,1035.89 -1347.52,1055.87"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1478.02,1035.89 -1347.52,1055.87"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1445.89,1040.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(98.70)">
@@ -3121,7 +3121,7 @@
         <g id="162">
             <desc>L4-6-1</desc>
             <g id="162.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1134.36,1033.17 -1093.75,952.40"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1134.36,1033.17 -1093.75,952.40"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1119.76,1004.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(26.69)">
@@ -3140,7 +3140,7 @@
                 </g>
             </g>
             <g id="162.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1053.14,871.63 -1093.75,952.40"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1053.14,871.63 -1093.75,952.40"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1067.74,900.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-153.31)">
@@ -3252,7 +3252,7 @@
         <g id="165">
             <desc>L56-42-1</desc>
             <g id="165.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1466.87,-511.08 1554.24,-341.80"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1466.87,-511.08 1554.24,-341.80"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1481.78,-482.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(152.70)">
@@ -3271,7 +3271,7 @@
                 </g>
             </g>
             <g id="165.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="1641.60,-172.52 1554.24,-341.80"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1641.60,-172.52 1554.24,-341.80"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1626.70,-201.40)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-27.30)">
@@ -3338,7 +3338,7 @@
         <g id="167">
             <desc>L47-48-1</desc>
             <g id="167.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="967.99,-381.32 945.07,-268.57"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="967.99,-381.32 945.07,-268.57"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(961.52,-349.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-168.51)">
@@ -3357,7 +3357,7 @@
                 </g>
             </g>
             <g id="167.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="922.15,-155.81 945.07,-268.57"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="922.15,-155.81 945.07,-268.57"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(928.62,-187.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(11.49)">
@@ -3379,7 +3379,7 @@
         <g id="168">
             <desc>L5-6-1</desc>
             <g id="168.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1479.65,1021.57 -1272.99,939.40"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1479.65,1021.57 -1272.99,939.40"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1449.44,1009.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(68.32)">
@@ -3398,7 +3398,7 @@
                 </g>
             </g>
             <g id="168.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1066.34,857.23 -1272.99,939.40"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1066.34,857.23 -1272.99,939.40"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1096.54,869.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-111.68)">
@@ -3420,7 +3420,7 @@
         <g id="169">
             <desc>L29-52-1</desc>
             <g id="169.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-710.22,879.71 -514.35,1160.97"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-710.22,879.71 -514.35,1160.97"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-691.64,906.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(145.15)">
@@ -3439,7 +3439,7 @@
                 </g>
             </g>
             <g id="169.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-318.48,1442.23 -514.35,1160.97"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-318.48,1442.23 -514.35,1160.97"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-337.05,1415.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-34.85)">
@@ -3461,7 +3461,7 @@
         <g id="170">
             <desc>L52-53-1</desc>
             <g id="170.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-277.43,1475.51 -81.16,1558.51"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-277.43,1475.51 -81.16,1558.51"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-247.50,1488.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(112.92)">
@@ -3480,7 +3480,7 @@
                 </g>
             </g>
             <g id="170.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="115.11,1641.51 -81.16,1558.51"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="115.11,1641.51 -81.16,1558.51"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(85.17,1628.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-67.08)">
@@ -3502,7 +3502,7 @@
         <g id="171">
             <desc>L53-54-1</desc>
             <g id="171.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="160.70,1633.62 308.58,1497.93"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="160.70,1633.62 308.58,1497.93"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(184.64,1611.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(47.46)">
@@ -3521,7 +3521,7 @@
                 </g>
             </g>
             <g id="171.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="456.46,1362.24 308.58,1497.93"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="456.46,1362.24 308.58,1497.93"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(432.52,1384.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-132.54)">
@@ -3543,7 +3543,7 @@
         <g id="172">
             <desc>L54-55-1</desc>
             <g id="172.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="480.02,1316.35 513.64,1037.50"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="480.02,1316.35 513.64,1037.50"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(483.91,1284.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(6.87)">
@@ -3562,7 +3562,7 @@
                 </g>
             </g>
             <g id="172.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="547.26,758.65 513.64,1037.50"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="547.26,758.65 513.64,1037.50"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(539.78,820.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-173.13)">
@@ -3584,7 +3584,7 @@
         <g id="173">
             <desc>L6-7-1</desc>
             <g id="173.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1013.32,845.72 -891.93,839.80"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1013.32,845.72 -891.93,839.80"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-980.85,844.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(87.20)">
@@ -3603,7 +3603,7 @@
                 </g>
             </g>
             <g id="173.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-770.54,833.87 -891.93,839.80"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-770.54,833.87 -891.93,839.80"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-832.97,836.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-92.80)">
@@ -3625,7 +3625,7 @@
         <g id="174">
             <desc>L6-8-1</desc>
             <g id="174.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-1013.29,847.52 -663.96,853.35"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1013.29,847.52 -663.96,853.35"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-980.79,848.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(90.96)">
@@ -3644,7 +3644,7 @@
                 </g>
             </g>
             <g id="174.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-314.64,859.17 -663.96,853.35"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-314.64,859.17 -663.96,853.35"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-347.14,858.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-89.04)">
@@ -3666,7 +3666,7 @@
         <g id="175">
             <desc>L7-8-1</desc>
             <g id="175.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-715.63,834.16 -515.11,846.08"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-715.63,834.16 -515.11,846.08"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-653.24,837.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(93.40)">
@@ -3685,7 +3685,7 @@
                 </g>
             </g>
             <g id="175.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-314.59,858.00 -515.11,846.08"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-314.59,858.00 -515.11,846.08"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-347.04,856.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-86.60)">
@@ -3752,7 +3752,7 @@
         <g id="177">
             <desc>L8-9-1</desc>
             <g id="177.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-259.96,855.47 116.88,797.76"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-259.96,855.47 116.88,797.76"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-227.83,850.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(81.29)">
@@ -3771,7 +3771,7 @@
                 </g>
             </g>
             <g id="177.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable" points="493.71,740.06 116.88,797.76"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="493.71,740.06 116.88,797.76"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(461.59,744.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-98.71)">

--- a/network-area-diagram/src/test/resources/current_limits.svg
+++ b/network-area-diagram/src/test/resources/current_limits.svg
@@ -79,7 +79,7 @@
     <g class="nad-branch-edges">
         <g id="4" class="nad-overload">
             <g id="4.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="-183.23,-161.22 -118.51,-20.70"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-183.23,-161.22 -118.51,-20.70"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-169.63,-131.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.27)">
@@ -98,7 +98,7 @@
                 </g>
             </g>
             <g id="4.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="-53.78,119.83 -118.51,-20.70"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-53.78,119.83 -118.51,-20.70"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-67.38,90.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.73)">
@@ -119,7 +119,7 @@
         </g>
         <g id="7" class="nad-dangling-line-edge">
             <g id="7.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="-14.82,146.33 139.65,154.93"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-14.82,146.33 139.65,154.93"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(17.63,148.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(93.18)">
@@ -138,7 +138,7 @@
                 </g>
             </g>
             <g id="7.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="294.13,163.52 139.65,154.93"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="294.13,163.52 139.65,154.93"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(261.68,161.72)"></g>
             </g>
         </g>

--- a/network-area-diagram/src/test/resources/detailed_text_node.svg
+++ b/network-area-diagram/src/test/resources/detailed_text_node.svg
@@ -144,7 +144,7 @@
     <g class="nad-branch-edges">
         <g id="4">
             <g id="4.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-183.23,-161.22 -118.51,-20.70"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-183.23,-161.22 -118.51,-20.70"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-169.63,-131.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.27)">
@@ -163,7 +163,7 @@
                 </g>
             </g>
             <g id="4.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-53.78,119.83 -118.51,-20.70"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-53.78,119.83 -118.51,-20.70"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-67.38,90.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.73)">
@@ -184,7 +184,7 @@
         </g>
         <g id="7" class="nad-dangling-line-edge">
             <g id="7.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-14.82,146.33 139.65,154.93"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-14.82,146.33 139.65,154.93"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(17.63,148.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(93.18)">
@@ -203,7 +203,7 @@
                 </g>
             </g>
             <g id="7.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="294.13,163.52 139.65,154.93"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="294.13,163.52 139.65,154.93"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(261.68,161.72)"></g>
             </g>
         </g>

--- a/network-area-diagram/src/test/resources/detailed_text_node_no_legend.svg
+++ b/network-area-diagram/src/test/resources/detailed_text_node_no_legend.svg
@@ -144,7 +144,7 @@
     <g class="nad-branch-edges">
         <g id="4">
             <g id="4.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-183.23,-161.22 -118.51,-20.70"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-183.23,-161.22 -118.51,-20.70"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-169.63,-131.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.27)">
@@ -163,7 +163,7 @@
                 </g>
             </g>
             <g id="4.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-53.78,119.83 -118.51,-20.70"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-53.78,119.83 -118.51,-20.70"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-67.38,90.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.73)">
@@ -184,7 +184,7 @@
         </g>
         <g id="7" class="nad-dangling-line-edge">
             <g id="7.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-14.82,146.33 139.65,154.93"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-14.82,146.33 139.65,154.93"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(17.63,148.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(93.18)">
@@ -203,7 +203,7 @@
                 </g>
             </g>
             <g id="7.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="294.13,163.52 139.65,154.93"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="294.13,163.52 139.65,154.93"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(261.68,161.72)"></g>
             </g>
         </g>

--- a/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.0.svg
+++ b/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.0.svg
@@ -153,7 +153,7 @@
     <g class="nad-branch-edges">
         <g id="30">
             <g id="30.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="-1053.42,340.93 -866.40,391.80"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1053.42,340.93 -866.40,391.80"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1022.06,349.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(105.22)">
@@ -172,7 +172,7 @@
                 </g>
             </g>
             <g id="30.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="-679.38,442.67 -866.40,391.80"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-679.38,442.67 -866.40,391.80"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-710.74,434.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-74.78)">
@@ -193,7 +193,7 @@
         </g>
         <g id="31">
             <g id="31.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="-1378.04,125.88 -1264.89,204.77"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1378.04,125.88 -1264.89,204.77"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1351.38,144.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(124.88)">
@@ -212,7 +212,7 @@
                 </g>
             </g>
             <g id="31.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="-1102.52,317.98 -1215.67,239.09"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1102.52,317.98 -1215.67,239.09"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1129.18,299.39)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-55.12)">
@@ -237,7 +237,7 @@
         </g>
         <g id="32">
             <g id="32.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="-625.73,445.30 -392.94,405.86"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-625.73,445.30 -392.94,405.86"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-593.69,439.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(80.39)">
@@ -256,7 +256,7 @@
                 </g>
             </g>
             <g id="32.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="-160.15,366.42 -392.94,405.86"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-160.15,366.42 -392.94,405.86"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-192.19,371.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-99.61)">
@@ -277,7 +277,7 @@
         </g>
         <g id="33">
             <g id="33.1" class="nad-vl50to70">
-                <polyline class="nad-edge-path nad-stretchable" points="717.69,-62.60 860.99,-182.07"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="717.69,-62.60 860.99,-182.07"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(742.65,-83.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(50.18)">
@@ -296,7 +296,7 @@
                 </g>
             </g>
             <g id="33.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="1050.37,-339.96 907.07,-220.49"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1050.37,-339.96 907.07,-220.49"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1025.41,-319.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-129.82)">
@@ -321,7 +321,7 @@
         </g>
         <g id="34">
             <g id="34.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="-108.34,349.72 254.83,171.63"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-108.34,349.72 254.83,171.63"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-79.16,335.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(63.88)">
@@ -340,7 +340,7 @@
                 </g>
             </g>
             <g id="34.2" class="nad-vl50to70">
-                <polyline class="nad-edge-path nad-stretchable" points="671.88,-32.88 308.70,145.21"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="671.88,-32.88 308.70,145.21"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(642.70,-18.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-116.12)">
@@ -365,7 +365,7 @@
         </g>
         <g id="35">
             <g id="35.1" class="nad-vl50to70">
-                <polyline class="nad-edge-path nad-stretchable" points="713.75,-23.52 793.31,75.87"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="713.75,-23.52 793.31,75.87"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(734.06,1.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(141.33)">
@@ -384,7 +384,7 @@
                 </g>
             </g>
             <g id="35.2" class="nad-vl50to70">
-                <polyline class="nad-edge-path nad-stretchable" points="872.86,175.25 793.31,75.87"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="872.86,175.25 793.31,75.87"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(852.55,149.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-38.67)">
@@ -405,7 +405,7 @@
         </g>
         <g id="36">
             <g id="36.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="394.36,-8.93 391.55,-230.95"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="394.36,-8.93 391.55,-230.95"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(393.95,-41.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-0.72)">
@@ -424,7 +424,7 @@
                 </g>
             </g>
             <g id="36.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="388.74,-452.96 391.55,-230.95"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="388.74,-452.96 391.55,-230.95"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(389.15,-420.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(179.28)">
@@ -445,7 +445,7 @@
         </g>
         <g id="37">
             <g id="37.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-177.00,-244.11 96.36,-118.51"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-177.00,-244.11 96.36,-118.51"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-147.47,-230.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(114.68)">
@@ -464,7 +464,7 @@
                 </g>
             </g>
             <g id="37.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="369.72,7.08 96.36,-118.51"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="369.72,7.08 96.36,-118.51"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(340.19,-6.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-65.32)">
@@ -485,7 +485,7 @@
         </g>
         <g id="38">
             <g id="38.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="524.17,514.32 462.91,279.75"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="524.17,514.32 462.91,279.75"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(515.96,482.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-14.64)">
@@ -504,7 +504,7 @@
                 </g>
             </g>
             <g id="38.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="401.66,45.17 462.91,279.75"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="401.66,45.17 462.91,279.75"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(409.87,76.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(165.36)">
@@ -525,7 +525,7 @@
         </g>
         <g id="39">
             <g id="39.1" class="nad-vl50to70">
-                <polyline class="nad-edge-path nad-stretchable" points="864.17,187.42 670.61,117.80"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="864.17,187.42 670.61,117.80"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(833.58,176.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-70.22)">
@@ -544,7 +544,7 @@
                 </g>
             </g>
             <g id="39.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="420.58,27.87 614.15,97.49"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="420.58,27.87 614.15,97.49"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(451.17,38.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(109.78)">
@@ -569,7 +569,7 @@
         </g>
         <g id="40">
             <g id="40.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="361.12,-484.01 207.73,-504.02"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="361.12,-484.01 207.73,-504.02"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(328.90,-488.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-82.57)">
@@ -588,7 +588,7 @@
                 </g>
             </g>
             <g id="40.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="54.34,-524.02 207.73,-504.02"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="54.34,-524.02 207.73,-504.02"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(86.56,-519.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(97.43)">
@@ -609,7 +609,7 @@
         </g>
         <g id="41">
             <g id="41.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="0.47,-534.58 -163.09,-577.62"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="0.47,-534.58 -163.09,-577.62"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-30.96,-542.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-75.26)">
@@ -628,7 +628,7 @@
                 </g>
             </g>
             <g id="41.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-326.66,-620.67 -163.09,-577.62"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-326.66,-620.67 -163.09,-577.62"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-295.23,-612.40)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.74)">
@@ -649,7 +649,7 @@
         </g>
         <g id="42">
             <g id="42.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="27.54,-500.09 32.02,-240.72"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="27.54,-500.09 32.02,-240.72"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(28.10,-467.59)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(179.01)">
@@ -668,7 +668,7 @@
                 </g>
             </g>
             <g id="42.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="36.49,18.65 32.02,-240.72"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="36.49,18.65 32.02,-240.72"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(35.93,-13.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-0.99)">
@@ -689,7 +689,7 @@
         </g>
         <g id="43">
             <g id="43.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-342.90,-602.19 -277.62,-441.63"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-342.90,-602.19 -277.62,-441.63"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-330.66,-572.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(157.88)">
@@ -708,7 +708,7 @@
                 </g>
             </g>
             <g id="43.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-212.34,-281.06 -277.62,-441.63"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-212.34,-281.06 -277.62,-441.63"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-224.58,-311.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-22.12)">
@@ -729,7 +729,7 @@
         </g>
         <g id="44">
             <g id="44.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="44.75,72.52 117.06,317.59"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="44.75,72.52 117.06,317.59"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(53.95,103.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(163.56)">
@@ -748,7 +748,7 @@
                 </g>
             </g>
             <g id="44.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="189.36,562.66 117.06,317.59"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="189.36,562.66 117.06,317.59"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(180.17,531.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-16.44)">
@@ -769,7 +769,7 @@
         </g>
         <g id="45">
             <g id="45.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="224.37,585.12 364.13,564.99"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="224.37,585.12 364.13,564.99"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(256.53,580.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(81.80)">
@@ -788,7 +788,7 @@
                 </g>
             </g>
             <g id="45.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="503.90,544.85 364.13,564.99"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="503.90,544.85 364.13,564.99"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(471.73,549.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-98.20)">

--- a/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.2.svg
+++ b/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.2.svg
@@ -153,7 +153,7 @@
     <g class="nad-branch-edges">
         <g id="30">
             <g id="30.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="-1767.52,311.35 -1619.12,463.19"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1767.52,311.35 -1619.12,463.19"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1744.81,334.60)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(135.65)">
@@ -172,7 +172,7 @@
                 </g>
             </g>
             <g id="30.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="-1470.72,615.02 -1619.12,463.19"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1470.72,615.02 -1619.12,463.19"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1493.44,591.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-44.35)">
@@ -193,7 +193,7 @@
         </g>
         <g id="31">
             <g id="31.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="-2010.40,-11.18 -1924.56,105.06"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2010.40,-11.18 -1924.56,105.06"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1991.10,14.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(143.55)">
@@ -212,7 +212,7 @@
                 </g>
             </g>
             <g id="31.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="-1803.08,269.57 -1888.92,153.33"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1803.08,269.57 -1888.92,153.33"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1822.39,243.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-36.45)">
@@ -237,7 +237,7 @@
         </g>
         <g id="32">
             <g id="32.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="-1427.00,647.18 -1228.08,748.64"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1427.00,647.18 -1228.08,748.64"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-1398.05,661.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(117.02)">
@@ -256,7 +256,7 @@
                 </g>
             </g>
             <g id="32.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="-1029.17,850.09 -1228.08,748.64"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1029.17,850.09 -1228.08,748.64"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-1058.12,835.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-62.98)">
@@ -277,7 +277,7 @@
         </g>
         <g id="33">
             <g id="33.1" class="nad-vl50to70">
-                <polyline class="nad-edge-path nad-stretchable" points="-461.07,733.13 -497.83,590.10"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-461.07,733.13 -497.83,590.10"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-469.16,701.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-14.41)">
@@ -296,7 +296,7 @@
                 </g>
             </g>
             <g id="33.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="-549.53,388.95 -512.77,531.99"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-549.53,388.95 -512.77,531.99"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-541.44,420.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(165.59)">
@@ -321,7 +321,7 @@
         </g>
         <g id="34">
             <g id="34.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="-977.64,857.54 -758.94,816.68"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-977.64,857.54 -758.94,816.68"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-945.69,851.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(79.42)">
@@ -340,7 +340,7 @@
                 </g>
             </g>
             <g id="34.2" class="nad-vl50to70">
-                <polyline class="nad-edge-path nad-stretchable" points="-481.26,764.81 -699.96,805.67"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-481.26,764.81 -699.96,805.67"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-513.21,770.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-100.58)">
@@ -365,7 +365,7 @@
         </g>
         <g id="35">
             <g id="35.1" class="nad-vl50to70">
-                <polyline class="nad-edge-path nad-stretchable" points="-427.62,752.81 -170.92,685.75"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-427.62,752.81 -170.92,685.75"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-396.17,744.60)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(75.36)">
@@ -384,7 +384,7 @@
                 </g>
             </g>
             <g id="35.2" class="nad-vl50to70">
-                <polyline class="nad-edge-path nad-stretchable" points="85.77,618.69 -170.92,685.75"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="85.77,618.69 -170.92,685.75"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(54.33,626.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-104.64)">
@@ -405,7 +405,7 @@
         </g>
         <g id="36">
             <g id="36.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="516.57,93.31 611.37,-122.24"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="516.57,93.31 611.37,-122.24"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(529.65,63.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(23.74)">
@@ -424,7 +424,7 @@
                 </g>
             </g>
             <g id="36.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="706.18,-337.78 611.37,-122.24"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="706.18,-337.78 611.37,-122.24"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(693.09,-308.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-156.26)">
@@ -445,7 +445,7 @@
         </g>
         <g id="37">
             <g id="37.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="127.64,-376.35 308.22,-139.86"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="127.64,-376.35 308.22,-139.86"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(147.36,-350.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(142.63)">
@@ -464,7 +464,7 @@
                 </g>
             </g>
             <g id="37.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="488.80,96.62 308.22,-139.86"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="488.80,96.62 308.22,-139.86"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(469.08,70.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-37.37)">
@@ -485,7 +485,7 @@
         </g>
         <g id="38">
             <g id="38.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="1109.90,193.19 821.34,157.52"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1109.90,193.19 821.34,157.52"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1077.65,189.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-82.95)">
@@ -504,7 +504,7 @@
                 </g>
             </g>
             <g id="38.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="532.79,121.85 821.34,157.52"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="532.79,121.85 821.34,157.52"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(565.04,125.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(97.05)">
@@ -525,7 +525,7 @@
         </g>
         <g id="39">
             <g id="39.1" class="nad-vl50to70">
-                <polyline class="nad-edge-path nad-stretchable" points="129.52,590.23 290.24,388.57"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="129.52,590.23 290.24,388.57"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(149.77,564.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(38.55)">
@@ -544,7 +544,7 @@
                 </g>
             </g>
             <g id="39.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="488.35,139.98 327.63,341.65"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="488.35,139.98 327.63,341.65"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(468.10,165.40)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-141.45)">
@@ -569,7 +569,7 @@
         </g>
         <g id="40">
             <g id="40.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="722.81,-389.89 768.34,-610.30"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="722.81,-389.89 768.34,-610.30"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(729.39,-421.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(11.67)">
@@ -588,7 +588,7 @@
                 </g>
             </g>
             <g id="40.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="813.87,-830.71 768.34,-610.30"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="813.87,-830.71 768.34,-610.30"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(807.30,-798.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-168.33)">
@@ -609,7 +609,7 @@
         </g>
         <g id="41">
             <g id="41.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="791.98,-859.19 543.88,-873.14"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="791.98,-859.19 543.88,-873.14"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(759.53,-861.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-86.78)">
@@ -628,7 +628,7 @@
                 </g>
             </g>
             <g id="41.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="295.78,-887.10 543.88,-873.14"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="295.78,-887.10 543.88,-873.14"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(328.23,-885.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(93.22)">
@@ -649,7 +649,7 @@
         </g>
         <g id="42">
             <g id="42.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="845.92,-850.24 1089.27,-782.19"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="845.92,-850.24 1089.27,-782.19"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(877.22,-841.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(105.62)">
@@ -668,7 +668,7 @@
                 </g>
             </g>
             <g id="42.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="1332.63,-714.15 1089.27,-782.19"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1332.63,-714.15 1089.27,-782.19"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1301.33,-722.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-74.38)">
@@ -689,7 +689,7 @@
         </g>
         <g id="43">
             <g id="43.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="259.92,-862.46 189.63,-643.42"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="259.92,-862.46 189.63,-643.42"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(249.99,-831.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-162.21)">
@@ -708,7 +708,7 @@
                 </g>
             </g>
             <g id="43.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="119.35,-424.39 189.63,-643.42"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="119.35,-424.39 189.63,-643.42"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(129.28,-455.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(17.79)">
@@ -729,7 +729,7 @@
         </g>
         <g id="44">
             <g id="44.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="1366.06,-680.13 1425.49,-452.55"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1366.06,-680.13 1425.49,-452.55"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1374.27,-648.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(165.37)">
@@ -748,7 +748,7 @@
                 </g>
             </g>
             <g id="44.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="1484.91,-224.96 1425.49,-452.55"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1484.91,-224.96 1425.49,-452.55"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1476.70,-256.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-14.63)">
@@ -769,7 +769,7 @@
         </g>
         <g id="45">
             <g id="45.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="1473.48,-177.89 1314.53,-0.90"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1473.48,-177.89 1314.53,-0.90"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(1451.77,-153.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-138.07)">
@@ -788,7 +788,7 @@
                 </g>
             </g>
             <g id="45.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable" points="1155.57,176.10 1314.53,-0.90"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1155.57,176.10 1314.53,-0.90"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(1177.28,151.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(41.93)">

--- a/network-area-diagram/src/test/resources/edge_info_missing_label.svg
+++ b/network-area-diagram/src/test/resources/edge_info_missing_label.svg
@@ -79,7 +79,7 @@
     <g class="nad-branch-edges">
         <g id="4">
             <g id="4.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="-183.23,-161.22 -118.51,-20.70"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-183.23,-161.22 -118.51,-20.70"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-178.00,-149.86)">
                     <g class="nad-state-out">
                         <g transform="rotate(155.27)">
@@ -90,7 +90,7 @@
                 </g>
             </g>
             <g id="4.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="-53.78,119.83 -118.51,-20.70"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-53.78,119.83 -118.51,-20.70"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-59.01,108.47)">
                     <g class="nad-state-out">
                         <g transform="rotate(-24.73)">
@@ -103,7 +103,7 @@
         </g>
         <g id="7" class="nad-dangling-line-edge">
             <g id="7.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="-14.82,146.33 139.65,154.93"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-14.82,146.33 139.65,154.93"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-2.34,147.03)">
                     <g class="nad-state-out">
                         <g transform="rotate(93.18)">
@@ -114,7 +114,7 @@
                 </g>
             </g>
             <g id="7.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="294.13,163.52 139.65,154.93"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="294.13,163.52 139.65,154.93"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(281.65,162.83)">
                     <g class="nad-state-out">
                         <g transform="rotate(-86.82)">

--- a/network-area-diagram/src/test/resources/edge_info_perpendicular_label.svg
+++ b/network-area-diagram/src/test/resources/edge_info_perpendicular_label.svg
@@ -79,7 +79,7 @@
     <g class="nad-branch-edges">
         <g id="4">
             <g id="4.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="-183.23,-161.22 -118.51,-20.70"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-183.23,-161.22 -118.51,-20.70"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-161.27,-113.53)">
                     <g class="nad-state-out">
                         <g transform="rotate(155.27)">
@@ -92,7 +92,7 @@
                 </g>
             </g>
             <g id="4.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="-53.78,119.83 -118.51,-20.70"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-53.78,119.83 -118.51,-20.70"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-75.75,72.14)">
                     <g class="nad-state-out">
                         <g transform="rotate(-24.73)">
@@ -107,7 +107,7 @@
         </g>
         <g id="7" class="nad-dangling-line-edge">
             <g id="7.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="-14.82,146.33 139.65,154.93"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-14.82,146.33 139.65,154.93"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(37.60,149.25)">
                     <g class="nad-state-out">
                         <g transform="rotate(93.18)">
@@ -120,7 +120,7 @@
                 </g>
             </g>
             <g id="7.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="294.13,163.52 139.65,154.93"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="294.13,163.52 139.65,154.93"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(241.71,160.60)">
                     <g class="nad-state-out">
                         <g transform="rotate(-86.82)">

--- a/network-area-diagram/src/test/resources/edge_info_shift.svg
+++ b/network-area-diagram/src/test/resources/edge_info_shift.svg
@@ -91,7 +91,7 @@
     <g class="nad-branch-edges">
         <g id="8">
             <g id="8.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="-219.57,227.17 -168.03,237.17 -53.24,197.61"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-219.57,227.17 -168.03,237.17 -53.24,197.61"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-149.13,230.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(70.98)">
@@ -110,7 +110,7 @@
                 </g>
             </g>
             <g id="8.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="95.99,118.42 61.56,158.05 -53.24,197.61"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="95.99,118.42 61.56,158.05 -53.24,197.61"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(42.65,164.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-109.02)">
@@ -131,7 +131,7 @@
         </g>
         <g id="9">
             <g id="9.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="-208.86,178.53 -194.10,161.54 -79.30,121.98"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-208.86,178.53 -194.10,161.54 -79.30,121.98"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-175.19,155.02)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(70.98)">
@@ -150,7 +150,7 @@
                 </g>
             </g>
             <g id="9.2" class="nad-disconnected nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="87.03,92.42 35.49,82.41 -79.30,121.98"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="87.03,92.42 35.49,82.41 -79.30,121.98"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(16.58,88.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-109.02)">
@@ -171,7 +171,7 @@
         </g>
         <g id="10">
             <g id="10.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="-235.36,165.54 -216.19,69.13"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-235.36,165.54 -216.19,69.13"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-230.97,143.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(11.25)">
@@ -190,7 +190,7 @@
                 </g>
             </g>
             <g id="10.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="-185.32,-86.12 -204.49,10.28"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-185.32,-86.12 -204.49,10.28"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-195.56,-34.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-168.75)">
@@ -215,7 +215,7 @@
         </g>
         <g id="11">
             <g id="11.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="91.68,81.63 3.61,18.50"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="91.68,81.63 3.61,18.50"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(73.39,68.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-54.36)">
@@ -234,7 +234,7 @@
                 </g>
             </g>
             <g id="11.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="-133.22,-79.59 -45.15,-16.46"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-133.22,-79.59 -45.15,-16.46"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-114.94,-66.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(125.64)">
@@ -259,7 +259,7 @@
         </g>
         <g id="14" class="nad-dangling-line-edge">
             <g id="14.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="138.53,85.18 288.81,8.64"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="138.53,85.18 288.81,8.64"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(158.58,74.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(63.01)">
@@ -278,7 +278,7 @@
                 </g>
             </g>
             <g id="14.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="439.09,-67.90 288.81,8.64"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="439.09,-67.90 288.81,8.64"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(419.04,-57.69)"></g>
             </g>
         </g>

--- a/network-area-diagram/src/test/resources/hvdc-vl-depth-1.svg
+++ b/network-area-diagram/src/test/resources/hvdc-vl-depth-1.svg
@@ -76,7 +76,7 @@
         <g id="4" class="nad-hvdc-edge">
             <desc>HVDC</desc>
             <g id="4.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="140.62,-69.02 37.43,39.35"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="140.62,-69.02 37.43,39.35"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(118.21,-45.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-136.40)">
@@ -95,7 +95,7 @@
                 </g>
             </g>
             <g id="4.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="-65.77,147.71 37.43,39.35"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-65.77,147.71 37.43,39.35"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-43.36,124.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(43.60)">

--- a/network-area-diagram/src/test/resources/hvdc.svg
+++ b/network-area-diagram/src/test/resources/hvdc.svg
@@ -98,7 +98,7 @@
         <g id="10">
             <desc>TWT</desc>
             <g id="10.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="-547.03,60.17 -400.64,54.62"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-547.03,60.17 -400.64,54.62"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-514.56,58.94)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(87.83)">
@@ -117,7 +117,7 @@
                 </g>
             </g>
             <g id="10.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="-194.28,46.80 -340.68,52.35"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-194.28,46.80 -340.68,52.35"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-226.76,48.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-92.17)">
@@ -144,7 +144,7 @@
         <g id="11" class="nad-hvdc-edge">
             <desc>HVDC1</desc>
             <g id="11.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="-151.62,26.99 -47.74,-86.96"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-151.62,26.99 -47.74,-86.96"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-129.73,2.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(42.36)">
@@ -163,7 +163,7 @@
                 </g>
             </g>
             <g id="11.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="56.14,-200.90 -47.74,-86.96"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="56.14,-200.90 -47.74,-86.96"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(34.25,-176.88)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-137.64)">
@@ -188,7 +188,7 @@
         <g id="12" class="nad-hvdc-edge">
             <desc>HVDC2</desc>
             <g id="12.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="-143.47,48.73 40.85,69.82"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-143.47,48.73 40.85,69.82"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-111.18,52.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(96.53)">
@@ -207,7 +207,7 @@
                 </g>
             </g>
             <g id="12.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="225.16,90.92 40.85,69.82"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="225.16,90.92 40.85,69.82"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(192.87,87.22)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-83.47)">
@@ -232,7 +232,7 @@
         <g id="13">
             <desc>LINE_S2S3</desc>
             <g id="13.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="85.87,-197.54 161.91,-62.96"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="85.87,-197.54 161.91,-62.96"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(101.86,-169.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(150.53)">
@@ -251,7 +251,7 @@
                 </g>
             </g>
             <g id="13.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="237.95,71.61 161.91,-62.96"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="237.95,71.61 161.91,-62.96"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(221.96,43.32)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-29.47)">
@@ -273,7 +273,7 @@
         <g id="14">
             <desc>LINE_S3S4</desc>
             <g id="14.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="274.69,101.87 442.12,157.61"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="274.69,101.87 442.12,157.61"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(305.53,112.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(108.41)">
@@ -292,7 +292,7 @@
                 </g>
             </g>
             <g id="14.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="609.55,213.35 442.12,157.61"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="609.55,213.35 442.12,157.61"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(578.71,203.09)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-71.59)">

--- a/network-area-diagram/src/test/resources/parallel_transformers.svg
+++ b/network-area-diagram/src/test/resources/parallel_transformers.svg
@@ -82,7 +82,7 @@
     <g class="nad-branch-edges">
         <g id="5">
             <g id="5.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="-197.26,-158.81 -202.08,-106.53 -167.39,-31.21"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-197.26,-158.81 -202.08,-106.53 -167.39,-31.21"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-189.53,-79.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.27)">
@@ -101,7 +101,7 @@
                 </g>
             </g>
             <g id="5.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="-64.73,128.92 -107.60,98.61 -142.29,23.29"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-64.73,128.92 -107.60,98.61 -142.29,23.29"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-120.15,71.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.73)">
@@ -126,7 +126,7 @@
         </g>
         <g id="6">
             <g id="6.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="-147.79,-152.99 -129.42,-140.00 -94.73,-64.68"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-147.79,-152.99 -129.42,-140.00 -94.73,-64.68"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-116.87,-112.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.27)">
@@ -145,7 +145,7 @@
                 </g>
             </g>
             <g id="6.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="-39.75,117.42 -34.93,65.14 -69.63,-10.18"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-39.75,117.42 -34.93,65.14 -69.63,-10.18"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-47.48,37.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.73)">
@@ -170,7 +170,7 @@
         </g>
         <g id="9" class="nad-dangling-line-edge">
             <g id="9.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="-14.82,146.33 139.65,154.93"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-14.82,146.33 139.65,154.93"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(17.63,148.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(93.18)">
@@ -189,7 +189,7 @@
                 </g>
             </g>
             <g id="9.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable" points="294.13,163.52 139.65,154.93"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="294.13,163.52 139.65,154.93"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(261.68,161.72)"></g>
             </g>
         </g>

--- a/network-area-diagram/src/test/resources/simple-eu-loop100.svg
+++ b/network-area-diagram/src/test/resources/simple-eu-loop100.svg
@@ -210,7 +210,7 @@
         <g id="22">
             <desc>BBE1AA1  BBE2AA1  1</desc>
             <g id="22.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-492.02,-186.98 -525.98,-146.94 -553.50,4.50"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-492.02,-186.98 -525.98,-146.94 -553.50,4.50"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-531.34,-117.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-169.70)">
@@ -229,7 +229,7 @@
                 </g>
             </g>
             <g id="22.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-563.32,205.36 -581.02,155.93 -553.50,4.50"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-563.32,205.36 -581.02,155.93 -553.50,4.50"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-575.65,126.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(10.30)">
@@ -292,7 +292,7 @@
         <g id="24">
             <desc>BBE2AA1  BBE3AA1  1</desc>
             <g id="24.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-536.26,210.28 -502.31,170.24 -474.79,18.80"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-536.26,210.28 -502.31,170.24 -474.79,18.80"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-496.94,140.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(10.30)">
@@ -311,7 +311,7 @@
                 </g>
             </g>
             <g id="24.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-454.85,-153.82 -447.27,-132.64 -474.79,18.80"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-454.85,-153.82 -447.27,-132.64 -474.79,18.80"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-452.63,-103.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-169.70)">
@@ -333,7 +333,7 @@
         <g id="25">
             <desc>NNL2AA1  BBE3AA1  1</desc>
             <g id="25.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-169.02,-515.19 -301.37,-381.97"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-169.02,-515.19 -301.37,-381.97"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-191.93,-492.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-135.19)">
@@ -352,7 +352,7 @@
                 </g>
             </g>
             <g id="25.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-433.71,-248.75 -301.37,-381.97"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-433.71,-248.75 -301.37,-381.97"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-410.81,-271.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(44.81)">
@@ -420,7 +420,7 @@
         <g id="27">
             <desc>BBE2AA1  FFR3AA1  1</desc>
             <g id="27.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-542.54,256.22 -463.08,428.65"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-542.54,256.22 -463.08,428.65"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-528.94,285.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.26)">
@@ -439,7 +439,7 @@
                 </g>
             </g>
             <g id="27.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-383.63,601.07 -463.08,428.65"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-383.63,601.07 -463.08,428.65"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-397.23,571.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.74)">
@@ -461,7 +461,7 @@
         <g id="28">
             <desc>DDE1AA1  DDE2AA1  1</desc>
             <g id="28.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="686.85,254.06 577.89,137.39"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="686.85,254.06 577.89,137.39"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(664.67,230.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-43.04)">
@@ -480,7 +480,7 @@
                 </g>
             </g>
             <g id="28.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="468.92,20.71 577.89,137.39"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="468.92,20.71 577.89,137.39"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(491.10,44.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(136.96)">
@@ -502,7 +502,7 @@
         <g id="29">
             <desc>DDE1AA1  DDE3AA1  1</desc>
             <g id="29.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="680.95,286.30 540.26,355.48"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="680.95,286.30 540.26,355.48"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(651.78,300.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-116.19)">
@@ -521,7 +521,7 @@
                 </g>
             </g>
             <g id="29.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="399.58,424.67 540.26,355.48"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="399.58,424.67 540.26,355.48"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(428.75,410.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(63.81)">
@@ -543,7 +543,7 @@
         <g id="30">
             <desc>DDE2AA1  DDE3AA1  1</desc>
             <g id="30.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="445.47,27.72 412.53,218.71"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="445.47,27.72 412.53,218.71"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(439.95,59.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-170.21)">
@@ -562,7 +562,7 @@
                 </g>
             </g>
             <g id="30.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="379.58,409.70 412.53,218.71"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="379.58,409.70 412.53,218.71"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(385.11,377.68)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(9.79)">
@@ -584,7 +584,7 @@
         <g id="31">
             <desc>DDE2AA1  NNL3AA1  1</desc>
             <g id="31.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="438.92,-24.49 351.07,-220.83"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="438.92,-24.49 351.07,-220.83"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(425.65,-54.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.10)">
@@ -603,7 +603,7 @@
                 </g>
             </g>
             <g id="31.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="263.22,-417.18 351.07,-220.83"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="263.22,-417.18 351.07,-220.83"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(276.49,-387.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.90)">
@@ -625,7 +625,7 @@
         <g id="32">
             <desc>FFR2AA1  DDE3AA1  1</desc>
             <g id="32.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="79.75,693.89 216.96,574.38"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="79.75,693.89 216.96,574.38"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(104.26,672.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.94)">
@@ -644,7 +644,7 @@
                 </g>
             </g>
             <g id="32.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="354.17,454.87 216.96,574.38"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="354.17,454.87 216.96,574.38"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(329.66,476.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-131.06)">
@@ -707,7 +707,7 @@
         <g id="34">
             <desc>FFR1AA1  FFR3AA1  1</desc>
             <g id="34.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="16.78,712.38 -20.67,675.58 -157.85,640.12"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="16.78,712.38 -20.67,675.58 -157.85,640.12"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-49.72,668.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-75.51)">
@@ -726,7 +726,7 @@
                 </g>
             </g>
             <g id="34.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-345.62,618.69 -295.03,604.66 -157.85,640.12"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-345.62,618.69 -295.03,604.66 -157.85,640.12"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-265.98,612.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.49)">
@@ -748,7 +748,7 @@
         <g id="35">
             <desc>FFR2AA1  FFR3AA1  1</desc>
             <g id="35.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-19.02,747.02 -40.70,753.04 -177.87,717.58"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-19.02,747.02 -40.70,753.04 -177.87,717.58"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-69.74,745.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-75.51)">
@@ -767,7 +767,7 @@
                 </g>
             </g>
             <g id="35.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-352.50,645.32 -315.05,682.11 -177.87,717.58"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-352.50,645.32 -315.05,682.11 -177.87,717.58"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-286.01,689.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.49)">
@@ -835,7 +835,7 @@
         <g id="37">
             <desc>NNL1AA1  NNL2AA1  1</desc>
             <g id="37.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="103.48,-784.15 -13.29,-669.08"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="103.48,-784.15 -13.29,-669.08"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(80.33,-761.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-134.58)">
@@ -854,7 +854,7 @@
                 </g>
             </g>
             <g id="37.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-130.06,-554.00 -13.29,-669.08"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-130.06,-554.00 -13.29,-669.08"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-106.91,-576.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(45.42)">
@@ -876,7 +876,7 @@
         <g id="38">
             <desc>NNL1AA1  NNL3AA1  1</desc>
             <g id="38.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="132.31,-777.55 187.53,-622.87"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="132.31,-777.55 187.53,-622.87"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(143.24,-746.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(160.36)">
@@ -895,7 +895,7 @@
                 </g>
             </g>
             <g id="38.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="242.74,-468.18 187.53,-622.87"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="242.74,-468.18 187.53,-622.87"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(231.82,-498.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-19.64)">
@@ -917,7 +917,7 @@
         <g id="39">
             <desc>NNL2AA1  NNL3AA1  1</desc>
             <g id="39.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-122.84,-528.53 51.17,-488.49"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-122.84,-528.53 51.17,-488.49"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-91.17,-521.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(102.96)">
@@ -936,7 +936,7 @@
                 </g>
             </g>
             <g id="39.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="225.19,-448.45 51.17,-488.49"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="225.19,-448.45 51.17,-488.49"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(193.52,-455.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-77.04)">

--- a/network-area-diagram/src/test/resources/simple-eu-loop80.svg
+++ b/network-area-diagram/src/test/resources/simple-eu-loop80.svg
@@ -210,7 +210,7 @@
         <g id="22">
             <desc>BBE1AA1  BBE2AA1  1</desc>
             <g id="22.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-492.02,-186.98 -525.98,-146.94 -553.50,4.50"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-492.02,-186.98 -525.98,-146.94 -553.50,4.50"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-531.34,-117.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-169.70)">
@@ -229,7 +229,7 @@
                 </g>
             </g>
             <g id="22.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-563.32,205.36 -581.02,155.93 -553.50,4.50"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-563.32,205.36 -581.02,155.93 -553.50,4.50"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-575.65,126.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(10.30)">
@@ -292,7 +292,7 @@
         <g id="24">
             <desc>BBE2AA1  BBE3AA1  1</desc>
             <g id="24.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-536.26,210.28 -502.31,170.24 -474.79,18.80"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-536.26,210.28 -502.31,170.24 -474.79,18.80"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-496.94,140.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(10.30)">
@@ -311,7 +311,7 @@
                 </g>
             </g>
             <g id="24.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-454.85,-153.82 -447.27,-132.64 -474.79,18.80"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-454.85,-153.82 -447.27,-132.64 -474.79,18.80"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-452.63,-103.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-169.70)">
@@ -333,7 +333,7 @@
         <g id="25">
             <desc>NNL2AA1  BBE3AA1  1</desc>
             <g id="25.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-169.02,-515.19 -301.37,-381.97"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-169.02,-515.19 -301.37,-381.97"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-191.93,-492.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-135.19)">
@@ -352,7 +352,7 @@
                 </g>
             </g>
             <g id="25.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-433.71,-248.75 -301.37,-381.97"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-433.71,-248.75 -301.37,-381.97"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-410.81,-271.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(44.81)">
@@ -420,7 +420,7 @@
         <g id="27">
             <desc>BBE2AA1  FFR3AA1  1</desc>
             <g id="27.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-542.54,256.22 -463.08,428.65"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-542.54,256.22 -463.08,428.65"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-528.94,285.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.26)">
@@ -439,7 +439,7 @@
                 </g>
             </g>
             <g id="27.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-383.63,601.07 -463.08,428.65"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-383.63,601.07 -463.08,428.65"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-397.23,571.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.74)">
@@ -461,7 +461,7 @@
         <g id="28">
             <desc>DDE1AA1  DDE2AA1  1</desc>
             <g id="28.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="686.85,254.06 577.89,137.39"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="686.85,254.06 577.89,137.39"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(664.67,230.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-43.04)">
@@ -480,7 +480,7 @@
                 </g>
             </g>
             <g id="28.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="468.92,20.71 577.89,137.39"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="468.92,20.71 577.89,137.39"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(491.10,44.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(136.96)">
@@ -502,7 +502,7 @@
         <g id="29">
             <desc>DDE1AA1  DDE3AA1  1</desc>
             <g id="29.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="680.95,286.30 540.26,355.48"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="680.95,286.30 540.26,355.48"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(651.78,300.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-116.19)">
@@ -521,7 +521,7 @@
                 </g>
             </g>
             <g id="29.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="399.58,424.67 540.26,355.48"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="399.58,424.67 540.26,355.48"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(428.75,410.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(63.81)">
@@ -543,7 +543,7 @@
         <g id="30">
             <desc>DDE2AA1  DDE3AA1  1</desc>
             <g id="30.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="445.47,27.72 412.53,218.71"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="445.47,27.72 412.53,218.71"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(439.95,59.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-170.21)">
@@ -562,7 +562,7 @@
                 </g>
             </g>
             <g id="30.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="379.58,409.70 412.53,218.71"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="379.58,409.70 412.53,218.71"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(385.11,377.68)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(9.79)">
@@ -584,7 +584,7 @@
         <g id="31">
             <desc>DDE2AA1  NNL3AA1  1</desc>
             <g id="31.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="438.92,-24.49 351.07,-220.83"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="438.92,-24.49 351.07,-220.83"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(425.65,-54.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.10)">
@@ -603,7 +603,7 @@
                 </g>
             </g>
             <g id="31.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="263.22,-417.18 351.07,-220.83"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="263.22,-417.18 351.07,-220.83"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(276.49,-387.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.90)">
@@ -625,7 +625,7 @@
         <g id="32">
             <desc>FFR2AA1  DDE3AA1  1</desc>
             <g id="32.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="79.75,693.89 216.96,574.38"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="79.75,693.89 216.96,574.38"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(104.26,672.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.94)">
@@ -644,7 +644,7 @@
                 </g>
             </g>
             <g id="32.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="354.17,454.87 216.96,574.38"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="354.17,454.87 216.96,574.38"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(329.66,476.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-131.06)">
@@ -707,7 +707,7 @@
         <g id="34">
             <desc>FFR1AA1  FFR3AA1  1</desc>
             <g id="34.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="16.78,712.38 -20.67,675.58 -157.85,640.12"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="16.78,712.38 -20.67,675.58 -157.85,640.12"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-49.72,668.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-75.51)">
@@ -726,7 +726,7 @@
                 </g>
             </g>
             <g id="34.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-345.62,618.69 -295.03,604.66 -157.85,640.12"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-345.62,618.69 -295.03,604.66 -157.85,640.12"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-265.98,612.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.49)">
@@ -748,7 +748,7 @@
         <g id="35">
             <desc>FFR2AA1  FFR3AA1  1</desc>
             <g id="35.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-19.02,747.02 -40.70,753.04 -177.87,717.58"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-19.02,747.02 -40.70,753.04 -177.87,717.58"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-69.74,745.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-75.51)">
@@ -767,7 +767,7 @@
                 </g>
             </g>
             <g id="35.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-352.50,645.32 -315.05,682.11 -177.87,717.58"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-352.50,645.32 -315.05,682.11 -177.87,717.58"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-286.01,689.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.49)">
@@ -835,7 +835,7 @@
         <g id="37">
             <desc>NNL1AA1  NNL2AA1  1</desc>
             <g id="37.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="103.48,-784.15 -13.29,-669.08"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="103.48,-784.15 -13.29,-669.08"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(80.33,-761.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-134.58)">
@@ -854,7 +854,7 @@
                 </g>
             </g>
             <g id="37.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-130.06,-554.00 -13.29,-669.08"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-130.06,-554.00 -13.29,-669.08"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-106.91,-576.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(45.42)">
@@ -876,7 +876,7 @@
         <g id="38">
             <desc>NNL1AA1  NNL3AA1  1</desc>
             <g id="38.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="132.31,-777.55 187.53,-622.87"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="132.31,-777.55 187.53,-622.87"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(143.24,-746.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(160.36)">
@@ -895,7 +895,7 @@
                 </g>
             </g>
             <g id="38.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="242.74,-468.18 187.53,-622.87"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="242.74,-468.18 187.53,-622.87"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(231.82,-498.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-19.64)">
@@ -917,7 +917,7 @@
         <g id="39">
             <desc>NNL2AA1  NNL3AA1  1</desc>
             <g id="39.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-122.84,-528.53 51.17,-488.49"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-122.84,-528.53 51.17,-488.49"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-91.17,-521.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(102.96)">
@@ -936,7 +936,7 @@
                 </g>
             </g>
             <g id="39.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="225.19,-448.45 51.17,-488.49"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="225.19,-448.45 51.17,-488.49"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(193.52,-455.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-77.04)">

--- a/network-area-diagram/src/test/resources/simple-eu.svg
+++ b/network-area-diagram/src/test/resources/simple-eu.svg
@@ -210,7 +210,7 @@
         <g id="22">
             <desc>BBE1AA1  BBE2AA1  1</desc>
             <g id="22.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-492.02,-186.98 -525.98,-146.94 -553.50,4.50"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-492.02,-186.98 -525.98,-146.94 -553.50,4.50"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-531.34,-117.42)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-169.70)">
@@ -229,7 +229,7 @@
                 </g>
             </g>
             <g id="22.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-563.32,205.36 -581.02,155.93 -553.50,4.50"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-563.32,205.36 -581.02,155.93 -553.50,4.50"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-575.65,126.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(10.30)">
@@ -292,7 +292,7 @@
         <g id="24">
             <desc>BBE2AA1  BBE3AA1  1</desc>
             <g id="24.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-536.26,210.28 -502.31,170.24 -474.79,18.80"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-536.26,210.28 -502.31,170.24 -474.79,18.80"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-496.94,140.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(10.30)">
@@ -311,7 +311,7 @@
                 </g>
             </g>
             <g id="24.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-454.85,-153.82 -447.27,-132.64 -474.79,18.80"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-454.85,-153.82 -447.27,-132.64 -474.79,18.80"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-452.63,-103.12)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-169.70)">
@@ -333,7 +333,7 @@
         <g id="25">
             <desc>NNL2AA1  BBE3AA1  1</desc>
             <g id="25.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-169.02,-515.19 -301.37,-381.97"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-169.02,-515.19 -301.37,-381.97"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-191.93,-492.13)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-135.19)">
@@ -352,7 +352,7 @@
                 </g>
             </g>
             <g id="25.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-433.71,-248.75 -301.37,-381.97"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-433.71,-248.75 -301.37,-381.97"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-410.81,-271.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(44.81)">
@@ -420,7 +420,7 @@
         <g id="27">
             <desc>BBE2AA1  FFR3AA1  1</desc>
             <g id="27.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-542.54,256.22 -463.08,428.65"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-542.54,256.22 -463.08,428.65"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-528.94,285.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.26)">
@@ -439,7 +439,7 @@
                 </g>
             </g>
             <g id="27.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-383.63,601.07 -463.08,428.65"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-383.63,601.07 -463.08,428.65"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-397.23,571.55)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-24.74)">
@@ -461,7 +461,7 @@
         <g id="28">
             <desc>DDE1AA1  DDE2AA1  1</desc>
             <g id="28.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="686.85,254.06 577.89,137.39"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="686.85,254.06 577.89,137.39"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(664.67,230.31)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-43.04)">
@@ -480,7 +480,7 @@
                 </g>
             </g>
             <g id="28.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="468.92,20.71 577.89,137.39"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="468.92,20.71 577.89,137.39"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(491.10,44.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(136.96)">
@@ -502,7 +502,7 @@
         <g id="29">
             <desc>DDE1AA1  DDE3AA1  1</desc>
             <g id="29.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="680.95,286.30 540.26,355.48"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="680.95,286.30 540.26,355.48"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(651.78,300.64)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-116.19)">
@@ -521,7 +521,7 @@
                 </g>
             </g>
             <g id="29.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="399.58,424.67 540.26,355.48"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="399.58,424.67 540.26,355.48"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(428.75,410.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(63.81)">
@@ -543,7 +543,7 @@
         <g id="30">
             <desc>DDE2AA1  DDE3AA1  1</desc>
             <g id="30.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="445.47,27.72 412.53,218.71"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="445.47,27.72 412.53,218.71"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(439.95,59.74)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-170.21)">
@@ -562,7 +562,7 @@
                 </g>
             </g>
             <g id="30.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="379.58,409.70 412.53,218.71"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="379.58,409.70 412.53,218.71"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(385.11,377.68)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(9.79)">
@@ -584,7 +584,7 @@
         <g id="31">
             <desc>DDE2AA1  NNL3AA1  1</desc>
             <g id="31.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="438.92,-24.49 351.07,-220.83"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="438.92,-24.49 351.07,-220.83"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(425.65,-54.15)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-24.10)">
@@ -603,7 +603,7 @@
                 </g>
             </g>
             <g id="31.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="263.22,-417.18 351.07,-220.83"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="263.22,-417.18 351.07,-220.83"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(276.49,-387.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.90)">
@@ -625,7 +625,7 @@
         <g id="32">
             <desc>FFR2AA1  DDE3AA1  1</desc>
             <g id="32.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="79.75,693.89 216.96,574.38"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="79.75,693.89 216.96,574.38"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(104.26,672.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.94)">
@@ -644,7 +644,7 @@
                 </g>
             </g>
             <g id="32.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="354.17,454.87 216.96,574.38"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="354.17,454.87 216.96,574.38"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(329.66,476.21)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-131.06)">
@@ -707,7 +707,7 @@
         <g id="34">
             <desc>FFR1AA1  FFR3AA1  1</desc>
             <g id="34.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="16.78,712.38 -20.67,675.58 -157.85,640.12"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="16.78,712.38 -20.67,675.58 -157.85,640.12"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-49.72,668.08)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-75.51)">
@@ -726,7 +726,7 @@
                 </g>
             </g>
             <g id="34.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-345.62,618.69 -295.03,604.66 -157.85,640.12"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-345.62,618.69 -295.03,604.66 -157.85,640.12"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-265.98,612.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.49)">
@@ -748,7 +748,7 @@
         <g id="35">
             <desc>FFR2AA1  FFR3AA1  1</desc>
             <g id="35.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-19.02,747.02 -40.70,753.04 -177.87,717.58"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-19.02,747.02 -40.70,753.04 -177.87,717.58"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-69.74,745.53)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-75.51)">
@@ -767,7 +767,7 @@
                 </g>
             </g>
             <g id="35.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-352.50,645.32 -315.05,682.11 -177.87,717.58"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-352.50,645.32 -315.05,682.11 -177.87,717.58"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-286.01,689.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.49)">
@@ -835,7 +835,7 @@
         <g id="37">
             <desc>NNL1AA1  NNL2AA1  1</desc>
             <g id="37.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="103.48,-784.15 -13.29,-669.08"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="103.48,-784.15 -13.29,-669.08"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(80.33,-761.34)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-134.58)">
@@ -854,7 +854,7 @@
                 </g>
             </g>
             <g id="37.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-130.06,-554.00 -13.29,-669.08"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-130.06,-554.00 -13.29,-669.08"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-106.91,-576.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(45.42)">
@@ -876,7 +876,7 @@
         <g id="38">
             <desc>NNL1AA1  NNL3AA1  1</desc>
             <g id="38.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="132.31,-777.55 187.53,-622.87"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="132.31,-777.55 187.53,-622.87"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(143.24,-746.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(160.36)">
@@ -895,7 +895,7 @@
                 </g>
             </g>
             <g id="38.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="242.74,-468.18 187.53,-622.87"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="242.74,-468.18 187.53,-622.87"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(231.82,-498.79)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-19.64)">
@@ -917,7 +917,7 @@
         <g id="39">
             <desc>NNL2AA1  NNL3AA1  1</desc>
             <g id="39.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-122.84,-528.53 51.17,-488.49"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-122.84,-528.53 51.17,-488.49"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-91.17,-521.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(102.96)">
@@ -936,7 +936,7 @@
                 </g>
             </g>
             <g id="39.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="225.19,-448.45 51.17,-488.49"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="225.19,-448.45 51.17,-488.49"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(193.52,-455.73)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-77.04)">

--- a/network-area-diagram/src/test/resources/vl_description_id.svg
+++ b/network-area-diagram/src/test/resources/vl_description_id.svg
@@ -144,7 +144,7 @@
     <g class="nad-branch-edges">
         <g id="4">
             <g id="4.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-183.23,-161.22 -118.51,-20.70"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-183.23,-161.22 -118.51,-20.70"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-169.63,-131.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.27)">
@@ -163,7 +163,7 @@
                 </g>
             </g>
             <g id="4.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-53.78,119.83 -118.51,-20.70"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-53.78,119.83 -118.51,-20.70"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-67.38,90.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.73)">
@@ -184,7 +184,7 @@
         </g>
         <g id="7" class="nad-dangling-line-edge">
             <g id="7.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-14.82,146.33 139.65,154.93"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-14.82,146.33 139.65,154.93"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(17.63,148.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(93.18)">
@@ -203,7 +203,7 @@
                 </g>
             </g>
             <g id="7.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="294.13,163.52 139.65,154.93"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="294.13,163.52 139.65,154.93"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(261.68,161.72)"></g>
             </g>
         </g>

--- a/network-area-diagram/src/test/resources/vl_description_substation.svg
+++ b/network-area-diagram/src/test/resources/vl_description_substation.svg
@@ -144,7 +144,7 @@
     <g class="nad-branch-edges">
         <g id="4">
             <g id="4.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-183.23,-161.22 -118.51,-20.70"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-183.23,-161.22 -118.51,-20.70"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-169.63,-131.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.27)">
@@ -163,7 +163,7 @@
                 </g>
             </g>
             <g id="4.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-53.78,119.83 -118.51,-20.70"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-53.78,119.83 -118.51,-20.70"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-67.38,90.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.73)">
@@ -184,7 +184,7 @@
         </g>
         <g id="7" class="nad-dangling-line-edge">
             <g id="7.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-14.82,146.33 139.65,154.93"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-14.82,146.33 139.65,154.93"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(17.63,148.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(93.18)">
@@ -203,7 +203,7 @@
                 </g>
             </g>
             <g id="7.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="294.13,163.52 139.65,154.93"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="294.13,163.52 139.65,154.93"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(261.68,161.72)"></g>
             </g>
         </g>

--- a/network-area-diagram/src/test/resources/vl_description_substation_id.svg
+++ b/network-area-diagram/src/test/resources/vl_description_substation_id.svg
@@ -144,7 +144,7 @@
     <g class="nad-branch-edges">
         <g id="4">
             <g id="4.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-183.23,-161.22 -118.51,-20.70"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-183.23,-161.22 -118.51,-20.70"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-169.63,-131.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.27)">
@@ -163,7 +163,7 @@
                 </g>
             </g>
             <g id="4.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-53.78,119.83 -118.51,-20.70"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-53.78,119.83 -118.51,-20.70"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-67.38,90.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.73)">
@@ -184,7 +184,7 @@
         </g>
         <g id="7" class="nad-dangling-line-edge">
             <g id="7.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="-14.82,146.33 139.65,154.93"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-14.82,146.33 139.65,154.93"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(17.63,148.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(93.18)">
@@ -203,7 +203,7 @@
                 </g>
             </g>
             <g id="7.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable" points="294.13,163.52 139.65,154.93"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="294.13,163.52 139.65,154.93"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(261.68,161.72)"></g>
             </g>
         </g>

--- a/network-area-diagram/src/test/resources/voltage_limits.svg
+++ b/network-area-diagram/src/test/resources/voltage_limits.svg
@@ -82,7 +82,7 @@
     <g class="nad-branch-edges">
         <g id="5">
             <g id="5.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="-197.26,-158.81 -202.08,-106.53 -154.84,-3.96"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-197.26,-158.81 -202.08,-106.53 -154.84,-3.96"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-189.53,-79.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.27)">
@@ -101,7 +101,7 @@
                 </g>
             </g>
             <g id="5.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="-64.73,128.92 -107.60,98.61 -154.84,-3.96"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-64.73,128.92 -107.60,98.61 -154.84,-3.96"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-120.15,71.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.73)">
@@ -122,7 +122,7 @@
         </g>
         <g id="6">
             <g id="6.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="-147.79,-152.99 -129.42,-140.00 -82.18,-37.43"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-147.79,-152.99 -129.42,-140.00 -82.18,-37.43"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-116.87,-112.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.27)">
@@ -141,7 +141,7 @@
                 </g>
             </g>
             <g id="6.2" class="nad-disconnected nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="-39.75,117.42 -34.93,65.14 -82.18,-37.43"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-39.75,117.42 -34.93,65.14 -82.18,-37.43"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-47.48,37.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.73)">
@@ -162,7 +162,7 @@
         </g>
         <g id="9" class="nad-dangling-line-edge">
             <g id="9.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="-14.82,146.33 139.65,154.93"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-14.82,146.33 139.65,154.93"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(17.63,148.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(93.18)">
@@ -181,7 +181,7 @@
                 </g>
             </g>
             <g id="9.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable" points="294.13,163.52 139.65,154.93"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="294.13,163.52 139.65,154.93"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(261.68,161.72)"></g>
             </g>
         </g>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Currently the drawings for half edges are only labelled as _stretchable_.
To handle updates of these drawings during user interaction (moving nodes) we need to label each edge half as _glued_ to the corresponding edge end, in addition to _stretchable_.


**What is the new behavior (if this is a feature change)?**
Every half edge is labelled as _stretchable_ and _glued_ to its corresponding end.


