### PR TITLE
draw external part of boundary nodes

### DIFF
--- a/network-area-diagram/src/main/resources/nominalStyle.css
+++ b/network-area-diagram/src/main/resources/nominalStyle.css
@@ -30,6 +30,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}

--- a/network-area-diagram/src/main/resources/topologicalStyle.css
+++ b/network-area-diagram/src/main/resources/topologicalStyle.css
@@ -95,6 +95,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}

--- a/network-area-diagram/src/test/resources/3wt.svg
+++ b/network-area-diagram/src/test/resources/3wt.svg
@@ -33,6 +33,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}

--- a/network-area-diagram/src/test/resources/3wt_disconnected.svg
+++ b/network-area-diagram/src/test/resources/3wt_disconnected.svg
@@ -33,6 +33,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}

--- a/network-area-diagram/src/test/resources/3wt_disconnected_topological.svg
+++ b/network-area-diagram/src/test/resources/3wt_disconnected_topological.svg
@@ -98,6 +98,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}

--- a/network-area-diagram/src/test/resources/3wt_partial.svg
+++ b/network-area-diagram/src/test/resources/3wt_partial.svg
@@ -33,6 +33,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}

--- a/network-area-diagram/src/test/resources/IEEE_118_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_118_bus.svg
@@ -98,6 +98,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}

--- a/network-area-diagram/src/test/resources/IEEE_118_bus_partial.svg
+++ b/network-area-diagram/src/test/resources/IEEE_118_bus_partial.svg
@@ -98,6 +98,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}

--- a/network-area-diagram/src/test/resources/IEEE_118_bus_partial_non_connected.svg
+++ b/network-area-diagram/src/test/resources/IEEE_118_bus_partial_non_connected.svg
@@ -98,6 +98,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}

--- a/network-area-diagram/src/test/resources/IEEE_14_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus.svg
@@ -33,6 +33,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_disconnection.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_disconnection.svg
@@ -33,6 +33,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_fictitious.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_fictitious.svg
@@ -33,6 +33,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_text_nodes.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_text_nodes.svg
@@ -33,6 +33,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}

--- a/network-area-diagram/src/test/resources/IEEE_14_id_prefixed.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_id_prefixed.svg
@@ -33,6 +33,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}

--- a/network-area-diagram/src/test/resources/IEEE_24_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_24_bus.svg
@@ -33,6 +33,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}

--- a/network-area-diagram/src/test/resources/IEEE_30_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_30_bus.svg
@@ -33,6 +33,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}

--- a/network-area-diagram/src/test/resources/IEEE_57_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_57_bus.svg
@@ -98,6 +98,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}

--- a/network-area-diagram/src/test/resources/current_limits.svg
+++ b/network-area-diagram/src/test/resources/current_limits.svg
@@ -33,6 +33,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}
@@ -73,7 +74,10 @@
             <circle r="27.50" id="3" class="nad-busnode"/>
         </g>
         <g transform="translate(321.59,165.05)" id="5" class="nad-boundary-node nad-vl300to500">
-            <path d="M-1.528,27.458 A27.500,27.500 180.000 0 1 1.528,-27.458" id="6" class="nad-busnode"/>
+            <g id="6" class="nad-busnode">
+                <path class="nad-boundary-network" d="M-1.528,27.458 A27.500,27.500 180.000 0 1 1.528,-27.458"/>
+                <path class="nad-boundary-external" d="M1.528,-27.458 A27.500,27.500 180.000 0 1 -1.528,27.458"/>
+            </g>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/network-area-diagram/src/test/resources/detailed_text_node.svg
+++ b/network-area-diagram/src/test/resources/detailed_text_node.svg
@@ -98,6 +98,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}
@@ -138,7 +139,10 @@
             <circle r="27.50" id="3" class="nad-vl300to500-0 nad-busnode"/>
         </g>
         <g transform="translate(321.59,165.05)" id="5" class="nad-boundary-node">
-            <path d="M-1.528,27.458 A27.500,27.500 180.000 0 1 1.528,-27.458" id="6" class="nad-vl300to500-0 nad-busnode"/>
+            <g id="6" class="nad-vl300to500-0 nad-busnode">
+                <path class="nad-boundary-network" d="M-1.528,27.458 A27.500,27.500 180.000 0 1 1.528,-27.458"/>
+                <path class="nad-boundary-external" d="M1.528,-27.458 A27.500,27.500 180.000 0 1 -1.528,27.458"/>
+            </g>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/network-area-diagram/src/test/resources/detailed_text_node_no_legend.svg
+++ b/network-area-diagram/src/test/resources/detailed_text_node_no_legend.svg
@@ -98,6 +98,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}
@@ -138,7 +139,10 @@
             <circle r="27.50" id="3" class="nad-vl300to500-0 nad-busnode"/>
         </g>
         <g transform="translate(321.59,165.05)" id="5" class="nad-boundary-node">
-            <path d="M-1.528,27.458 A27.500,27.500 180.000 0 1 1.528,-27.458" id="6" class="nad-vl300to500-0 nad-busnode"/>
+            <g id="6" class="nad-vl300to500-0 nad-busnode">
+                <path class="nad-boundary-network" d="M-1.528,27.458 A27.500,27.500 180.000 0 1 1.528,-27.458"/>
+                <path class="nad-boundary-external" d="M1.528,-27.458 A27.500,27.500 180.000 0 1 -1.528,27.458"/>
+            </g>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.0.svg
+++ b/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.0.svg
@@ -33,6 +33,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}

--- a/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.2.svg
+++ b/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.2.svg
@@ -33,6 +33,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}

--- a/network-area-diagram/src/test/resources/edge_info_double_labels.svg
+++ b/network-area-diagram/src/test/resources/edge_info_double_labels.svg
@@ -33,6 +33,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}

--- a/network-area-diagram/src/test/resources/edge_info_missing_label.svg
+++ b/network-area-diagram/src/test/resources/edge_info_missing_label.svg
@@ -33,6 +33,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}
@@ -73,7 +74,10 @@
             <circle r="27.50" id="3" class="nad-busnode"/>
         </g>
         <g transform="translate(321.59,165.05)" id="5" class="nad-boundary-node nad-vl300to500">
-            <path d="M-1.528,27.458 A27.500,27.500 180.000 0 1 1.528,-27.458" id="6" class="nad-busnode"/>
+            <g id="6" class="nad-busnode">
+                <path class="nad-boundary-network" d="M-1.528,27.458 A27.500,27.500 180.000 0 1 1.528,-27.458"/>
+                <path class="nad-boundary-external" d="M1.528,-27.458 A27.500,27.500 180.000 0 1 -1.528,27.458"/>
+            </g>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/network-area-diagram/src/test/resources/edge_info_perpendicular_label.svg
+++ b/network-area-diagram/src/test/resources/edge_info_perpendicular_label.svg
@@ -33,6 +33,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}
@@ -73,7 +74,10 @@
             <circle r="27.50" id="3" class="nad-busnode"/>
         </g>
         <g transform="translate(321.59,165.05)" id="5" class="nad-boundary-node nad-vl300to500">
-            <path d="M-1.528,27.458 A27.500,27.500 180.000 0 1 1.528,-27.458" id="6" class="nad-busnode"/>
+            <g id="6" class="nad-busnode">
+                <path class="nad-boundary-network" d="M-1.528,27.458 A27.500,27.500 180.000 0 1 1.528,-27.458"/>
+                <path class="nad-boundary-external" d="M1.528,-27.458 A27.500,27.500 180.000 0 1 -1.528,27.458"/>
+            </g>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/network-area-diagram/src/test/resources/edge_info_shift.svg
+++ b/network-area-diagram/src/test/resources/edge_info_shift.svg
@@ -33,6 +33,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}
@@ -85,7 +86,10 @@
             <path d="M-18.453,54.459 A57.500,57.500 345.053 1 1 -3.783,57.375 L1.121,32.481 A32.500,32.500 -333.556 1 0 -13.461,29.581 Z " id="7" class="nad-busnode"/>
         </g>
         <g transform="translate(463.59,-80.38)" id="12" class="nad-boundary-node nad-vl300to500">
-            <path d="M12.480,24.505 A27.500,27.500 180.000 0 1 -12.480,-24.505" id="13" class="nad-busnode"/>
+            <g id="13" class="nad-busnode">
+                <path class="nad-boundary-network" d="M12.480,24.505 A27.500,27.500 180.000 0 1 -12.480,-24.505"/>
+                <path class="nad-boundary-external" d="M-12.480,-24.505 A27.500,27.500 180.000 0 1 12.480,24.505"/>
+            </g>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/network-area-diagram/src/test/resources/hvdc-vl-depth-1.svg
+++ b/network-area-diagram/src/test/resources/hvdc-vl-depth-1.svg
@@ -33,6 +33,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}

--- a/network-area-diagram/src/test/resources/hvdc.svg
+++ b/network-area-diagram/src/test/resources/hvdc.svg
@@ -33,6 +33,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}

--- a/network-area-diagram/src/test/resources/parallel_transformers.svg
+++ b/network-area-diagram/src/test/resources/parallel_transformers.svg
@@ -33,6 +33,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}
@@ -76,7 +77,10 @@
             <circle r="27.50" id="4" class="nad-busnode"/>
         </g>
         <g transform="translate(321.59,165.05)" id="7" class="nad-boundary-node nad-vl180to300">
-            <path d="M-1.528,27.458 A27.500,27.500 180.000 0 1 1.528,-27.458" id="8" class="nad-busnode"/>
+            <g id="8" class="nad-busnode">
+                <path class="nad-boundary-network" d="M-1.528,27.458 A27.500,27.500 180.000 0 1 1.528,-27.458"/>
+                <path class="nad-boundary-external" d="M1.528,-27.458 A27.500,27.500 180.000 0 1 -1.528,27.458"/>
+            </g>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/network-area-diagram/src/test/resources/simple-eu-loop100.svg
+++ b/network-area-diagram/src/test/resources/simple-eu-loop100.svg
@@ -98,6 +98,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}

--- a/network-area-diagram/src/test/resources/simple-eu-loop80.svg
+++ b/network-area-diagram/src/test/resources/simple-eu-loop80.svg
@@ -98,6 +98,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}

--- a/network-area-diagram/src/test/resources/simple-eu.svg
+++ b/network-area-diagram/src/test/resources/simple-eu.svg
@@ -98,6 +98,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}

--- a/network-area-diagram/src/test/resources/vl_description_id.svg
+++ b/network-area-diagram/src/test/resources/vl_description_id.svg
@@ -98,6 +98,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}
@@ -138,7 +139,10 @@
             <circle r="27.50" id="3" class="nad-vl300to500-0 nad-busnode"/>
         </g>
         <g transform="translate(321.59,165.05)" id="5" class="nad-boundary-node">
-            <path d="M-1.528,27.458 A27.500,27.500 180.000 0 1 1.528,-27.458" id="6" class="nad-vl300to500-0 nad-busnode"/>
+            <g id="6" class="nad-vl300to500-0 nad-busnode">
+                <path class="nad-boundary-network" d="M-1.528,27.458 A27.500,27.500 180.000 0 1 1.528,-27.458"/>
+                <path class="nad-boundary-external" d="M1.528,-27.458 A27.500,27.500 180.000 0 1 -1.528,27.458"/>
+            </g>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/network-area-diagram/src/test/resources/vl_description_substation.svg
+++ b/network-area-diagram/src/test/resources/vl_description_substation.svg
@@ -98,6 +98,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}
@@ -138,7 +139,10 @@
             <circle r="27.50" id="3" class="nad-vl300to500-0 nad-busnode"/>
         </g>
         <g transform="translate(321.59,165.05)" id="5" class="nad-boundary-node">
-            <path d="M-1.528,27.458 A27.500,27.500 180.000 0 1 1.528,-27.458" id="6" class="nad-vl300to500-0 nad-busnode"/>
+            <g id="6" class="nad-vl300to500-0 nad-busnode">
+                <path class="nad-boundary-network" d="M-1.528,27.458 A27.500,27.500 180.000 0 1 1.528,-27.458"/>
+                <path class="nad-boundary-external" d="M1.528,-27.458 A27.500,27.500 180.000 0 1 -1.528,27.458"/>
+            </g>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/network-area-diagram/src/test/resources/vl_description_substation_id.svg
+++ b/network-area-diagram/src/test/resources/vl_description_substation_id.svg
@@ -98,6 +98,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}
@@ -138,7 +139,10 @@
             <circle r="27.50" id="3" class="nad-vl300to500-0 nad-busnode"/>
         </g>
         <g transform="translate(321.59,165.05)" id="5" class="nad-boundary-node">
-            <path d="M-1.528,27.458 A27.500,27.500 180.000 0 1 1.528,-27.458" id="6" class="nad-vl300to500-0 nad-busnode"/>
+            <g id="6" class="nad-vl300to500-0 nad-busnode">
+                <path class="nad-boundary-network" d="M-1.528,27.458 A27.500,27.500 180.000 0 1 1.528,-27.458"/>
+                <path class="nad-boundary-external" d="M1.528,-27.458 A27.500,27.500 180.000 0 1 -1.528,27.458"/>
+            </g>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/network-area-diagram/src/test/resources/voltage_limits.svg
+++ b/network-area-diagram/src/test/resources/voltage_limits.svg
@@ -33,6 +33,7 @@
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+.nad-boundary-external {stroke-width: 3; stroke:gray; fill:none; stroke-dasharray: 3,3}
 
 @keyframes line-blink {
   0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}
@@ -76,7 +77,10 @@
             <circle r="27.50" id="4" class="nad-undervoltage nad-busnode"/>
         </g>
         <g transform="translate(321.59,165.05)" id="7" class="nad-boundary-node nad-vl300to500">
-            <path d="M-1.528,27.458 A27.500,27.500 180.000 0 1 1.528,-27.458" id="8" class="nad-busnode"/>
+            <g id="8" class="nad-busnode">
+                <path class="nad-boundary-network" d="M-1.528,27.458 A27.500,27.500 180.000 0 1 1.528,-27.458"/>
+                <path class="nad-boundary-external" d="M1.528,-27.458 A27.500,27.500 180.000 0 1 -1.528,27.458"/>
+            </g>
         </g>
     </g>
     <g class="nad-branch-edges">


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Only the _network_ part of boundary nodes has a drawing.


**What is the new behavior (if this is a feature change)?**
In addition to the drawing representing the inner (_network_) part of the boundary node, the external part is drawn using a dotted semi circumference. This is interesting because now the center of the boundary drawing coincides with the location of the boundary node computed by the layout.


