### PR TITLE
Change default StyleProvider in draw functions

### DIFF
--- a/network-area-diagram/src/main/java/com/powsybl/nad/NetworkAreaDiagram.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/NetworkAreaDiagram.java
@@ -21,7 +21,7 @@ import com.powsybl.nad.svg.StyleProvider;
 import com.powsybl.nad.svg.SvgParameters;
 import com.powsybl.nad.svg.SvgWriter;
 import com.powsybl.nad.svg.iidm.DefaultLabelProvider;
-import com.powsybl.nad.svg.iidm.NominalVoltageStyleProvider;
+import com.powsybl.nad.svg.iidm.TopologicalStyleProvider;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -74,7 +74,7 @@ public class NetworkAreaDiagram {
     }
 
     public void draw(Path svgFile, SvgParameters svgParameters, LayoutParameters layoutParameters) {
-        draw(svgFile, svgParameters, layoutParameters, new NominalVoltageStyleProvider(network));
+        draw(svgFile, svgParameters, layoutParameters, new TopologicalStyleProvider(network));
     }
 
     public void draw(Path svgFile, SvgParameters svgParameters, LayoutParameters layoutParameters,
@@ -116,7 +116,7 @@ public class NetworkAreaDiagram {
     }
 
     public void draw(Writer writer, SvgParameters svgParameters, LayoutParameters layoutParameters) {
-        draw(writer, svgParameters, layoutParameters, new NominalVoltageStyleProvider(network));
+        draw(writer, svgParameters, layoutParameters, new TopologicalStyleProvider(network));
     }
 
     public void draw(Writer writer, SvgParameters svgParameters, LayoutParameters layoutParameters,


### PR DESCRIPTION
Change default StyleProvider in draw functions from NominalVoltageStyleProvider to TopologicalStyleProvider

Signed-off-by: Sophie Frasnedo <sophie.frasnedo@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
The default style provider is the NominalVoltageStyleProvider.


**What is the new behavior (if this is a feature change)?**
The default style provider is now the TopologicalStyleProvider.
