### PR TITLE
[SLD] Fix disconnector anchors in FlatDesignLibrary

### DIFF
--- a/single-line-diagram/single-line-diagram-core/src/main/resources/FlatDesignLibrary/components.json
+++ b/single-line-diagram/single-line-diagram-core/src/main/resources/FlatDesignLibrary/components.json
@@ -53,21 +53,15 @@
           "x": 0.0,
           "y": 0.0,
           "orientation": "NONE"
-        },
-        {
-          "x": -4.0,
-          "y": 0.0,
-          "orientation": "HORIZONTAL"
-        },
-        {
-          "x": 4.0,
-          "y": 0.0,
-          "orientation": "HORIZONTAL"
         }
       ],
       "size": {
         "width": 8.0,
         "height": 8.0
+      },
+      "transformations": {
+        "LEFT": "ROTATION",
+        "RIGHT": "ROTATION"
       },
       "subComponents": [
         {

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
@@ -35,7 +35,7 @@ public abstract class AbstractTestCase {
 
     protected boolean debugJsonFiles = false;
     protected boolean debugSvgFiles = false;
-    protected boolean overrideTestReferences = true;
+    protected boolean overrideTestReferences = false;
 
     protected final ResourcesComponentLibrary componentLibrary = getResourcesComponentLibrary();
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
@@ -35,7 +35,7 @@ public abstract class AbstractTestCase {
 
     protected boolean debugJsonFiles = false;
     protected boolean debugSvgFiles = false;
-    protected boolean overrideTestReferences = false;
+    protected boolean overrideTestReferences = true;
 
     protected final ResourcesComponentLibrary componentLibrary = getResourcesComponentLibrary();
 

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/TestCase11FlatDesign.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/TestCase11FlatDesign.svg
@@ -160,7 +160,7 @@
                 <polyline points="494.0,432.0,502.5,432.0"/>
             </g>
             <g class="sld-disconnector sld-closed sld-fictitious sld-vl300to500-0" id="iddsect11" transform="translate(436.0,428.0)">
-                <rect height="8" rx="2" ry="2" width="8" x="0" y="0"/>
+                <rect height="8" rx="2" ry="2" transform="rotate(90.0,4.0,4.0)" width="8" x="0" y="0"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrct11" transform="translate(436.0,428.0)">
                 <circle cx="4" cy="4" r="4"/>
@@ -173,7 +173,7 @@
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-disconnector sld-closed sld-fictitious sld-vl300to500-0" id="iddsect12" transform="translate(486.0,428.0)">
-                <rect height="8" rx="2" ry="2" width="8" x="0" y="0"/>
+                <rect height="8" rx="2" ry="2" transform="rotate(90.0,4.0,4.0)" width="8" x="0" y="0"/>
             </g>
         </g>
         <g class="sld-intern-cell sld-cell-shape-flat" id="idINTERN_32_1">
@@ -190,7 +190,7 @@
                 <polyline points="494.0,457.0,502.5,457.0"/>
             </g>
             <g class="sld-disconnector sld-closed sld-fictitious sld-vl300to500-1" id="iddsect21" transform="translate(436.0,453.0)">
-                <rect height="8" rx="2" ry="2" width="8" x="0" y="0"/>
+                <rect height="8" rx="2" ry="2" transform="rotate(90.0,4.0,4.0)" width="8" x="0" y="0"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dtrct21" transform="translate(436.0,453.0)">
                 <circle cx="4" cy="4" r="4"/>
@@ -203,7 +203,7 @@
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-disconnector sld-closed sld-fictitious sld-vl300to500-1" id="iddsect22" transform="translate(486.0,453.0)">
-                <rect height="8" rx="2" ry="2" width="8" x="0" y="0"/>
+                <rect height="8" rx="2" ry="2" transform="rotate(90.0,4.0,4.0)" width="8" x="0" y="0"/>
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_2">


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No


**What kind of change does this PR introduce?**
Bug fix



**What is the current behavior?**
Thre are too many anchors on disconnectors in FlatDesignLibrary, leading to wrong anchor taken on forks.



**What is the new behavior (if this is a feature change)?**
Remove spurious anchors and add possible transformation for `MIDDLE` orientation


**Does this PR introduce a breaking change or deprecate an API?** 
No