### PR TITLE
NAD : fix dangling line drawing disconnected status

### DIFF
--- a/network-area-diagram/src/main/java/com/powsybl/nad/utils/iidm/IidmUtils.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/utils/iidm/IidmUtils.java
@@ -14,7 +14,7 @@ public final class IidmUtils {
 
     public static boolean isDisconnected(Network network, BranchEdge edge, BranchEdge.Side side) {
         if (edge.getType().equals(BranchEdge.DANGLING_LINE_EDGE) && side.equals(BranchEdge.Side.TWO)) {
-            return false;
+            return isDisconnected(network, edge, BranchEdge.Side.ONE);
         }
         Terminal terminal = IidmUtils.getTerminalFromEdge(network, edge, side);
         return terminal == null || !terminal.isConnected();

--- a/network-area-diagram/src/test/java/com/powsybl/nad/svg/DanglingLineTest.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/svg/DanglingLineTest.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.nad.svg;
+
+import com.powsybl.iidm.network.Network;
+import com.powsybl.nad.AbstractTest;
+import com.powsybl.nad.layout.LayoutParameters;
+import com.powsybl.nad.svg.iidm.DefaultLabelProvider;
+import com.powsybl.nad.svg.iidm.NominalVoltageStyleProvider;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Luma Zamarreño <zamarrenolm at aia.es>
+ */
+public class DanglingLineTest extends AbstractTest {
+
+    @Before
+    public void setup() {
+        setLayoutParameters(new LayoutParameters());
+        setSvgParameters(new SvgParameters()
+                .setSvgWidthAndHeightAdded(true)
+                .setFixedWidth(800));
+    }
+
+    @Override
+    protected StyleProvider getStyleProvider(Network network) {
+        return new NominalVoltageStyleProvider(network);
+    }
+
+    @Override
+    protected LabelProvider getLabelProvider(Network network) {
+        return new DefaultLabelProvider(network, getSvgParameters()) {
+        };
+    }
+
+    @Test
+    public void testConnected() {
+        Network network = NetworkTestFactory.createThreeVoltageLevelsFiveBuses();
+        assertEquals(toString("/dangling_line_connected.svg"), generateSvgString(network, "/dangling_line_connected.svg"));
+    }
+
+    @Test
+    public void testDisconnected() {
+        Network network = NetworkTestFactory.createThreeVoltageLevelsFiveBuses();
+        network.getDanglingLines().iterator().next().getTerminal().disconnect();
+        assertEquals(toString("/dangling_line_disconnected.svg"), generateSvgString(network, "/dangling_line_disconnected.svg"));
+    }
+}

--- a/network-area-diagram/src/test/java/com/powsybl/nad/svg/DanglingLineTest.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/svg/DanglingLineTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/network-area-diagram/src/test/resources/dangling_line_connected.svg
+++ b/network-area-diagram/src/test/resources/dangling_line_connected.svg
@@ -1,0 +1,360 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="800.00" height="540.48" viewBox="-446.57 -328.09 1110.16 750.03" xmlns="http://www.w3.org/2000/svg">
+    <style><![CDATA[
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-text-edges {stroke: black; stroke-width: 3; stroke-dasharray: 6,7}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
+.nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
+.nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 40}
+.nad-dangling-line-edge {fill: var(--nad-vl-color, lighgrey)}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
+.nad-state-out .nad-arrow-in {visibility: hidden}
+.nad-state-in .nad-arrow-out {visibility: hidden}
+.nad-active path {stroke: none; fill: #546e7a}
+.nad-active {visibility: visible}
+.nad-reactive {visibility: hidden}
+.nad-reactive path {stroke: none; fill: #0277bd}
+.nad-text-background {flood-color: #90a4aeaa}
+.nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
+.nad-text-nodes foreignObject {overflow: visible; color: black}
+.nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in text {fill: #b71c1c}
+.nad-edge-infos .nad-state-out text {fill: #2e7d32}
+.nad-vl0to30 {--nad-vl-color: #AFB42B}
+.nad-vl30to50 {--nad-vl-color: #EF9A9A}
+.nad-vl50to70 {--nad-vl-color: #9C27B0}
+.nad-vl70to120 {--nad-vl-color: #E65100}
+.nad-vl120to180 {--nad-vl-color: #00ACC1}
+.nad-vl180to300 {--nad-vl-color: #2E7D32}
+.nad-vl300to500 {--nad-vl-color: #D32F2F}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
+.nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
+.nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+
+@keyframes line-blink {
+  0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}
+  40% {stroke: #FFEB3B; stroke-width: 15}
+}
+@keyframes node-over-blink {
+  0%, 80%, 100% {stroke: white; stroke-width: 0}
+  40% {stroke: #ff5722; stroke-width: 15}
+}
+@keyframes node-under-blink {
+  0%, 80%, 100% {stroke: white; stroke-width: 0}
+  40% {stroke: #00BCD4; stroke-width: 15}
+}
+]]></style>
+    <metadata>
+        <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
+            <nad:busNodes>
+                <nad:busNode svgId="1" equipmentId="vl1_0"/>
+                <nad:busNode svgId="2" equipmentId="vl1_1"/>
+                <nad:busNode svgId="4" equipmentId="vl2_0"/>
+                <nad:busNode svgId="6" equipmentId="vl3_0"/>
+                <nad:busNode svgId="7" equipmentId="vl3_1"/>
+                <nad:busNode svgId="13" equipmentId="dl1"/>
+            </nad:busNodes>
+            <nad:nodes>
+                <nad:node svgId="0" equipmentId="vl1" x="-246.57" y="221.93"/>
+                <nad:node svgId="3" equipmentId="vl2" x="114.03" y="97.66"/>
+                <nad:node svgId="5" equipmentId="vl3" x="-179.96" y="-113.09"/>
+                <nad:node svgId="12" equipmentId="dl1" x="463.59" y="-80.38"/>
+            </nad:nodes>
+            <nad:edges>
+                <nad:edge svgId="8" equipmentId="l1" node1="0" node2="3"/>
+                <nad:edge svgId="9" equipmentId="l2" node1="0" node2="3"/>
+                <nad:edge svgId="10" equipmentId="tr1" node1="0" node2="5"/>
+                <nad:edge svgId="11" equipmentId="tr2" node1="3" node2="5"/>
+                <nad:edge svgId="14" equipmentId="dl1" node1="3" node2="12"/>
+            </nad:edges>
+        </nad:nad>
+    </metadata>
+    <g class="nad-vl-nodes">
+        <g transform="translate(-246.57,221.93)" id="0" class="nad-vl300to500">
+            <circle r="27.50" id="1" class="nad-busnode"/>
+            <path d="M54.542,18.204 A57.500,57.500 345.053 1 1 57.392,3.521 L32.475,-1.269 A32.500,32.500 -333.556 1 0 29.642,13.326 Z " id="2" class="nad-busnode"/>
+        </g>
+        <g transform="translate(114.03,97.66)" id="3" class="nad-vl300to500">
+            <circle r="27.50" id="4" class="nad-busnode"/>
+        </g>
+        <g transform="translate(-179.96,-113.09)" id="5" class="nad-vl180to300">
+            <circle r="27.50" id="6" class="nad-busnode"/>
+            <path d="M-18.453,54.459 A57.500,57.500 345.053 1 1 -3.783,57.375 L1.121,32.481 A32.500,32.500 -333.556 1 0 -13.461,29.581 Z " id="7" class="nad-busnode"/>
+        </g>
+        <g transform="translate(463.59,-80.38)" id="12" class="nad-boundary-node nad-vl300to500">
+            <path d="M12.480,24.505 A27.500,27.500 180.000 0 1 -12.480,-24.505" id="13" class="nad-busnode"/>
+        </g>
+    </g>
+    <g class="nad-branch-edges">
+        <g id="8">
+            <g id="8.1" class="nad-vl300to500">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-219.57,227.17 -168.03,237.17 -53.24,197.61"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-139.67,227.40)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(70.98)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-19.02)" x="19.00"></text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(70.98)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-19.02)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="8.2" class="nad-vl300to500">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="95.99,118.42 61.56,158.05 -53.24,197.61"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(33.20,167.82)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-109.02)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-19.02)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-109.02)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-19.02)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-edge-label" transform="translate(-53.24,197.61)">
+                    <text transform="rotate(-19.02)" x="0.00" style="text-anchor:middle">l1</text>
+                </g>
+            </g>
+        </g>
+        <g id="9">
+            <g id="9.1" class="nad-vl300to500">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-208.86,178.53 -194.10,161.54 -79.30,121.98"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-165.74,151.77)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(70.98)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-19.02)" x="19.00"></text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(70.98)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-19.02)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="9.2" class="nad-disconnected nad-vl300to500">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="87.03,92.42 35.49,82.41 -79.30,121.98"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(7.13,92.19)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-109.02)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-19.02)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-109.02)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-19.02)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-edge-label" transform="translate(-79.30,121.98)">
+                    <text transform="rotate(-19.02)" x="0.00" style="text-anchor:middle">l2</text>
+                </g>
+            </g>
+        </g>
+        <g id="10">
+            <g id="10.1" class="nad-vl300to500">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-235.36,165.54 -216.19,69.13"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-229.02,133.66)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(11.25)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-78.75)" x="19.00"></text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(11.25)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-78.75)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="10.2" class="nad-vl180to300">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-185.32,-86.12 -204.49,10.28"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-197.51,-24.82)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-168.75)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-78.75)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-168.75)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-78.75)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-glued-center">
+                <circle class="nad-vl300to500 nad-winding" cx="-212.29" cy="49.51" r="20.00"/>
+                <circle class="nad-vl180to300 nad-winding" cx="-208.39" cy="29.90" r="20.00"/>
+                <g class="nad-edge-label" transform="translate(-210.34,39.71)">
+                    <text transform="rotate(-78.75)" x="0.00" style="text-anchor:middle">tr1</text>
+                </g>
+            </g>
+        </g>
+        <g id="11">
+            <g id="11.1" class="nad-vl300to500">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="91.68,81.63 3.61,18.50"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(65.26,62.70)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-54.36)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-324.36)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-54.36)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-324.36)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="11.2" class="nad-vl180to300">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-133.22,-79.59 -45.15,-16.46"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-106.81,-60.66)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(125.64)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(35.64)" x="19.00"></text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(125.64)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(35.64)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-glued-center">
+                <circle class="nad-vl300to500 nad-winding" cx="-12.65" cy="6.85" r="20.00"/>
+                <circle class="nad-vl180to300 nad-winding" cx="-28.90" cy="-4.81" r="20.00"/>
+                <g class="nad-edge-label" transform="translate(-20.77,1.02)">
+                    <text transform="rotate(-324.36)" x="0.00" style="text-anchor:middle">tr2</text>
+                </g>
+            </g>
+        </g>
+        <g id="14" class="nad-dangling-line-edge">
+            <g id="14.1" class="nad-vl300to500">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="138.53,85.18 288.81,8.64"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(167.49,70.43)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(63.01)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-26.99)" x="19.00"></text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(63.01)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-26.99)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="14.2" class="nad-vl300to500">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="439.09,-67.90 288.81,8.64"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(410.13,-53.15)"></g>
+            </g>
+        </g>
+    </g>
+    <g class="nad-text-edges">
+        <polyline id="0-textedge" points="-187.23,213.03 -146.57,206.93"/>
+        <polyline id="3-textedge" points="143.70,93.21 214.03,82.66"/>
+        <polyline id="5-textedge" points="-120.62,-121.99 -79.96,-128.09"/>
+    </g>
+    <g class="nad-text-nodes">
+        <foreignObject id="0-textnode" y="181.93" x="-146.57" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>Voltage level 1</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-legend-square"/>
+                        </td>
+                        <td> kV / °</td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <div class="nad-legend-square"/>
+                        </td>
+                        <td> kV / °</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+        <foreignObject id="3-textnode" y="57.66" x="214.03" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>Voltage level 2</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-legend-square"/>
+                        </td>
+                        <td> kV / °</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+        <foreignObject id="5-textnode" y="-153.09" x="-79.96" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>vl3</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-legend-square"/>
+                        </td>
+                        <td> kV / °</td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <div class="nad-legend-square"/>
+                        </td>
+                        <td> kV / °</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+    </g>
+</svg>

--- a/network-area-diagram/src/test/resources/dangling_line_disconnected.svg
+++ b/network-area-diagram/src/test/resources/dangling_line_disconnected.svg
@@ -1,0 +1,360 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="800.00" height="540.48" viewBox="-446.57 -328.09 1110.16 750.03" xmlns="http://www.w3.org/2000/svg">
+    <style><![CDATA[
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-text-edges {stroke: black; stroke-width: 3; stroke-dasharray: 6,7}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
+.nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
+.nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 40}
+.nad-dangling-line-edge {fill: var(--nad-vl-color, lighgrey)}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
+.nad-state-out .nad-arrow-in {visibility: hidden}
+.nad-state-in .nad-arrow-out {visibility: hidden}
+.nad-active path {stroke: none; fill: #546e7a}
+.nad-active {visibility: visible}
+.nad-reactive {visibility: hidden}
+.nad-reactive path {stroke: none; fill: #0277bd}
+.nad-text-background {flood-color: #90a4aeaa}
+.nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
+.nad-text-nodes foreignObject {overflow: visible; color: black}
+.nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in text {fill: #b71c1c}
+.nad-edge-infos .nad-state-out text {fill: #2e7d32}
+.nad-vl0to30 {--nad-vl-color: #AFB42B}
+.nad-vl30to50 {--nad-vl-color: #EF9A9A}
+.nad-vl50to70 {--nad-vl-color: #9C27B0}
+.nad-vl70to120 {--nad-vl-color: #E65100}
+.nad-vl120to180 {--nad-vl-color: #00ACC1}
+.nad-vl180to300 {--nad-vl-color: #2E7D32}
+.nad-vl300to500 {--nad-vl-color: #D32F2F}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
+.nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
+.nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+
+@keyframes line-blink {
+  0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}
+  40% {stroke: #FFEB3B; stroke-width: 15}
+}
+@keyframes node-over-blink {
+  0%, 80%, 100% {stroke: white; stroke-width: 0}
+  40% {stroke: #ff5722; stroke-width: 15}
+}
+@keyframes node-under-blink {
+  0%, 80%, 100% {stroke: white; stroke-width: 0}
+  40% {stroke: #00BCD4; stroke-width: 15}
+}
+]]></style>
+    <metadata>
+        <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
+            <nad:busNodes>
+                <nad:busNode svgId="1" equipmentId="vl1_0"/>
+                <nad:busNode svgId="2" equipmentId="vl1_1"/>
+                <nad:busNode svgId="4" equipmentId="vl2_0"/>
+                <nad:busNode svgId="6" equipmentId="vl3_0"/>
+                <nad:busNode svgId="7" equipmentId="vl3_1"/>
+                <nad:busNode svgId="13" equipmentId="dl1"/>
+            </nad:busNodes>
+            <nad:nodes>
+                <nad:node svgId="0" equipmentId="vl1" x="-246.57" y="221.93"/>
+                <nad:node svgId="3" equipmentId="vl2" x="114.03" y="97.66"/>
+                <nad:node svgId="5" equipmentId="vl3" x="-179.96" y="-113.09"/>
+                <nad:node svgId="12" equipmentId="dl1" x="463.59" y="-80.38"/>
+            </nad:nodes>
+            <nad:edges>
+                <nad:edge svgId="8" equipmentId="l1" node1="0" node2="3"/>
+                <nad:edge svgId="9" equipmentId="l2" node1="0" node2="3"/>
+                <nad:edge svgId="10" equipmentId="tr1" node1="0" node2="5"/>
+                <nad:edge svgId="11" equipmentId="tr2" node1="3" node2="5"/>
+                <nad:edge svgId="14" equipmentId="dl1" node1="3" node2="12"/>
+            </nad:edges>
+        </nad:nad>
+    </metadata>
+    <g class="nad-vl-nodes">
+        <g transform="translate(-246.57,221.93)" id="0" class="nad-vl300to500">
+            <circle r="27.50" id="1" class="nad-busnode"/>
+            <path d="M54.542,18.204 A57.500,57.500 345.053 1 1 57.392,3.521 L32.475,-1.269 A32.500,32.500 -333.556 1 0 29.642,13.326 Z " id="2" class="nad-busnode"/>
+        </g>
+        <g transform="translate(114.03,97.66)" id="3" class="nad-vl300to500">
+            <circle r="27.50" id="4" class="nad-busnode"/>
+        </g>
+        <g transform="translate(-179.96,-113.09)" id="5" class="nad-vl180to300">
+            <circle r="27.50" id="6" class="nad-busnode"/>
+            <path d="M-18.453,54.459 A57.500,57.500 345.053 1 1 -3.783,57.375 L1.121,32.481 A32.500,32.500 -333.556 1 0 -13.461,29.581 Z " id="7" class="nad-busnode"/>
+        </g>
+        <g transform="translate(463.59,-80.38)" id="12" class="nad-boundary-node nad-vl300to500">
+            <path d="M12.480,24.505 A27.500,27.500 180.000 0 1 -12.480,-24.505" id="13" class="nad-busnode"/>
+        </g>
+    </g>
+    <g class="nad-branch-edges">
+        <g id="8">
+            <g id="8.1" class="nad-vl300to500">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-219.57,227.17 -168.03,237.17 -53.24,197.61"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-139.67,227.40)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(70.98)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-19.02)" x="19.00"></text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(70.98)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-19.02)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="8.2" class="nad-vl300to500">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="95.99,118.42 61.56,158.05 -53.24,197.61"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(33.20,167.82)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-109.02)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-19.02)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-109.02)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-19.02)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-edge-label" transform="translate(-53.24,197.61)">
+                    <text transform="rotate(-19.02)" x="0.00" style="text-anchor:middle">l1</text>
+                </g>
+            </g>
+        </g>
+        <g id="9">
+            <g id="9.1" class="nad-vl300to500">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-208.86,178.53 -194.10,161.54 -79.30,121.98"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-165.74,151.77)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(70.98)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-19.02)" x="19.00"></text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(70.98)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-19.02)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="9.2" class="nad-disconnected nad-vl300to500">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="87.03,92.42 35.49,82.41 -79.30,121.98"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(7.13,92.19)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-109.02)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-19.02)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-109.02)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-19.02)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-edge-label" transform="translate(-79.30,121.98)">
+                    <text transform="rotate(-19.02)" x="0.00" style="text-anchor:middle">l2</text>
+                </g>
+            </g>
+        </g>
+        <g id="10">
+            <g id="10.1" class="nad-vl300to500">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-235.36,165.54 -216.19,69.13"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-229.02,133.66)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(11.25)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-78.75)" x="19.00"></text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(11.25)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-78.75)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="10.2" class="nad-vl180to300">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-185.32,-86.12 -204.49,10.28"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-197.51,-24.82)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-168.75)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-78.75)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-168.75)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-78.75)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-glued-center">
+                <circle class="nad-vl300to500 nad-winding" cx="-212.29" cy="49.51" r="20.00"/>
+                <circle class="nad-vl180to300 nad-winding" cx="-208.39" cy="29.90" r="20.00"/>
+                <g class="nad-edge-label" transform="translate(-210.34,39.71)">
+                    <text transform="rotate(-78.75)" x="0.00" style="text-anchor:middle">tr1</text>
+                </g>
+            </g>
+        </g>
+        <g id="11">
+            <g id="11.1" class="nad-vl300to500">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="91.68,81.63 3.61,18.50"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(65.26,62.70)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-54.36)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-324.36)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-54.36)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-324.36)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="11.2" class="nad-vl180to300">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-133.22,-79.59 -45.15,-16.46"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-106.81,-60.66)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(125.64)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(35.64)" x="19.00"></text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(125.64)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(35.64)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-glued-center">
+                <circle class="nad-vl300to500 nad-winding" cx="-12.65" cy="6.85" r="20.00"/>
+                <circle class="nad-vl180to300 nad-winding" cx="-28.90" cy="-4.81" r="20.00"/>
+                <g class="nad-edge-label" transform="translate(-20.77,1.02)">
+                    <text transform="rotate(-324.36)" x="0.00" style="text-anchor:middle">tr2</text>
+                </g>
+            </g>
+        </g>
+        <g id="14" class="nad-disconnected nad-dangling-line-edge">
+            <g id="14.1" class="nad-disconnected nad-vl300to500">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="138.53,85.18 288.81,8.64"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(167.49,70.43)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(63.01)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-26.99)" x="19.00"></text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(63.01)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-26.99)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="14.2" class="nad-disconnected nad-vl300to500">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="439.09,-67.90 288.81,8.64"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(410.13,-53.15)"></g>
+            </g>
+        </g>
+    </g>
+    <g class="nad-text-edges">
+        <polyline id="0-textedge" points="-187.23,213.03 -146.57,206.93"/>
+        <polyline id="3-textedge" points="143.70,93.21 214.03,82.66"/>
+        <polyline id="5-textedge" points="-120.62,-121.99 -79.96,-128.09"/>
+    </g>
+    <g class="nad-text-nodes">
+        <foreignObject id="0-textnode" y="181.93" x="-146.57" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>Voltage level 1</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-legend-square"/>
+                        </td>
+                        <td> kV / °</td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <div class="nad-legend-square"/>
+                        </td>
+                        <td> kV / °</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+        <foreignObject id="3-textnode" y="57.66" x="214.03" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>Voltage level 2</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-legend-square"/>
+                        </td>
+                        <td> kV / °</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+        <foreignObject id="5-textnode" y="-153.09" x="-79.96" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>vl3</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-legend-square"/>
+                        </td>
+                        <td> kV / °</td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <div class="nad-legend-square"/>
+                        </td>
+                        <td> kV / °</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+    </g>
+</svg>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Drawings of disconnected dangling lines are painted with one half dashed and one half solid.
See the problem here:
<img width="610" alt="disconnected_bad" src="https://user-images.githubusercontent.com/3374819/215821883-c42aac04-c9f2-4e54-af59-f3f2817fa437.png">

**What is the new behavior (if this is a feature change)?**
A disconnected dangling line should be painted with both halves using the same style.
Solid when it is connected and dashed when it is disconnected.
See the fixed drawing for disconnected status:
<img width="610" alt="disconnected_ok" src="https://user-images.githubusercontent.com/3374819/215831269-507e780f-4b54-4291-8b49-332826bb3a80.png">

This is the (correct) drawing when the dangling line is connected:
<img width="610" alt="connected_ok" src="https://user-images.githubusercontent.com/3374819/215831343-d0eb4b9e-34a7-4d34-ac3e-e82d57381d3b.png">

