### PR TITLE
Add DebugDiagramLabelProvider

### DIFF
--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DebugDiagramLabelProvider.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DebugDiagramLabelProvider.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com/)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.sld.svg;
+
+import com.powsybl.iidm.network.Network;
+import com.powsybl.sld.layout.LayoutParameters;
+import com.powsybl.sld.library.ComponentLibrary;
+import com.powsybl.sld.model.coordinate.Direction;
+import com.powsybl.sld.model.nodes.EquipmentNode;
+import com.powsybl.sld.model.nodes.Node;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ */
+public class DebugDiagramLabelProvider extends DefaultDiagramLabelProvider {
+
+    public DebugDiagramLabelProvider(Network network, ComponentLibrary componentLibrary, LayoutParameters layoutParameters) {
+        super(network, componentLibrary, layoutParameters);
+    }
+
+    @Override
+    public List<NodeLabel> getNodeLabels(Node node, Direction direction) {
+        String debugLabel;
+        if (node instanceof EquipmentNode) {
+            EquipmentNode eqNode = (EquipmentNode) node;
+            debugLabel = Optional.ofNullable(node.getLabel().orElse(layoutParameters.isUseName() ? eqNode.getName() : eqNode.getEquipmentId()))
+                    .orElse(node.getId());
+        } else {
+            debugLabel = node.getId();
+        }
+        return List.of(new NodeLabel(debugLabel, getFeederLabelPosition(node, direction)));
+    }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No


**What kind of change does this PR introduce?**
Feature


**What is the current behavior?**
Only feeder and bus bar section names are displayed


**What is the new behavior (if this is a feature change)?**
With this labelProvider, all nodes ids (or names if `EquipmentNode` and `layoutParameters.isUseName()`) are displayed



**Does this PR introduce a breaking change or deprecate an API?**
No