### PR TITLE
Remove loadflow dependencies and config-test dependencies

### DIFF
--- a/network-area-diagram/pom.xml
+++ b/network-area-diagram/pom.xml
@@ -59,11 +59,6 @@
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
-            <artifactId>powsybl-config-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.powsybl</groupId>
             <artifactId>powsybl-diagram-test</artifactId>
             <scope>test</scope>
         </dependency>
@@ -85,6 +80,11 @@
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-ucte-converter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.jimfs</groupId>
+            <artifactId>jimfs</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,6 @@
 
         <powsybl-core.version>5.2.0</powsybl-core.version>
 
-        <powsybl-olf.version>0.23.0</powsybl-olf.version>
     </properties>
 
     <profiles>
@@ -176,24 +175,6 @@
                 <groupId>com.powsybl</groupId>
                 <artifactId>powsybl-ucte-converter</artifactId>
                 <version>${powsybl-core.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.powsybl</groupId>
-                <artifactId>powsybl-config-test</artifactId>
-                <version>${powsybl-core.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.powsybl</groupId>
-                <artifactId>powsybl-loadflow-api</artifactId>
-                <version>${powsybl-core.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.powsybl</groupId>
-                <artifactId>powsybl-open-loadflow</artifactId>
-                <version>${powsybl-olf.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/pom.xml
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/pom.xml
@@ -51,11 +51,6 @@
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
-            <artifactId>powsybl-config-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-impl</artifactId>
             <scope>test</scope>
         </dependency>

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/pom.xml
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/pom.xml
@@ -46,11 +46,6 @@
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
-            <artifactId>powsybl-config-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-impl</artifactId>
             <scope>test</scope>
         </dependency>

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/pom.xml
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/pom.xml
@@ -49,11 +49,6 @@
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
-            <artifactId>powsybl-config-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-impl</artifactId>
             <scope>test</scope>
         </dependency>

--- a/single-line-diagram/single-line-diagram-core/pom.xml
+++ b/single-line-diagram/single-line-diagram-core/pom.xml
@@ -68,11 +68,6 @@
 
         <dependency>
             <groupId>com.powsybl</groupId>
-            <artifactId>powsybl-config-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.powsybl</groupId>
             <artifactId>powsybl-diagram-test</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines

**What kind of change does this PR introduce?**
Pom cleaning :
- No need for loadflow dependencies
- No need of powsybl-config-test (a com.google.common.jimfs dependency has been added directly in network-area-diagram whereas it was precedently pulled from powsybl-config-test) 

**Does this PR introduce a breaking change or deprecate an API?**
No
