### PR TITLE
Fix cross-module coverage of diagram-test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,14 +146,13 @@
                 <artifactId>powsybl-diagram-util</artifactId>
                 <version>${project.version}</version>
             </dependency>
-
-            <!-- Test dependencies -->
             <dependency>
                 <groupId>com.powsybl</groupId>
                 <artifactId>powsybl-diagram-test</artifactId>
                 <version>${project.version}</version>
-                <scope>test</scope>
             </dependency>
+
+            <!-- Test dependencies -->
             <dependency>
                 <groupId>com.powsybl</groupId>
                 <artifactId>powsybl-iidm-impl</artifactId>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
powsybl-diagram-test is in test scope and is therefore not covered by tests according to sonar report


**What is the new behavior (if this is a feature change)?**
 powsybl-diagram-test covered by tests as not in test scope anymore


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
Fixes #524 which was not correcting properly coverage computation