### PR TITLE
[WIP] Allow the use of units on single-line diagram feeder info

### DIFF
--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultDiagramLabelProvider.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultDiagramLabelProvider.java
@@ -217,11 +217,12 @@ public class DefaultDiagramLabelProvider extends AbstractDiagramLabelProvider {
     }
 
     private List<FeederInfo> buildFeederInfos(Terminal terminal) {
+        //TODO after API modification: fill unit parameter with svgParameters.getPUnit(), svgParameters.getQUnit(), svgParameters.getIUnit()
         List<FeederInfo> feederInfoList = new ArrayList<>();
-        feederInfoList.add(new DirectionalFeederInfo(ARROW_ACTIVE, terminal.getP(), valueFormatter::formatPower));
-        feederInfoList.add(new DirectionalFeederInfo(ARROW_REACTIVE, terminal.getQ(), valueFormatter::formatPower));
+        feederInfoList.add(new DirectionalFeederInfo(ARROW_ACTIVE, terminal.getP(), "", (value, unit) -> valueFormatter.formatPower(value, unit)));
+        feederInfoList.add(new DirectionalFeederInfo(ARROW_REACTIVE, terminal.getQ(), "", (value, unit) -> valueFormatter.formatPower(value, unit)));
         if (this.layoutParameters.isDisplayCurrentFeederInfo()) {
-            feederInfoList.add(new DirectionalFeederInfo(ARROW_CURRENT, terminal.getI(), valueFormatter::formatCurrent));
+            feederInfoList.add(new DirectionalFeederInfo(ARROW_CURRENT, terminal.getI(), "", (value, unit) -> valueFormatter.formatCurrent(value, unit)));
         }
         return feederInfoList;
     }

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DirectionalFeederInfo.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DirectionalFeederInfo.java
@@ -1,6 +1,7 @@
 package com.powsybl.sld.svg;
 
 import java.util.Objects;
+import java.util.function.BiFunction;
 import java.util.function.DoubleFunction;
 
 /**
@@ -31,6 +32,12 @@ public class DirectionalFeederInfo extends AbstractFeederInfo {
 
     public DirectionalFeederInfo(String componentType, double value, DoubleFunction<String> formatter, String userDefinedId) {
         super(componentType, null, formatter.apply(value), userDefinedId);
+        this.arrowDirection = Objects.requireNonNull(getArrowDirection(value));
+        this.value = value;
+    }
+
+    public DirectionalFeederInfo(String componentType, double value, String unit, BiFunction<Double, String, String> formatter) {
+        super(componentType, null, formatter.apply(value, unit), null);
         this.arrowDirection = Objects.requireNonNull(getArrowDirection(value));
         this.value = value;
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?**
Feature/Bug
While there were existing functions in the ValueFormatter to take into account units for feeder info, it was not possible to customize the diagram: no units were displayed. The aim is to allow users to choose a unit for feeder info. The setters for single-line diagram feeder info units would be in the future SvgParameters class (available after the #522 merge).
The default value for each unit would be an empty String so as not to change the current behaviour.

**Does this PR introduce a breaking change or deprecate an API?**
No