### PR TITLE
LCC & VSC : add escaped id in metadata

### DIFF
--- a/diagram-test/src/main/java/com/powsybl/diagram/test/Networks.java
+++ b/diagram-test/src/main/java/com/powsybl/diagram/test/Networks.java
@@ -410,6 +410,10 @@ public final class Networks {
     }
 
     public static Network createNetworkWithHvdcLine() {
+        return createNetworkWithHvdcLine(CONVERTER_1_ID, CONVERTER_2_ID);
+    }
+
+    public static Network createNetworkWithHvdcLine(String vsc1Id, String vsc2Id) {
         Network network = Network.create(NETWORK_ID, "test");
         network.setCaseDate(DateTime.parse(CASE_DATE));
         Substation substation1 = network.newSubstation()
@@ -426,7 +430,7 @@ public final class Networks {
                 .add();
         // VSC 1
         voltageLevel1.newVscConverterStation()
-                .setId(CONVERTER_1_ID)
+                .setId(vsc1Id)
                 .setConnectableBus("Bus1")
                 .setBus("Bus1")
                 .setLossFactor(0.011f)
@@ -447,7 +451,7 @@ public final class Networks {
                 .add();
         // VSC 2
         voltageLevel2.newVscConverterStation()
-                .setId(CONVERTER_2_ID)
+                .setId(vsc2Id)
                 .setConnectableBus("Bus2")
                 .setBus("Bus2")
                 .setLossFactor(0.011f)
@@ -456,8 +460,8 @@ public final class Networks {
                 .add();
         network.newHvdcLine()
                 .setId("HvdcLine")
-                .setConverterStationId1(CONVERTER_1_ID)
-                .setConverterStationId2(CONVERTER_2_ID)
+                .setConverterStationId1(vsc1Id)
+                .setConverterStationId2(vsc2Id)
                 .setR(1)
                 .setNominalV(400)
                 .setConvertersMode(HvdcLine.ConvertersMode.SIDE_1_INVERTER_SIDE_2_RECTIFIER)
@@ -467,8 +471,9 @@ public final class Networks {
         return network;
     }
 
-    public static Network createNetworkWithHvdcLines() {
-        Network network = Networks.createNetworkWithHvdcLine();
+    public static Network createNetworkWithHvdcLines(String vsc1Id, String vsc2Id,
+                                                     String lcc1Id, String lcc2Id) {
+        Network network = Networks.createNetworkWithHvdcLine(vsc1Id, vsc2Id);
         VoltageLevel voltageLevel1 = network.getVoltageLevel(VOLTAGELEVEL_1_ID);
         VoltageLevel voltageLevel2 = network.getVoltageLevel(VOLTAGELEVEL_2_ID);
         voltageLevel1.getBusBreakerView().newBus()
@@ -476,7 +481,7 @@ public final class Networks {
                 .add();
         // LCC 1
         voltageLevel1.newLccConverterStation()
-                .setId(CONVERTER_3_ID)
+                .setId(lcc1Id)
                 .setConnectableBus("Bus3")
                 .setBus("Bus3")
                 .setLossFactor(0.011f)
@@ -487,7 +492,7 @@ public final class Networks {
                 .add();
         // LCC 2
         voltageLevel2.newLccConverterStation()
-                .setId(CONVERTER_4_ID)
+                .setId(lcc2Id)
                 .setConnectableBus("Bus4")
                 .setBus("Bus4")
                 .setLossFactor(0.011f)
@@ -495,8 +500,8 @@ public final class Networks {
                 .add();
         network.newHvdcLine()
                 .setId("HvdcLine2")
-                .setConverterStationId1(CONVERTER_3_ID)
-                .setConverterStationId2(CONVERTER_4_ID)
+                .setConverterStationId1(lcc1Id)
+                .setConverterStationId2(lcc2Id)
                 .setR(1)
                 .setNominalV(400)
                 .setConvertersMode(HvdcLine.ConvertersMode.SIDE_1_INVERTER_SIDE_2_RECTIFIER)
@@ -504,6 +509,10 @@ public final class Networks {
                 .setActivePowerSetpoint(280)
                 .add();
         return network;
+    }
+
+    public static Network createNetworkWithHvdcLines() {
+        return createNetworkWithHvdcLines(CONVERTER_1_ID, CONVERTER_2_ID, CONVERTER_3_ID, CONVERTER_4_ID);
     }
 
     public static Network createNetworkWithBusbarAndSwitch() {

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
@@ -477,14 +477,22 @@ public class DefaultSVGWriter implements SVGWriter {
 
         String vId = graph instanceof VoltageLevelGraph ? ((VoltageLevelGraph) graph).getVoltageLevelInfos().getId() : "";
         boolean isOpen = node.getType() == NodeType.SWITCH && ((SwitchNode) node).isOpen();
-        String unescapedId = (node.getComponentType().compareTo(VSC_CONVERTER_STATION) == 0 || node.getComponentType().compareTo(LCC_CONVERTER_STATION) == 0) ? IdUtil.unescapeId(nodeEscapedId) : null;
 
         metadata.addNodeMetadata(
-                new GraphMetadata.NodeMetadata(unescapedId, nodeEscapedId, vId, nextVId, node.getComponentType(), isOpen, direction, false,
+                new GraphMetadata.NodeMetadata(getUnescapedId(node, nodeEscapedId), nodeEscapedId, vId, nextVId, node.getComponentType(), isOpen, direction, false,
                         node instanceof EquipmentNode ? ((EquipmentNode) node).getEquipmentId() : null,
                         createNodeLabelMetadata(prefixId, node, nodeLabels)));
 
         addInfoComponentMetadata(metadata, node.getComponentType());
+    }
+
+    private String getUnescapedId(Node node, String nodeEscapedId) {
+        String unescapedId = null;
+        if (node.getComponentType().compareTo(VSC_CONVERTER_STATION) == 0 ||
+            node.getComponentType().compareTo(LCC_CONVERTER_STATION) == 0) {
+            unescapedId = IdUtil.unescapeId(nodeEscapedId);
+        }
+        return unescapedId;
     }
 
     protected void drawNodeLabel(String prefixId, Element g, Node node, List<DiagramLabelProvider.NodeLabel> nodeLabels) {

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
@@ -448,9 +448,9 @@ public class DefaultSVGWriter implements SVGWriter {
                              Collection<? extends Node> nodes) {
 
         for (Node node : nodes) {
-            String nodeId = IdUtil.escapeId(prefixId + node.getId());
+            String nodeEscapedId = IdUtil.escapeId(prefixId + node.getId());
             Element g = root.getOwnerDocument().createElement(GROUP);
-            g.setAttribute("id", nodeId);
+            g.setAttribute("id", nodeEscapedId);
             g.setAttribute(CLASS, String.join(" ", styleProvider.getNodeStyles(graph.getVoltageLevelGraph(node), node, componentLibrary, layoutParameters.isShowInternalNodes())));
 
             incorporateComponents(prefixId, graph, node, shift, g, labelProvider, styleProvider);
@@ -461,11 +461,11 @@ public class DefaultSVGWriter implements SVGWriter {
             root.appendChild(g);
 
             Direction direction = node instanceof FeederNode ? graph.getDirection(node) : Direction.UNDEFINED;
-            setMetadata(prefixId, metadata, node, nodeId, graph, direction, nodeLabels);
+            setMetadata(prefixId, metadata, node, nodeEscapedId, graph, direction, nodeLabels);
         }
     }
 
-    protected void setMetadata(String prefixId, GraphMetadata metadata, Node node, String nodeId, BaseGraph graph, Direction direction, List<DiagramLabelProvider.NodeLabel> nodeLabels) {
+    protected void setMetadata(String prefixId, GraphMetadata metadata, Node node, String nodeEscapedId, BaseGraph graph, Direction direction, List<DiagramLabelProvider.NodeLabel> nodeLabels) {
         String nextVId = null;
         if (node instanceof FeederNode && ((FeederNode) node).getFeeder() instanceof FeederWithSides) {
             FeederWithSides feederWs = (FeederWithSides) ((FeederNode) node).getFeeder();
@@ -475,10 +475,12 @@ public class DefaultSVGWriter implements SVGWriter {
             }
         }
 
-        String id = graph instanceof VoltageLevelGraph ? ((VoltageLevelGraph) graph).getVoltageLevelInfos().getId() : "";
+        String vId = graph instanceof VoltageLevelGraph ? ((VoltageLevelGraph) graph).getVoltageLevelInfos().getId() : "";
         boolean isOpen = node.getType() == NodeType.SWITCH && ((SwitchNode) node).isOpen();
+        String unescapedId = (node.getComponentType().compareTo(VSC_CONVERTER_STATION) == 0 || node.getComponentType().compareTo(LCC_CONVERTER_STATION) == 0) ? IdUtil.unescapeId(nodeEscapedId) : null;
+
         metadata.addNodeMetadata(
-                new GraphMetadata.NodeMetadata(nodeId, id, nextVId, node.getComponentType(), isOpen, direction, false,
+                new GraphMetadata.NodeMetadata(unescapedId, nodeEscapedId, vId, nextVId, node.getComponentType(), isOpen, direction, false,
                         node instanceof EquipmentNode ? ((EquipmentNode) node).getEquipmentId() : null,
                         createNodeLabelMetadata(prefixId, node, nodeLabels)));
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
@@ -350,7 +350,7 @@ public class DefaultSVGWriter implements SVGWriter {
             drawGridHorizontalLine(document, graph, maxH, graph.getY() + graph.getFirstBusY() + graph.getExternCellHeight(BOTTOM) - layoutParameters.getFeederSpan() + layoutParameters.getVerticalSpaceBus() * maxV, gridRoot);
         }
 
-        metadata.addNodeMetadata(new GraphMetadata.NodeMetadata(gridId,
+        metadata.addNodeMetadata(new GraphMetadata.NodeMetadata(null, gridId,
                 graph.getVoltageLevelInfos().getId(),
                 null,
                 null,
@@ -412,7 +412,7 @@ public class DefaultSVGWriter implements SVGWriter {
             root.appendChild(g);
 
             metadata.addNodeMetadata(
-                new GraphMetadata.NodeMetadata(nodeId, graph.getVoltageLevelInfos().getId(), null, BUSBAR_SECTION,
+                new GraphMetadata.NodeMetadata(null, nodeId, graph.getVoltageLevelInfos().getId(), null, BUSBAR_SECTION,
                     false, UNDEFINED, false, busNode.getEquipmentId(), createNodeLabelMetadata(prefixId, busNode, nodeLabels)));
             if (metadata.getComponentMetadata(BUSBAR_SECTION) == null) {
                 metadata.addComponent(new Component(BUSBAR_SECTION,
@@ -479,18 +479,18 @@ public class DefaultSVGWriter implements SVGWriter {
         boolean isOpen = node.getType() == NodeType.SWITCH && ((SwitchNode) node).isOpen();
 
         metadata.addNodeMetadata(
-                new GraphMetadata.NodeMetadata(getUnescapedId(node, nodeEscapedId), nodeEscapedId, vId, nextVId, node.getComponentType(), isOpen, direction, false,
+                new GraphMetadata.NodeMetadata(getUnescapedId(node), nodeEscapedId, vId, nextVId, node.getComponentType(), isOpen, direction, false,
                         node instanceof EquipmentNode ? ((EquipmentNode) node).getEquipmentId() : null,
                         createNodeLabelMetadata(prefixId, node, nodeLabels)));
 
         addInfoComponentMetadata(metadata, node.getComponentType());
     }
 
-    private String getUnescapedId(Node node, String nodeEscapedId) {
+    private String getUnescapedId(Node node) {
         String unescapedId = null;
-        if (node.getComponentType().compareTo(VSC_CONVERTER_STATION) == 0 ||
-            node.getComponentType().compareTo(LCC_CONVERTER_STATION) == 0) {
-            unescapedId = IdUtil.unescapeId(nodeEscapedId);
+        if (node.getComponentType().equals(VSC_CONVERTER_STATION) ||
+            node.getComponentType().equals(LCC_CONVERTER_STATION)) {
+            unescapedId = node.getId();
         }
         return unescapedId;
     }
@@ -535,7 +535,7 @@ public class DefaultSVGWriter implements SVGWriter {
         gLabel.appendChild(label);
         root.appendChild(gLabel);
 
-        metadata.addNodeMetadata(new GraphMetadata.NodeMetadata(idLabelVoltageLevel,
+        metadata.addNodeMetadata(new GraphMetadata.NodeMetadata(null, idLabelVoltageLevel,
                 graph.getVoltageLevelInfos().getId(),
                 null,
                 null,

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/GraphMetadata.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/GraphMetadata.java
@@ -33,6 +33,8 @@ public class GraphMetadata {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class NodeMetadata {
 
+        private final String unescapedId;
+
         private final String id;
 
         private final String componentType;
@@ -51,8 +53,7 @@ public class GraphMetadata {
 
         private final List<NodeLabelMetadata> labels;
 
-        @JsonCreator
-        public NodeMetadata(@JsonProperty("id") String id,
+        public NodeMetadata(@JsonProperty("id") String escapedId,
                             @JsonProperty("vid") String vId,
                             @JsonProperty("nextVId") String nextVId,
                             @JsonProperty("componentType") String componentType,
@@ -61,7 +62,22 @@ public class GraphMetadata {
                             @JsonProperty("vlabel") boolean vLabel,
                             @JsonProperty("equipmentId") String equipmentId,
                             @JsonProperty("labels") List<NodeLabelMetadata> labels) {
-            this.id = Objects.requireNonNull(id);
+            this(null, escapedId, vId, nextVId, componentType, open, direction, vLabel, equipmentId, labels);
+        }
+
+        @JsonCreator
+        public NodeMetadata(@JsonProperty("unescapedId") String unescapedId,
+                            @JsonProperty("id") String escapedId,
+                            @JsonProperty("vid") String vId,
+                            @JsonProperty("nextVId") String nextVId,
+                            @JsonProperty("componentType") String componentType,
+                            @JsonProperty("open") boolean open,
+                            @JsonProperty("direction") Direction direction,
+                            @JsonProperty("vlabel") boolean vLabel,
+                            @JsonProperty("equipmentId") String equipmentId,
+                            @JsonProperty("labels") List<NodeLabelMetadata> labels) {
+            this.unescapedId = unescapedId;
+            this.id = Objects.requireNonNull(escapedId);
             this.vId = Objects.requireNonNull(vId);
             this.nextVId = nextVId;
             this.componentType = componentType;
@@ -70,6 +86,10 @@ public class GraphMetadata {
             this.vLabel = vLabel;
             this.equipmentId = equipmentId;
             this.labels = Objects.requireNonNull(labels);
+        }
+
+        public String getUnescapedId() {
+            return unescapedId;
         }
 
         public String getId() {

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/GraphMetadata.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/GraphMetadata.java
@@ -53,6 +53,11 @@ public class GraphMetadata {
 
         private final List<NodeLabelMetadata> labels;
 
+
+        /**
+         * @deprecated use {@link NodeMetadata#NodeMetadata(String, String, String, String, String, boolean, Direction, boolean, String, List)} instead.
+         */
+        @Deprecated(since = "4.0.0", forRemoval = true)
         public NodeMetadata(@JsonProperty("id") String escapedId,
                             @JsonProperty("vid") String vId,
                             @JsonProperty("nextVId") String nextVId,

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase11SubstationGraph.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase11SubstationGraph.java
@@ -147,6 +147,21 @@ class TestCase11SubstationGraph extends AbstractTestCaseIidm {
     }
 
     @Test
+    void testMetadataWithHvdcLines() {
+        network = Networks.createNetworkWithHvdcLines("VSC_1", "VSC_2", "LCC_1", "LCC_2");
+        substation = network.getSubstation("Substation1");
+        graphBuilder = new NetworkGraphBuilder(network);
+
+        SubstationGraph g = graphBuilder.buildSubstationGraph(substation.getId());
+
+        assertTrue(compareMetadata(g, "/substDiag_with_hvdc_line_metadata.json",
+                new HorizontalSubstationLayoutFactory(),
+                new PositionVoltageLevelLayoutFactory(),
+                new DefaultDiagramLabelProvider(network, componentLibrary, layoutParameters),
+                new BasicStyleProvider()));
+    }
+
+    @Test
     void testHorizontalDefaultStyle() {
         // compare metadata of substation diagram with reference
         // (with horizontal substation layout)

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/svg/GraphMetadataTest.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/svg/GraphMetadataTest.java
@@ -149,6 +149,7 @@ class GraphMetadataTest {
     @Test
     void testGraphMetadataWithLine() throws IOException {
         GraphMetadata metadata = new GraphMetadata(new LayoutParameters());
+        metadata.addNodeMetadata(new GraphMetadata.NodeMetadata("STATION_EXEMPLE", "idSTATION_95_EXEMPLE", "vid1", null, LCC_CONVERTER_STATION, false, Direction.UNDEFINED, false, null, Collections.emptyList()));
         metadata.addNodeMetadata(new GraphMetadata.NodeMetadata("bid1", "vid1", null, BUSBAR_SECTION, false, Direction.UNDEFINED, false, null, Collections.emptyList()));
         metadata.addNodeMetadata(new GraphMetadata.NodeMetadata("lid1", "vid1", null, LINE, false, Direction.UNDEFINED, false, null, Collections.emptyList()));
         metadata.addWireMetadata(new GraphMetadata.WireMetadata("wid1", "bid1", "lid1", false, false));
@@ -170,8 +171,10 @@ class GraphMetadataTest {
     }
 
     private void checkMetadata(GraphMetadata metadata) {
-        assertEquals(4, metadata.getNodeMetadata().size());
+        assertEquals(5, metadata.getNodeMetadata().size());
+        assertEquals("STATION_EXEMPLE", metadata.getNodeMetadata("idSTATION_95_EXEMPLE").getUnescapedId());
         assertNotNull(metadata.getNodeMetadata("bid1"));
+        assertNull(metadata.getNodeMetadata("bid1").getUnescapedId());
         assertEquals("bid1", metadata.getNodeMetadata("bid1").getId());
         assertEquals("vid1", metadata.getNodeMetadata("bid1").getVId());
         assertEquals(BUSBAR_SECTION, metadata.getNodeMetadata("bid1").getComponentType());

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/svg/GraphMetadataTest.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/svg/GraphMetadataTest.java
@@ -61,8 +61,8 @@ class GraphMetadataTest {
 
         List<GraphMetadata.NodeLabelMetadata> labels = Collections.singletonList(new GraphMetadata.NodeLabelMetadata("id", "position_name", "user_id"));
 
-        metadata.addNodeMetadata(new GraphMetadata.NodeMetadata("id1", "vid1", null, BREAKER, false, Direction.UNDEFINED, false, null, labels));
-        metadata.addNodeMetadata(new GraphMetadata.NodeMetadata("id2", "vid2", null, BUSBAR_SECTION, false, Direction.UNDEFINED, false, null, labels));
+        metadata.addNodeMetadata(new GraphMetadata.NodeMetadata(null, "id1", "vid1", null, BREAKER, false, Direction.UNDEFINED, false, null, labels));
+        metadata.addNodeMetadata(new GraphMetadata.NodeMetadata(null, "id2", "vid2", null, BUSBAR_SECTION, false, Direction.UNDEFINED, false, null, labels));
         metadata.addWireMetadata(new GraphMetadata.WireMetadata("id3", "id1", "id2", false, false));
         metadata.addFeederInfoMetadata(new GraphMetadata.FeederInfoMetadata("id1", "id3", "ONE", "COMPONENT_TYPE", "user_id"));
         metadata.addElectricalNodeInfoMetadata(new GraphMetadata.ElectricalNodeInfoMetadata("id1", "user_id"));
@@ -149,12 +149,12 @@ class GraphMetadataTest {
     @Test
     void testGraphMetadataWithLine() throws IOException {
         GraphMetadata metadata = new GraphMetadata(new LayoutParameters());
-        metadata.addNodeMetadata(new GraphMetadata.NodeMetadata("STATION_EXEMPLE", "idSTATION_95_EXEMPLE", "vid1", null, LCC_CONVERTER_STATION, false, Direction.UNDEFINED, false, null, Collections.emptyList()));
-        metadata.addNodeMetadata(new GraphMetadata.NodeMetadata("bid1", "vid1", null, BUSBAR_SECTION, false, Direction.UNDEFINED, false, null, Collections.emptyList()));
-        metadata.addNodeMetadata(new GraphMetadata.NodeMetadata("lid1", "vid1", null, LINE, false, Direction.UNDEFINED, false, null, Collections.emptyList()));
+        metadata.addNodeMetadata(new GraphMetadata.NodeMetadata("STATION_EXAMPLE", "idSTATION_95_EXAMPLE", "vid1", null, LCC_CONVERTER_STATION, false, Direction.UNDEFINED, false, null, Collections.emptyList()));
+        metadata.addNodeMetadata(new GraphMetadata.NodeMetadata(null, "bid1", "vid1", null, BUSBAR_SECTION, false, Direction.UNDEFINED, false, null, Collections.emptyList()));
+        metadata.addNodeMetadata(new GraphMetadata.NodeMetadata(null, "lid1", "vid1", null, LINE, false, Direction.UNDEFINED, false, null, Collections.emptyList()));
         metadata.addWireMetadata(new GraphMetadata.WireMetadata("wid1", "bid1", "lid1", false, false));
-        metadata.addNodeMetadata(new GraphMetadata.NodeMetadata("bid2", "vid2", null, BUSBAR_SECTION, false, Direction.UNDEFINED, false, null, Collections.emptyList()));
-        metadata.addNodeMetadata(new GraphMetadata.NodeMetadata("lid2", "vid2", null, LINE, false, Direction.UNDEFINED, false, null, Collections.emptyList()));
+        metadata.addNodeMetadata(new GraphMetadata.NodeMetadata(null, "bid2", "vid2", null, BUSBAR_SECTION, false, Direction.UNDEFINED, false, null, Collections.emptyList()));
+        metadata.addNodeMetadata(new GraphMetadata.NodeMetadata(null, "lid2", "vid2", null, LINE, false, Direction.UNDEFINED, false, null, Collections.emptyList()));
         metadata.addWireMetadata(new GraphMetadata.WireMetadata("wid2", "bid2", "lid2", false, false));
         metadata.addLineMetadata(new GraphMetadata.LineMetadata("lid", "lid1", "lid2"));
 
@@ -172,7 +172,7 @@ class GraphMetadataTest {
 
     private void checkMetadata(GraphMetadata metadata) {
         assertEquals(5, metadata.getNodeMetadata().size());
-        assertEquals("STATION_EXEMPLE", metadata.getNodeMetadata("idSTATION_95_EXEMPLE").getUnescapedId());
+        assertEquals("STATION_EXAMPLE", metadata.getNodeMetadata("idSTATION_95_EXAMPLE").getUnescapedId());
         assertNotNull(metadata.getNodeMetadata("bid1"));
         assertNull(metadata.getNodeMetadata("bid1").getUnescapedId());
         assertEquals("bid1", metadata.getNodeMetadata("bid1").getId());

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/substDiag_with_hvdc_line_metadata.json
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/substDiag_with_hvdc_line_metadata.json
@@ -1,0 +1,323 @@
+{
+  "components" : [ {
+    "type" : "BUSBAR_SECTION",
+    "size" : {
+      "width" : 0.0,
+      "height" : 0.0
+    },
+    "styleClass" : "sld-busbar-section"
+  }, {
+    "type" : "LCC_CONVERTER_STATION",
+    "anchorPoints" : [ {
+      "x" : 0.0,
+      "y" : -6.0,
+      "orientation" : "VERTICAL"
+    }, {
+      "x" : 0.0,
+      "y" : 6.0,
+      "orientation" : "VERTICAL"
+    } ],
+    "size" : {
+      "width" : 16.0,
+      "height" : 8.0
+    },
+    "transformations" : {
+      "LEFT" : "ROTATION",
+      "RIGHT" : "ROTATION"
+    },
+    "styleClass" : "sld-lcc"
+  }, {
+    "type" : "ARROW_REACTIVE",
+    "size" : {
+      "width" : 10.0,
+      "height" : 10.0
+    },
+    "transformations" : {
+      "LEFT" : "ROTATION",
+      "RIGHT" : "ROTATION"
+    },
+    "styleClass" : "sld-reactive-power"
+  }, {
+    "type" : "ARROW_ACTIVE",
+    "size" : {
+      "width" : 10.0,
+      "height" : 10.0
+    },
+    "transformations" : {
+      "LEFT" : "ROTATION",
+      "RIGHT" : "ROTATION"
+    },
+    "styleClass" : "sld-active-power"
+  }, {
+    "type" : "NODE",
+    "anchorPoints" : [ {
+      "x" : 0.0,
+      "y" : 0.0,
+      "orientation" : "NONE"
+    } ],
+    "size" : {
+      "width" : 8.0,
+      "height" : 8.0
+    },
+    "styleClass" : "sld-node"
+  }, {
+    "type" : "VSC_CONVERTER_STATION",
+    "anchorPoints" : [ {
+      "x" : 0.0,
+      "y" : -6.0,
+      "orientation" : "VERTICAL"
+    }, {
+      "x" : 0.0,
+      "y" : 6.0,
+      "orientation" : "VERTICAL"
+    } ],
+    "size" : {
+      "width" : 16.0,
+      "height" : 8.0
+    },
+    "transformations" : {
+      "LEFT" : "ROTATION",
+      "RIGHT" : "ROTATION"
+    },
+    "styleClass" : "sld-vsc"
+  }, {
+    "type" : "BUS_CONNECTION",
+    "anchorPoints" : [ {
+      "x" : 0.0,
+      "y" : 0.0,
+      "orientation" : "VERTICAL"
+    } ],
+    "size" : {
+      "width" : 8.0,
+      "height" : 8.0
+    },
+    "styleClass" : "sld-bus-connection"
+  } ],
+  "nodes" : [ {
+    "id" : "idBus1",
+    "vid" : "VoltageLevel1",
+    "componentType" : "BUSBAR_SECTION",
+    "open" : false,
+    "vlabel" : false,
+    "equipmentId" : "Bus1",
+    "labels" : [ {
+      "id" : "Bus1_NW_LABEL",
+      "positionName" : "NW_LABEL"
+    } ]
+  }, {
+    "id" : "idINTERNAL_95_VoltageLevel1_95_LCC_95_1",
+    "vid" : "VoltageLevel1",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
+    "id" : "idBus3",
+    "vid" : "VoltageLevel1",
+    "componentType" : "BUSBAR_SECTION",
+    "open" : false,
+    "vlabel" : false,
+    "equipmentId" : "Bus3",
+    "labels" : [ {
+      "id" : "Bus3_NW_LABEL",
+      "positionName" : "NW_LABEL"
+    } ]
+  }, {
+    "id" : "idLCC_95_1",
+    "vid" : "VoltageLevel1",
+    "nextVId" : "VoltageLevel2",
+    "componentType" : "LCC_CONVERTER_STATION",
+    "open" : false,
+    "direction" : "BOTTOM",
+    "vlabel" : false,
+    "equipmentId" : "HvdcLine2",
+    "labels" : [ {
+      "id" : "LCC_1_S_LABEL",
+      "positionName" : "S_LABEL"
+    } ],
+    "unescapedId" : "LCC_1"
+  }, {
+    "id" : "LABEL_VL_VoltageLevel1",
+    "vid" : "VoltageLevel1",
+    "open" : false,
+    "vlabel" : true,
+    "labels" : [ ]
+  }, {
+    "id" : "idBUSCO_95_Bus3_95_LCC_95_1",
+    "vid" : "VoltageLevel1",
+    "componentType" : "BUS_CONNECTION",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
+    "id" : "idINTERNAL_95_VoltageLevel1_95_BUSCO_95_Bus3_95_LCC_95_1_45_LCC_95_1",
+    "vid" : "VoltageLevel1",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
+    "id" : "idINTERNAL_95_VoltageLevel1_95_BUSCO_95_Bus1_95_VSC_95_1_45_VSC_95_1",
+    "vid" : "VoltageLevel1",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
+    "id" : "idVSC_95_1",
+    "vid" : "VoltageLevel1",
+    "nextVId" : "VoltageLevel2",
+    "componentType" : "VSC_CONVERTER_STATION",
+    "open" : false,
+    "direction" : "TOP",
+    "vlabel" : false,
+    "equipmentId" : "HvdcLine",
+    "labels" : [ {
+      "id" : "VSC_1_N_LABEL",
+      "positionName" : "N_LABEL"
+    } ],
+    "unescapedId" : "VSC_1"
+  }, {
+    "id" : "idBUSCO_95_Bus1_95_VSC_95_1",
+    "vid" : "VoltageLevel1",
+    "componentType" : "BUS_CONNECTION",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
+    "id" : "idINTERNAL_95_VoltageLevel1_95_VSC_95_1",
+    "vid" : "VoltageLevel1",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  } ],
+  "wires" : [ {
+    "id" : "_95_VoltageLevel1_95_INTERNAL_95_VoltageLevel1_95_LCC_95_1_95_LCC_95_1",
+    "nodeId1" : "idINTERNAL_95_VoltageLevel1_95_LCC_95_1",
+    "nodeId2" : "idLCC_95_1",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_VoltageLevel1_95_INTERNAL_95_VoltageLevel1_95_BUSCO_95_Bus3_95_LCC_95_1_45_LCC_95_1_95_INTERNAL_95_VoltageLevel1_95_LCC_95_1",
+    "nodeId1" : "idINTERNAL_95_VoltageLevel1_95_BUSCO_95_Bus3_95_LCC_95_1_45_LCC_95_1",
+    "nodeId2" : "idINTERNAL_95_VoltageLevel1_95_LCC_95_1",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_VoltageLevel1_95_INTERNAL_95_VoltageLevel1_95_VSC_95_1_95_VSC_95_1",
+    "nodeId1" : "idINTERNAL_95_VoltageLevel1_95_VSC_95_1",
+    "nodeId2" : "idVSC_95_1",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_VoltageLevel1_95_BUSCO_95_Bus1_95_VSC_95_1_95_INTERNAL_95_VoltageLevel1_95_BUSCO_95_Bus1_95_VSC_95_1_45_VSC_95_1",
+    "nodeId1" : "idBUSCO_95_Bus1_95_VSC_95_1",
+    "nodeId2" : "idINTERNAL_95_VoltageLevel1_95_BUSCO_95_Bus1_95_VSC_95_1_45_VSC_95_1",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_VoltageLevel1_95_INTERNAL_95_VoltageLevel1_95_BUSCO_95_Bus1_95_VSC_95_1_45_VSC_95_1_95_INTERNAL_95_VoltageLevel1_95_VSC_95_1",
+    "nodeId1" : "idINTERNAL_95_VoltageLevel1_95_BUSCO_95_Bus1_95_VSC_95_1_45_VSC_95_1",
+    "nodeId2" : "idINTERNAL_95_VoltageLevel1_95_VSC_95_1",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_VoltageLevel1_95_Bus1_95_BUSCO_95_Bus1_95_VSC_95_1",
+    "nodeId1" : "idBus1",
+    "nodeId2" : "idBUSCO_95_Bus1_95_VSC_95_1",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_VoltageLevel1_95_Bus3_95_BUSCO_95_Bus3_95_LCC_95_1",
+    "nodeId1" : "idBus3",
+    "nodeId2" : "idBUSCO_95_Bus3_95_LCC_95_1",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_VoltageLevel1_95_BUSCO_95_Bus3_95_LCC_95_1_95_INTERNAL_95_VoltageLevel1_95_BUSCO_95_Bus3_95_LCC_95_1_45_LCC_95_1",
+    "nodeId1" : "idBUSCO_95_Bus3_95_LCC_95_1",
+    "nodeId2" : "idINTERNAL_95_VoltageLevel1_95_BUSCO_95_Bus3_95_LCC_95_1_45_LCC_95_1",
+    "straight" : false,
+    "snakeLine" : false
+  } ],
+  "lines" : [ ],
+  "feederInfos" : [ {
+    "id" : "idVSC_95_1_ARROW_ACTIVE",
+    "equipmentId" : "HvdcLine",
+    "side" : "ONE",
+    "componentType" : "ARROW_ACTIVE"
+  }, {
+    "id" : "idVSC_95_1_ARROW_REACTIVE",
+    "equipmentId" : "HvdcLine",
+    "side" : "ONE",
+    "componentType" : "ARROW_REACTIVE"
+  }, {
+    "id" : "idLCC_95_1_ARROW_REACTIVE",
+    "equipmentId" : "HvdcLine2",
+    "side" : "ONE",
+    "componentType" : "ARROW_REACTIVE"
+  }, {
+    "id" : "idLCC_95_1_ARROW_ACTIVE",
+    "equipmentId" : "HvdcLine2",
+    "side" : "ONE",
+    "componentType" : "ARROW_ACTIVE"
+  } ],
+  "electricalNodeInfos" : [ ],
+  "busInfos" : [ ],
+  "layoutParams" : {
+    "voltageLevelPadding" : {
+      "left" : 20.0,
+      "top" : 60.0,
+      "right" : 20.0,
+      "bottom" : 60.0
+    },
+    "diagramPadding" : {
+      "left" : 20.0,
+      "top" : 20.0,
+      "right" : 20.0,
+      "bottom" : 20.0
+    },
+    "verticalSpaceBus" : 25.0,
+    "horizontalBusPadding" : 20.0,
+    "cellWidth" : 50.0,
+    "externCellHeight" : 250.0,
+    "internCellHeight" : 40.0,
+    "stackHeight" : 30.0,
+    "showGrid" : false,
+    "tooltipEnabled" : false,
+    "showInternalNodes" : false,
+    "scaleFactor" : 1.0,
+    "drawStraightWires" : false,
+    "horizontalSnakeLinePadding" : 30.0,
+    "verticalSnakeLinePadding" : 30.0,
+    "feederInfosOuterMargin" : 20.0,
+    "spaceForFeederInfos" : 50.0,
+    "diagramName" : null,
+    "avoidSVGComponentsDuplication" : false,
+    "adaptCellHeightToContent" : true,
+    "maxComponentHeight" : 12.0,
+    "minSpaceBetweenComponents" : 15.0,
+    "minExternCellHeight" : 80.0,
+    "labelCentered" : false,
+    "labelDiagonal" : false,
+    "angleLabelShift" : 15.0,
+    "addNodesInfos" : false,
+    "feederInfoSymmetry" : false,
+    "cssLocation" : "INSERTED_IN_SVG",
+    "svgWidthAndHeightAdded" : true,
+    "useName" : true,
+    "feederInfosIntraMargin" : 10.0,
+    "busInfoMargin" : 0.0,
+    "busbarsAlignment" : "FIRST",
+    "componentsOnBusbars" : [ "DISCONNECTOR" ],
+    "languageTag" : "en",
+    "voltageValuePrecision" : 1,
+    "powerValuePrecision" : 0,
+    "angleValuePrecision" : 1,
+    "currentValuePrecision" : 0,
+    "displayCurrentFeederInfo" : false,
+    "undefinedValueSymbol" : "—",
+    "removeFictitiousSwitchNodes" : false
+  }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Feature

**What is the current behavior?**
In node metadata for VSC or LCC contains fields id & equipmentId.
But the field id is "ascii-encoded" & equipmentId is the HVDC line id.

**What is the new behavior (if this is a feature change)?**
Add in metadata the LCC or VSC id.

