### PR TITLE
Java 17 syntax support

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2.3.4
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-parent</artifactId>
-        <version>10</version>
+        <version>13</version>
         <relativePath/>
     </parent>
     <artifactId>powsybl-diagram</artifactId>

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/CgmesDLImportPostProcessor.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/CgmesDLImportPostProcessor.java
@@ -43,7 +43,7 @@ public class CgmesDLImportPostProcessor implements CgmesImportPostProcessor {
     }
 
     private boolean isDlProfileAvailable(Network network, TripleStore tripleStore) {
-        return (tripleStore != null) && (tripleStore.contextNames().contains(ContextUtils.contextNameFor(CgmesSubset.DIAGRAM_LAYOUT, tripleStore, network.getId())));
+        return tripleStore != null && tripleStore.contextNames().contains(ContextUtils.contextNameFor(CgmesSubset.DIAGRAM_LAYOUT, tripleStore, network.getId()));
     }
 
     @Override

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/VerticalSubstationLayout.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/VerticalSubstationLayout.java
@@ -228,7 +228,7 @@ public class VerticalSubstationLayout extends AbstractSubstationLayout {
         Direction dNode2 = getNodeDirection(node2, 2);
         VoltageLevelGraph vlGraph1 = getGraph().getVoltageLevelGraph(node1);
         VoltageLevelGraph vlGraph2 = getGraph().getVoltageLevelGraph(node2);
-        return (dNode1 == BOTTOM && dNode2 == TOP && getGraph().graphAdjacents(vlGraph1, vlGraph2))
-                || (dNode1 == TOP && dNode2 == BOTTOM && getGraph().graphAdjacents(vlGraph2, vlGraph1));
+        return dNode1 == BOTTOM && dNode2 == TOP && getGraph().graphAdjacents(vlGraph1, vlGraph2)
+                || dNode1 == TOP && dNode2 == BOTTOM && getGraph().graphAdjacents(vlGraph2, vlGraph1);
     }
 }

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/iidm/TopologicalStyleProvider.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/iidm/TopologicalStyleProvider.java
@@ -64,7 +64,7 @@ public class TopologicalStyleProvider extends AbstractVoltageStyleProvider {
     protected boolean isNodeSeparatingStyles(Node node) {
         return isMultiTerminalNode(node)
                 // filtering out leg nodes as they are nodes with the same voltage level at each side
-                && !((node instanceof FeederNode) && (((FeederNode) node).getFeeder() instanceof FeederTwLeg));
+                && !(node instanceof FeederNode && ((FeederNode) node).getFeeder() instanceof FeederTwLeg);
     }
 
     private boolean isMultiTerminalNode(Node node) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Quality


**What is the current behavior?**
<!-- You can also link to an open issue here -->
The new java17 syntax is **not** recognized by maven-checkstyle-plugin.


**What is the new behavior (if this is a feature change)?**
The new java17 syntax is recognized by maven-checkstyle-plugin.


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
Java17 syntax is not fully supported by the currently used version of maven-checkstyle-plugin (v3.1.1). This plugin's version provided by powsybl-parent v13 (maven-checkstyle-plugin v3.3.0) supports it but introduces or redefines some rules. Among them are changes about the UnnecessaryParentheses rule, which now considers the precedence between the `&&` and `||` logical operators (on this subject, you can see https://github.com/checkstyle/checkstyle/issues/10946).