### PR TITLE
Delete fixSvg function since migrating to Java 17

### DIFF
--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
@@ -107,23 +107,13 @@ public abstract class AbstractTestCase {
             return;
         }
         try (BufferedWriter bw = Files.newBufferedWriter(testReference, StandardCharsets.UTF_8)) {
-            bw.write(normalizeLineSeparator(fixSvg(content.toString())));
+            bw.write(normalizeLineSeparator(content.toString()));
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
     }
 
     public abstract String toSVG(Graph g, String filename);
-
-    /**
-     * Between Java 9 and 14 an extra new lines is added before and after CDATA element. To support both Java 11 and 17
-     * we need to remove these new lines => To remove when migrating to Java 17.
-     *
-     * See https://stackoverflow.com/questions/55853220/handling-change-in-newlines-by-xml-transformation-for-cdata-from-java-8-to-java
-     */
-    protected static String fixSvg(String svg) {
-        return SVG_FIX_PATTERN.matcher(Objects.requireNonNull(svg)).replaceAll(">$1</");
-    }
 
     public String toSVG(Graph graph, String filename, DiagramLabelProvider labelProvider, StyleProvider styleProvider) {
         try (StringWriter writer = new StringWriter()) {
@@ -137,7 +127,7 @@ public abstract class AbstractTestCase {
                 overrideTestReference(filename, writer);
             }
 
-            return fixSvg(normalizeLineSeparator(writer.toString()));
+            return normalizeLineSeparator(writer.toString());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSingleLineDiagramClass.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSingleLineDiagramClass.java
@@ -81,16 +81,16 @@ class TestSingleLineDiagramClass extends AbstractTestCaseIidm {
 
         Writer writerForSvg = new StringWriter();
         SingleLineDiagram.drawVoltageLevel(network, vl.getId(), writerForSvg, new NullWriter());
-        assertEquals(expected, fixSvg(normalizeLineSeparator(writerForSvg.toString())));
+        assertEquals(expected, normalizeLineSeparator(writerForSvg.toString()));
 
         Path svgPath = tmpDir.resolve("result.svg");
         Path metadataPath = tmpDir.resolve("result_metadata.json");
         SingleLineDiagram.drawVoltageLevel(network, vl.getId(), svgPath);
-        assertEquals(expected, fixSvg(toString(Files.newInputStream(svgPath))));
+        assertEquals(expected, toString(Files.newInputStream(svgPath)));
         assertEquals(expectedMetadata, toString(Files.newInputStream(metadataPath)));
 
         SingleLineDiagram.draw(network, vl.getId(), svgPath);
-        assertEquals(expected, fixSvg(toString(Files.newInputStream(svgPath))));
+        assertEquals(expected, toString(Files.newInputStream(svgPath)));
         assertEquals(expectedMetadata, toString(Files.newInputStream(metadataPath)));
     }
 
@@ -108,7 +108,7 @@ class TestSingleLineDiagramClass extends AbstractTestCaseIidm {
 
     @Test
     void testSvgSubs() throws IOException {
-        String expected = fixSvg(toString("/TestSldClassSubstation.svg"));
+        String expected = toString("/TestSldClassSubstation.svg");
         String expectedMetadata = toString("/TestSldClassSubstationMetadata.json");
         assertEquals(expected, toDefaultSVG(network, substation.getId(), "/TestSldClassSubstation.svg", "/TestSldClassSubstationMetadata.json"));
 
@@ -122,16 +122,16 @@ class TestSingleLineDiagramClass extends AbstractTestCaseIidm {
 
         Writer writerForSvg = new StringWriter();
         SingleLineDiagram.drawSubstation(network, substation.getId(), writerForSvg, new NullWriter());
-        assertEquals(expected, fixSvg(normalizeLineSeparator(writerForSvg.toString())));
+        assertEquals(expected, normalizeLineSeparator(writerForSvg.toString()));
 
         Path svgPath = tmpDir.resolve("result.svg");
         Path metadataPath = tmpDir.resolve("result_metadata.json");
         SingleLineDiagram.drawSubstation(network, substation.getId(), svgPath);
-        assertEquals(expected, fixSvg(toString(Files.newInputStream(svgPath))));
+        assertEquals(expected, toString(Files.newInputStream(svgPath)));
         assertEquals(expectedMetadata, toString(Files.newInputStream(metadataPath)));
 
         SingleLineDiagram.draw(network, substation.getId(), svgPath);
-        assertEquals(expected, fixSvg(toString(Files.newInputStream(svgPath))));
+        assertEquals(expected, toString(Files.newInputStream(svgPath)));
         assertEquals(expectedMetadata, toString(Files.newInputStream(metadataPath)));
 
         PowsyblException e2 = assertThrows(PowsyblException.class, () -> SingleLineDiagram.draw(network, "bbs2", svgPath));
@@ -158,7 +158,7 @@ class TestSingleLineDiagramClass extends AbstractTestCaseIidm {
                 overrideTestReference(jsonFilename, metadataWriter);
             }
 
-            return fixSvg(normalizeLineSeparator(writer.toString()));
+            return normalizeLineSeparator(writer.toString());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines

**What kind of change does this PR introduce?**
Quality

**What is the current behavior?**
A function was added to allow Java 11 and Java 17 support.

**What is the new behavior (if this is a feature change)?**
Since we have moved to Java 17, this function is no longer necessary.
