### PR TITLE
Fix extensions version in pom

### DIFF
--- a/diagram-test/pom.xml
+++ b/diagram-test/pom.xml
@@ -48,8 +48,6 @@
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-extensions</artifactId>
-            <version>5.2.0</version>
-            <scope>compile</scope>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
powsybl-iidm-extensions v5.2.0 in powsybl-diagram-test


**What is the new behavior (if this is a feature change)?**
powsybl-iidm-extensions in powsybl-diagram-test has the version importer from powsybl-core pom


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
No