### PR TITLE
Add literal annotation in author's email address

### DIFF
--- a/diagram-test/src/main/java/com/powsybl/diagram/test/Networks.java
+++ b/diagram-test/src/main/java/com/powsybl/diagram/test/Networks.java
@@ -15,7 +15,7 @@ import java.util.Optional;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public final class Networks {
 

--- a/diagram-util/src/main/java-templates/com/powsybl/diagram/util/PowsyblDiagramVersion.java
+++ b/diagram-util/src/main/java-templates/com/powsybl/diagram/util/PowsyblDiagramVersion.java
@@ -10,7 +10,7 @@ import com.google.auto.service.AutoService;
 import com.powsybl.tools.*;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 @AutoService(Version.class)
 public class PowsyblDiagramVersion extends AbstractVersion {

--- a/diagram-util/src/main/java/com/powsybl/diagram/util/ValueFormatter.java
+++ b/diagram-util/src/main/java/com/powsybl/diagram/util/ValueFormatter.java
@@ -11,7 +11,7 @@ import java.text.DecimalFormatSymbols;
 import java.util.Locale;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class ValueFormatter {
 

--- a/diagram-util/src/main/java/com/powsybl/diagram/util/forcelayout/BoundingBox.java
+++ b/diagram-util/src/main/java/com/powsybl/diagram/util/forcelayout/BoundingBox.java
@@ -9,7 +9,7 @@ package com.powsybl.diagram.util.forcelayout;
 import java.util.Collection;
 
 /**
- * @author Mathilde Grapin <mathilde.grapin at rte-france.com>
+ * @author Mathilde Grapin {@literal <mathilde.grapin at rte-france.com>}
  */
 public final class BoundingBox {
 

--- a/diagram-util/src/main/java/com/powsybl/diagram/util/forcelayout/Canvas.java
+++ b/diagram-util/src/main/java/com/powsybl/diagram/util/forcelayout/Canvas.java
@@ -9,7 +9,7 @@ package com.powsybl.diagram.util.forcelayout;
 import java.util.Objects;
 
 /**
- * @author Mathilde Grapin <mathilde.grapin at rte-france.com>
+ * @author Mathilde Grapin {@literal <mathilde.grapin at rte-france.com>}
  */
 public class Canvas {
     private final double width;

--- a/diagram-util/src/main/java/com/powsybl/diagram/util/forcelayout/ForceLayout.java
+++ b/diagram-util/src/main/java/com/powsybl/diagram/util/forcelayout/ForceLayout.java
@@ -48,7 +48,7 @@ import java.util.function.Function;
  *
  * The algorithm is taken from: https://github.com/dhotson/springy
  *
- * @author Mathilde Grapin <mathilde.grapin at rte-france.com>
+ * @author Mathilde Grapin {@literal <mathilde.grapin at rte-france.com>}
  */
 public class ForceLayout<V, E> {
     private static final Logger LOGGER = LoggerFactory.getLogger(ForceLayout.class);

--- a/diagram-util/src/main/java/com/powsybl/diagram/util/forcelayout/Point.java
+++ b/diagram-util/src/main/java/com/powsybl/diagram/util/forcelayout/Point.java
@@ -11,7 +11,7 @@ import java.util.Locale;
 import java.util.function.Function;
 
 /**
- * @author Mathilde Grapin <mathilde.grapin at rte-france.com>
+ * @author Mathilde Grapin {@literal <mathilde.grapin at rte-france.com>}
  */
 public class Point {
     private static final double DEFAULT_MASS = 1.0;

--- a/diagram-util/src/main/java/com/powsybl/diagram/util/forcelayout/Spring.java
+++ b/diagram-util/src/main/java/com/powsybl/diagram/util/forcelayout/Spring.java
@@ -11,7 +11,7 @@ import java.util.Locale;
 import java.util.Objects;
 
 /**
- * @author Mathilde Grapin <mathilde.grapin at rte-france.com>
+ * @author Mathilde Grapin {@literal <mathilde.grapin at rte-france.com>}
  */
 public class Spring {
     private static final double DEFAULT_LENGTH = 1.0;

--- a/diagram-util/src/main/java/com/powsybl/diagram/util/forcelayout/Vector.java
+++ b/diagram-util/src/main/java/com/powsybl/diagram/util/forcelayout/Vector.java
@@ -7,7 +7,7 @@
 package com.powsybl.diagram.util.forcelayout;
 
 /**
- * @author Mathilde Grapin <mathilde.grapin at rte-france.com>
+ * @author Mathilde Grapin {@literal <mathilde.grapin at rte-france.com>}
  */
 public class Vector {
     private final double x;

--- a/diagram-util/src/test/java/com/powsybl/diagram/util/forcelayout/BoundingBoxTest.java
+++ b/diagram-util/src/test/java/com/powsybl/diagram/util/forcelayout/BoundingBoxTest.java
@@ -13,7 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 class BoundingBoxTest {
 

--- a/diagram-util/src/test/java/com/powsybl/diagram/util/forcelayout/CanvasTest.java
+++ b/diagram-util/src/test/java/com/powsybl/diagram/util/forcelayout/CanvasTest.java
@@ -13,7 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 class CanvasTest {
 

--- a/diagram-util/src/test/java/com/powsybl/diagram/util/forcelayout/VectorTest.java
+++ b/diagram-util/src/test/java/com/powsybl/diagram/util/forcelayout/VectorTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 class VectorTest {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/NadParameters.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/NadParameters.java
@@ -20,7 +20,7 @@ import java.util.Objects;
 
 /**
  *
- * @author Sophie Frasnedo <sophie.frasnedo at rte-france.com>
+ * @author Sophie Frasnedo {@literal <sophie.frasnedo at rte-france.com>}
  */
 public class NadParameters {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/NetworkAreaDiagram.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/NetworkAreaDiagram.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 import java.util.function.Predicate;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public final class NetworkAreaDiagram {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/build/GraphBuilder.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/build/GraphBuilder.java
@@ -9,7 +9,7 @@ package com.powsybl.nad.build;
 import com.powsybl.nad.model.Graph;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public interface GraphBuilder {
     Graph buildGraph();

--- a/network-area-diagram/src/main/java/com/powsybl/nad/build/iidm/IdProvider.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/build/iidm/IdProvider.java
@@ -10,7 +10,7 @@ import com.powsybl.iidm.network.Identifiable;
 import com.powsybl.iidm.network.ThreeWindingsTransformer;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public interface IdProvider {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/build/iidm/IntIdProvider.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/build/iidm/IntIdProvider.java
@@ -10,7 +10,7 @@ import com.powsybl.iidm.network.Identifiable;
 import com.powsybl.iidm.network.ThreeWindingsTransformer;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class IntIdProvider implements IdProvider {
     private int count;

--- a/network-area-diagram/src/main/java/com/powsybl/nad/build/iidm/NetworkGraphBuilder.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/build/iidm/NetworkGraphBuilder.java
@@ -19,7 +19,7 @@ import java.util.Objects;
 import java.util.function.Predicate;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class NetworkGraphBuilder implements GraphBuilder {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/build/iidm/VoltageLevelFilter.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/build/iidm/VoltageLevelFilter.java
@@ -15,7 +15,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class VoltageLevelFilter implements Predicate<VoltageLevel> {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/layout/AbstractLayout.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/layout/AbstractLayout.java
@@ -14,7 +14,7 @@ import java.util.stream.Stream;
 
 /**
  *
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public abstract class AbstractLayout implements Layout {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/layout/BasicFixedLayout.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/layout/BasicFixedLayout.java
@@ -12,7 +12,7 @@ import com.powsybl.nad.model.Node;
 import com.powsybl.nad.model.Point;
 
 /**
- * @author Luma Zamarreño <zamarrenolm at aia.es>
+ * @author Luma Zamarreño {@literal <zamarrenolm at aia.es>}
  */
 public class BasicFixedLayout extends AbstractLayout {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/layout/BasicFixedLayoutFactory.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/layout/BasicFixedLayoutFactory.java
@@ -12,7 +12,7 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * @author Luma Zamarreño <zamarrenolm at aia.es>
+ * @author Luma Zamarreño {@literal <zamarrenolm at aia.es>}
  */
 public class BasicFixedLayoutFactory implements LayoutFactory {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/layout/BasicForceLayout.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/layout/BasicForceLayout.java
@@ -18,7 +18,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class BasicForceLayout extends AbstractLayout {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/layout/BasicForceLayoutFactory.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/layout/BasicForceLayoutFactory.java
@@ -7,7 +7,7 @@
 package com.powsybl.nad.layout;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class BasicForceLayoutFactory implements LayoutFactory {
     @Override

--- a/network-area-diagram/src/main/java/com/powsybl/nad/layout/Layout.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/layout/Layout.java
@@ -13,7 +13,7 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public interface Layout {
     void run(Graph graph, LayoutParameters layoutParameters);

--- a/network-area-diagram/src/main/java/com/powsybl/nad/layout/LayoutFactory.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/layout/LayoutFactory.java
@@ -7,7 +7,7 @@
 package com.powsybl.nad.layout;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public interface LayoutFactory {
     Layout create();

--- a/network-area-diagram/src/main/java/com/powsybl/nad/layout/LayoutParameters.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/layout/LayoutParameters.java
@@ -9,7 +9,7 @@ package com.powsybl.nad.layout;
 import com.powsybl.nad.model.Point;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class LayoutParameters {
     private boolean textNodesForceLayout = false;

--- a/network-area-diagram/src/main/java/com/powsybl/nad/model/AbstractEdge.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/model/AbstractEdge.java
@@ -7,7 +7,7 @@
 package com.powsybl.nad.model;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public abstract class AbstractEdge extends AbstractIdentifiable implements Edge {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/model/AbstractIdentifiable.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/model/AbstractIdentifiable.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 abstract class AbstractIdentifiable implements Identifiable {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/model/AbstractNode.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/model/AbstractNode.java
@@ -7,7 +7,7 @@
 package com.powsybl.nad.model;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public abstract class AbstractNode extends AbstractIdentifiable implements Node {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/model/BoundaryBusNode.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/model/BoundaryBusNode.java
@@ -8,7 +8,7 @@
 package com.powsybl.nad.model;
 
 /**
- * @author Luma Zamarreño <zamarrenolm at aia.es>
+ * @author Luma Zamarreño {@literal <zamarrenolm at aia.es>}
  */
 public class BoundaryBusNode extends BusNode {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/model/BoundaryNode.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/model/BoundaryNode.java
@@ -8,7 +8,7 @@
 package com.powsybl.nad.model;
 
 /**
- * @author Luma Zamarreño <zamarrenolm at aia.es>
+ * @author Luma Zamarreño {@literal <zamarrenolm at aia.es>}
  */
 public class BoundaryNode extends VoltageLevelNode {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/model/BranchEdge.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/model/BranchEdge.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class BranchEdge extends AbstractEdge {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/model/BusNode.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/model/BusNode.java
@@ -7,7 +7,7 @@
 package com.powsybl.nad.model;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class BusNode extends AbstractNode {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/model/Edge.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/model/Edge.java
@@ -7,7 +7,7 @@
 package com.powsybl.nad.model;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public interface Edge extends Identifiable {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/model/Graph.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/model/Graph.java
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class Graph {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/model/Identifiable.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/model/Identifiable.java
@@ -9,7 +9,7 @@ package com.powsybl.nad.model;
 import java.util.Optional;
 
 /**
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 public interface Identifiable {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/model/Node.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/model/Node.java
@@ -7,7 +7,7 @@
 package com.powsybl.nad.model;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public interface Node extends Identifiable {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/model/Point.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/model/Point.java
@@ -9,7 +9,7 @@ package com.powsybl.nad.model;
 import java.util.Objects;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class Point {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/model/TextEdge.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/model/TextEdge.java
@@ -10,7 +10,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class TextEdge extends AbstractEdge {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/model/TextNode.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/model/TextNode.java
@@ -7,7 +7,7 @@
 package com.powsybl.nad.model;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class TextNode extends AbstractNode {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/model/ThreeWtEdge.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/model/ThreeWtEdge.java
@@ -11,7 +11,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class ThreeWtEdge extends AbstractEdge {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/model/ThreeWtNode.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/model/ThreeWtNode.java
@@ -7,7 +7,7 @@
 package com.powsybl.nad.model;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class ThreeWtNode extends AbstractNode {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/model/VoltageLevelNode.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/model/VoltageLevelNode.java
@@ -10,7 +10,7 @@ import java.util.*;
 import java.util.stream.Stream;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class VoltageLevelNode extends AbstractNode {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/AbstractStyleProvider.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/AbstractStyleProvider.java
@@ -20,7 +20,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public abstract class AbstractStyleProvider implements StyleProvider {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/DefaultEdgeRendering.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/DefaultEdgeRendering.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class DefaultEdgeRendering implements EdgeRendering {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/EdgeInfo.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/EdgeInfo.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 import java.util.function.DoubleFunction;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class EdgeInfo {
     public static final String ACTIVE_POWER = "ActivePower";

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/EdgeRendering.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/EdgeRendering.java
@@ -9,7 +9,7 @@ package com.powsybl.nad.svg;
 import com.powsybl.nad.model.Graph;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public interface EdgeRendering {
     void run(Graph graph, SvgParameters svgParameters);

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/LabelProvider.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/LabelProvider.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public interface LabelProvider {
     Optional<EdgeInfo> getEdgeInfo(Graph graph, BranchEdge edge, BranchEdge.Side side);

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/Padding.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/Padding.java
@@ -7,7 +7,7 @@
 package com.powsybl.nad.svg;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class Padding {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/StyleProvider.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/StyleProvider.java
@@ -11,7 +11,7 @@ import com.powsybl.nad.model.*;
 import java.util.List;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public interface StyleProvider {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/SvgParameters.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/SvgParameters.java
@@ -12,7 +12,7 @@ import java.util.Locale;
 import java.util.Objects;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class SvgParameters {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/SvgWriter.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/SvgWriter.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class SvgWriter {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/iidm/AbstractVoltageStyleProvider.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/iidm/AbstractVoltageStyleProvider.java
@@ -19,7 +19,7 @@ import com.powsybl.nad.utils.iidm.IidmUtils;
 import java.util.*;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public abstract class AbstractVoltageStyleProvider extends AbstractStyleProvider {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/iidm/DefaultLabelProvider.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/iidm/DefaultLabelProvider.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class DefaultLabelProvider implements LabelProvider {
     private final Network network;

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/iidm/IdProviderFactory.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/iidm/IdProviderFactory.java
@@ -12,7 +12,7 @@ import com.powsybl.nad.build.iidm.IdProvider;
 
 /**
  *
- * @author Sophie Frasnedo <sophie.frasnedo at rte-france.com>
+ * @author Sophie Frasnedo {@literal <sophie.frasnedo at rte-france.com>}
  */
 @FunctionalInterface
 public interface IdProviderFactory {

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/iidm/LabelProviderFactory.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/iidm/LabelProviderFactory.java
@@ -14,7 +14,7 @@ import com.powsybl.nad.svg.SvgParameters;
 
 /**
  *
- * @author Sophie Frasnedo <sophie.frasnedo at rte-france.com>
+ * @author Sophie Frasnedo {@literal <sophie.frasnedo at rte-france.com>}
  */
 @FunctionalInterface
 public interface LabelProviderFactory {

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/iidm/NominalVoltageStyleProvider.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/iidm/NominalVoltageStyleProvider.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class NominalVoltageStyleProvider extends AbstractVoltageStyleProvider {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/iidm/StyleProviderFactory.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/iidm/StyleProviderFactory.java
@@ -13,7 +13,7 @@ import com.powsybl.nad.svg.StyleProvider;
 
 /**
  *
- * @author Sophie Frasnedo <sophie.frasnedo at rte-france.com>
+ * @author Sophie Frasnedo {@literal <sophie.frasnedo at rte-france.com>}
  */
 @FunctionalInterface
 public interface StyleProviderFactory {

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/iidm/TopologicalStyleProvider.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/iidm/TopologicalStyleProvider.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class TopologicalStyleProvider extends AbstractVoltageStyleProvider {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/AbstractMetadataItem.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/AbstractMetadataItem.java
@@ -12,7 +12,7 @@ import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
 
 /**
- * @author Luma Zamarreño <zamarrenolm at aia.es>
+ * @author Luma Zamarreño {@literal <zamarrenolm at aia.es>}
  */
 public abstract class AbstractMetadataItem {
     private static final String DIAGRAM_ID_ATTRIBUTE = "svgId";

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/BusNodeMetadata.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/BusNodeMetadata.java
@@ -10,7 +10,7 @@ import javax.xml.stream.XMLStreamReader;
 
 /**
  *
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 
 public class BusNodeMetadata extends AbstractMetadataItem {

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/DiagramMetadata.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/DiagramMetadata.java
@@ -19,7 +19,7 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 public class DiagramMetadata {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/EdgeMetadata.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/EdgeMetadata.java
@@ -12,7 +12,7 @@ import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
 
 /**
- * @author Luma Zamarreño <zamarrenolm at aia.es>
+ * @author Luma Zamarreño {@literal <zamarrenolm at aia.es>}
  */
 public class EdgeMetadata extends AbstractMetadataItem {
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/NodeMetadata.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/NodeMetadata.java
@@ -12,7 +12,7 @@ import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
 
 /**
- * @author Luma Zamarreño <zamarrenolm at aia.es>
+ * @author Luma Zamarreño {@literal <zamarrenolm at aia.es>}
  */
 public class NodeMetadata extends AbstractMetadataItem {
     private static final String ELEMENT_NAME = "node";

--- a/network-area-diagram/src/main/java/com/powsybl/nad/utils/iidm/IidmUtils.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/utils/iidm/IidmUtils.java
@@ -15,8 +15,8 @@ import java.util.Objects;
 
 /**
  *
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
- * @author Luma Zamarreño <zamarrenolm at aia.es>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
+ * @author Luma Zamarreño {@literal <zamarrenolm at aia.es>}
  */
 
 public final class IidmUtils {

--- a/network-area-diagram/src/test/java/com/powsybl/nad/AbstractTest.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/AbstractTest.java
@@ -28,7 +28,7 @@ import java.util.function.Predicate;
 import java.util.stream.*;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public abstract class AbstractTest {
 

--- a/network-area-diagram/src/test/java/com/powsybl/nad/NetworkAreaDiagramTest.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/NetworkAreaDiagramTest.java
@@ -29,7 +29,7 @@ import java.util.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 class NetworkAreaDiagramTest extends AbstractTest {
 

--- a/network-area-diagram/src/test/java/com/powsybl/nad/layout/FixedLayoutTest.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/layout/FixedLayoutTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
- * @author Luma Zamarreno <zamarrenolm at aia.es>
+ * @author Luma Zamarreno {@literal <zamarrenolm at aia.es>}
  */
 class FixedLayoutTest {
 

--- a/network-area-diagram/src/test/java/com/powsybl/nad/layout/ForceLayoutTest.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/layout/ForceLayoutTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.BeforeEach;
 
 /**
- * @author Luma Zamarreno <zamarrenolm at aia.es>
+ * @author Luma Zamarreno {@literal <zamarrenolm at aia.es>}
  */
 class ForceLayoutTest extends AbstractTest {
 

--- a/network-area-diagram/src/test/java/com/powsybl/nad/layout/LayoutNetworkFactory.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/layout/LayoutNetworkFactory.java
@@ -9,7 +9,7 @@ package com.powsybl.nad.layout;
 import com.powsybl.iidm.network.*;
 
 /**
- * @author Luma Zamarreno <zamarrenolm at aia.es>
+ * @author Luma Zamarreno {@literal <zamarrenolm at aia.es>}
  */
 final class LayoutNetworkFactory {
 

--- a/network-area-diagram/src/test/java/com/powsybl/nad/layout/LayoutParametersTest.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/layout/LayoutParametersTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class LayoutParametersTest {
 

--- a/network-area-diagram/src/test/java/com/powsybl/nad/layout/LayoutWithInitialPositionsTest.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/layout/LayoutWithInitialPositionsTest.java
@@ -34,7 +34,7 @@ import java.util.function.Predicate;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Luma Zamarreno <zamarrenolm at aia.es>
+ * @author Luma Zamarreno {@literal <zamarrenolm at aia.es>}
  */
 class LayoutWithInitialPositionsTest extends AbstractTest {
 

--- a/network-area-diagram/src/test/java/com/powsybl/nad/svg/DanglingLineTest.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/svg/DanglingLineTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Luma Zamarreño <zamarrenolm at aia.es>
+ * @author Luma Zamarreño {@literal <zamarrenolm at aia.es>}
  */
 class DanglingLineTest extends AbstractTest {
 

--- a/network-area-diagram/src/test/java/com/powsybl/nad/svg/DiagramMetadataTest.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/svg/DiagramMetadataTest.java
@@ -31,7 +31,7 @@ import java.nio.file.Path;
 import java.util.Objects;
 
 /**
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 class DiagramMetadataTest extends AbstractTest {
 

--- a/network-area-diagram/src/test/java/com/powsybl/nad/svg/EdgeIdTest.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/svg/EdgeIdTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class EdgeIdTest extends AbstractTest {
 

--- a/network-area-diagram/src/test/java/com/powsybl/nad/svg/EdgeInfoLabelTest.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/svg/EdgeInfoLabelTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.BeforeEach;
 import java.util.Optional;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class EdgeInfoLabelTest extends AbstractTest {
 

--- a/network-area-diagram/src/test/java/com/powsybl/nad/svg/EdgeInfoShiftTest.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/svg/EdgeInfoShiftTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class EdgeInfoShiftTest extends AbstractTest {
 

--- a/network-area-diagram/src/test/java/com/powsybl/nad/svg/HvdcTest.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/svg/HvdcTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Luma Zamarreño <zamarrenolm at aia.es>
+ * @author Luma Zamarreño {@literal <zamarrenolm at aia.es>}
  */
 class HvdcTest extends AbstractTest {
 

--- a/network-area-diagram/src/test/java/com/powsybl/nad/svg/LimitsTest.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/svg/LimitsTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class LimitsTest extends AbstractTest {
 

--- a/network-area-diagram/src/test/java/com/powsybl/nad/svg/NominalVoltageStyleTest.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/svg/NominalVoltageStyleTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class NominalVoltageStyleTest extends AbstractTest {
 

--- a/network-area-diagram/src/test/java/com/powsybl/nad/svg/ParallelTransformerTest.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/svg/ParallelTransformerTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class ParallelTransformerTest extends AbstractTest {
 

--- a/network-area-diagram/src/test/java/com/powsybl/nad/svg/SvgParametersTest.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/svg/SvgParametersTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class SvgParametersTest {
 

--- a/network-area-diagram/src/test/java/com/powsybl/nad/svg/TextNodeTest.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/svg/TextNodeTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.List;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class TextNodeTest extends AbstractTest {
 

--- a/network-area-diagram/src/test/java/com/powsybl/nad/svg/ThreeWindingTransformerTest.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/svg/ThreeWindingTransformerTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.Collections;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class ThreeWindingTransformerTest extends AbstractTest {
 

--- a/network-area-diagram/src/test/java/com/powsybl/nad/svg/TieLineTest.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/svg/TieLineTest.java
@@ -24,7 +24,7 @@ import java.util.Collections;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Sophie Frasnedo <sophie.frasnedo at rte-france.com>
+ * @author Sophie Frasnedo {@literal <sophie.frasnedo at rte-france.com>}
  */
 class TieLineTest extends AbstractTest {
 

--- a/network-area-diagram/src/test/java/com/powsybl/nad/svg/TopologicalStyleTest.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/svg/TopologicalStyleTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.Arrays;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class TopologicalStyleTest extends AbstractTest {
 

--- a/network-area-diagram/src/test/java/com/powsybl/nad/svg/TypeOfEdgeInfoTest.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/svg/TypeOfEdgeInfoTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Sophie Frasnedo <sophie.frasnedo at rte-france.com>
+ * @author Sophie Frasnedo {@literal <sophie.frasnedo at rte-france.com>}
  */
 class TypeOfEdgeInfoTest extends AbstractTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/AbstractCouplingDeviceDiagramDataExporter.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/AbstractCouplingDeviceDiagramDataExporter.java
@@ -17,7 +17,7 @@ import java.util.Objects;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public abstract class AbstractCouplingDeviceDiagramDataExporter extends AbstractDiagramDataExporter {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/AbstractDiagramDataExporter.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/AbstractDiagramDataExporter.java
@@ -23,7 +23,7 @@ import com.powsybl.triplestore.api.TripleStore;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public abstract class AbstractDiagramDataExporter {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/AbstractInjectionDiagramDataExporter.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/AbstractInjectionDiagramDataExporter.java
@@ -17,7 +17,7 @@ import com.powsybl.triplestore.api.TripleStore;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public abstract class AbstractInjectionDiagramDataExporter extends AbstractDiagramDataExporter {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/AbstractLineDiagramDataExporter.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/AbstractLineDiagramDataExporter.java
@@ -14,7 +14,7 @@ import com.powsybl.triplestore.api.TripleStore;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public abstract class AbstractLineDiagramDataExporter extends AbstractDiagramDataExporter {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/AbstractNodeDiagramDataExporter.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/AbstractNodeDiagramDataExporter.java
@@ -14,7 +14,7 @@ import com.powsybl.triplestore.api.TripleStore;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public abstract class AbstractNodeDiagramDataExporter extends AbstractDiagramDataExporter {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/BusDiagramDataExporter.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/BusDiagramDataExporter.java
@@ -15,7 +15,7 @@ import com.powsybl.triplestore.api.TripleStore;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class BusDiagramDataExporter extends AbstractNodeDiagramDataExporter {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/BusbarDiagramDataExporter.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/BusbarDiagramDataExporter.java
@@ -20,7 +20,7 @@ import com.powsybl.triplestore.api.TripleStore;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class BusbarDiagramDataExporter extends AbstractNodeDiagramDataExporter {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/CgmesDLExporter.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/CgmesDLExporter.java
@@ -23,7 +23,7 @@ import com.powsybl.triplestore.api.TripleStoreFactory;
 
 /**
 *
-* @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
 */
 public class CgmesDLExporter {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/CgmesDLImportPostProcessor.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/CgmesDLImportPostProcessor.java
@@ -19,7 +19,7 @@ import java.util.Objects;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 @AutoService(CgmesImportPostProcessor.class)
 public class CgmesDLImportPostProcessor implements CgmesImportPostProcessor {

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/CgmesDLImporter.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/CgmesDLImporter.java
@@ -21,7 +21,7 @@ import java.util.Set;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class CgmesDLImporter {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/CgmesDLModel.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/CgmesDLModel.java
@@ -19,7 +19,7 @@ import com.powsybl.triplestore.api.TripleStore;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class CgmesDLModel {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/CgmesDLUtils.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/CgmesDLUtils.java
@@ -22,7 +22,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * @author Christian Biasuzzi <christian.biasuzzi@techrain.eu>
+ * @author Christian Biasuzzi {@literal <christian.biasuzzi@techrain.eu>}
  */
 public final class CgmesDLUtils {
     private CgmesDLUtils() {

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/ContextUtils.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/ContextUtils.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public final class ContextUtils {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/DanglingLineDiagramDataExporter.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/DanglingLineDiagramDataExporter.java
@@ -14,7 +14,7 @@ import com.powsybl.triplestore.api.TripleStore;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class DanglingLineDiagramDataExporter extends AbstractLineDiagramDataExporter {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/ExportContext.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/ExportContext.java
@@ -14,7 +14,7 @@ import com.powsybl.triplestore.api.TripleStore;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class ExportContext {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/GeneratorDiagramDataExporter.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/GeneratorDiagramDataExporter.java
@@ -15,7 +15,7 @@ import com.powsybl.triplestore.api.TripleStore;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class GeneratorDiagramDataExporter extends AbstractInjectionDiagramDataExporter {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/HvdcLineDiagramDataExporter.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/HvdcLineDiagramDataExporter.java
@@ -14,7 +14,7 @@ import com.powsybl.triplestore.api.TripleStore;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class HvdcLineDiagramDataExporter extends AbstractLineDiagramDataExporter {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/LineDiagramDataExporter.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/LineDiagramDataExporter.java
@@ -14,7 +14,7 @@ import com.powsybl.triplestore.api.TripleStore;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class LineDiagramDataExporter extends AbstractLineDiagramDataExporter {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/LoadDiagramDataExporter.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/LoadDiagramDataExporter.java
@@ -15,7 +15,7 @@ import com.powsybl.triplestore.api.TripleStore;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class LoadDiagramDataExporter extends AbstractInjectionDiagramDataExporter {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/ShuntDiagramDataExporter.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/ShuntDiagramDataExporter.java
@@ -15,7 +15,7 @@ import com.powsybl.triplestore.api.TripleStore;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class ShuntDiagramDataExporter extends AbstractInjectionDiagramDataExporter {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/SvcDiagramDataExporter.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/SvcDiagramDataExporter.java
@@ -15,7 +15,7 @@ import com.powsybl.triplestore.api.TripleStore;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class SvcDiagramDataExporter extends AbstractInjectionDiagramDataExporter {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/SwitchDiagramDataExporter.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/SwitchDiagramDataExporter.java
@@ -15,7 +15,7 @@ import com.powsybl.triplestore.api.TripleStore;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class SwitchDiagramDataExporter extends AbstractCouplingDeviceDiagramDataExporter {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/Transformer3WDiagramDataExporter.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/Transformer3WDiagramDataExporter.java
@@ -19,7 +19,7 @@ import com.powsybl.triplestore.api.TripleStore;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class Transformer3WDiagramDataExporter extends AbstractDiagramDataExporter {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/TransformerDiagramDataExporter.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/TransformerDiagramDataExporter.java
@@ -15,7 +15,7 @@ import com.powsybl.triplestore.api.TripleStore;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class TransformerDiagramDataExporter extends AbstractCouplingDeviceDiagramDataExporter {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/VoltageLevelDiagramDataExporter.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/VoltageLevelDiagramDataExporter.java
@@ -19,7 +19,7 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
- * @author Christian Biasuzzi <christian.biasuzzi@techrain.eu>
+ * @author Christian Biasuzzi {@literal <christian.biasuzzi@techrain.eu>}
  */
 public class VoltageLevelDiagramDataExporter extends AbstractDiagramDataExporter {
     private static final Logger LOG = LoggerFactory.getLogger(VoltageLevelDiagramDataExporter.class);

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/AbstractCouplingDeviceDiagramDataImporter.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/AbstractCouplingDeviceDiagramDataImporter.java
@@ -20,7 +20,7 @@ import com.powsybl.triplestore.api.PropertyBags;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public abstract class AbstractCouplingDeviceDiagramDataImporter {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/AbstractInjectionDiagramDataImporter.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/AbstractInjectionDiagramDataImporter.java
@@ -19,7 +19,7 @@ import com.powsybl.triplestore.api.PropertyBags;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public abstract class AbstractInjectionDiagramDataImporter {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/BusDiagramDataImporter.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/BusDiagramDataImporter.java
@@ -22,7 +22,7 @@ import com.powsybl.triplestore.api.PropertyBag;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class BusDiagramDataImporter {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/BusbarDiagramDataImporter.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/BusbarDiagramDataImporter.java
@@ -21,7 +21,7 @@ import com.powsybl.triplestore.api.PropertyBag;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class BusbarDiagramDataImporter {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/GeneratorDiagramDataImporter.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/GeneratorDiagramDataImporter.java
@@ -23,7 +23,7 @@ import com.powsybl.triplestore.api.PropertyBags;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class GeneratorDiagramDataImporter extends AbstractInjectionDiagramDataImporter {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/HvdcLineDiagramDataImporter.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/HvdcLineDiagramDataImporter.java
@@ -21,7 +21,7 @@ import com.powsybl.triplestore.api.PropertyBag;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class HvdcLineDiagramDataImporter {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/LineDiagramDataImporter.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/LineDiagramDataImporter.java
@@ -23,7 +23,7 @@ import com.powsybl.triplestore.api.PropertyBag;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class LineDiagramDataImporter {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/LoadDiagramDataImporter.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/LoadDiagramDataImporter.java
@@ -23,7 +23,7 @@ import com.powsybl.triplestore.api.PropertyBags;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class LoadDiagramDataImporter extends AbstractInjectionDiagramDataImporter {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/ShuntDiagramDataImporter.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/ShuntDiagramDataImporter.java
@@ -23,7 +23,7 @@ import com.powsybl.triplestore.api.PropertyBags;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class ShuntDiagramDataImporter extends AbstractInjectionDiagramDataImporter {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/SvcDiagramDataImporter.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/SvcDiagramDataImporter.java
@@ -23,7 +23,7 @@ import com.powsybl.triplestore.api.PropertyBags;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class SvcDiagramDataImporter extends AbstractInjectionDiagramDataImporter {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/SwitchDiagramDataImporter.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/SwitchDiagramDataImporter.java
@@ -23,7 +23,7 @@ import com.powsybl.triplestore.api.PropertyBag;
 import com.powsybl.triplestore.api.PropertyBags;
 
 /**
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class SwitchDiagramDataImporter extends AbstractCouplingDeviceDiagramDataImporter {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/TransformerDiagramDataImporter.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/TransformerDiagramDataImporter.java
@@ -27,7 +27,7 @@ import com.powsybl.triplestore.api.PropertyBags;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class TransformerDiagramDataImporter extends AbstractCouplingDeviceDiagramDataImporter {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/VoltageLevelDiagramDataImporter.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/VoltageLevelDiagramDataImporter.java
@@ -19,7 +19,7 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * @author Christian Biasuzzi <christian.biasuzzi@techrain.eu>
+ * @author Christian Biasuzzi {@literal <christian.biasuzzi@techrain.eu>}
  */
 public class VoltageLevelDiagramDataImporter {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/AbstractCgmesDLExporterTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/AbstractCgmesDLExporterTest.java
@@ -28,7 +28,7 @@ import com.powsybl.triplestore.api.TripleStore;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public abstract class AbstractCgmesDLExporterTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/AbstractCgmesDLTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/AbstractCgmesDLTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.BeforeEach;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 abstract class AbstractCgmesDLTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/CgmesDLImportPostProcessorTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/CgmesDLImportPostProcessorTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 class CgmesDLImportPostProcessorTest extends CgmesDLModelTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/CgmesDLImporterTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/CgmesDLImporterTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 class CgmesDLImporterTest extends AbstractCgmesDLTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/CgmesDLModelTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/CgmesDLModelTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 class CgmesDLModelTest extends AbstractCgmesDLTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/exporters/AbstractCouplingDeviceDiagramDataExporterTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/exporters/AbstractCouplingDeviceDiagramDataExporterTest.java
@@ -17,7 +17,7 @@ import com.powsybl.triplestore.api.PropertyBags;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 abstract class AbstractCouplingDeviceDiagramDataExporterTest extends AbstractCgmesDLExporterTest {
     protected final DiagramPoint point = new DiagramPoint(20, 10, 0);

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/exporters/AbstractInjectionDiagramDataExporterTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/exporters/AbstractInjectionDiagramDataExporterTest.java
@@ -17,7 +17,7 @@ import com.powsybl.triplestore.api.PropertyBags;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 abstract class AbstractInjectionDiagramDataExporterTest extends AbstractCgmesDLExporterTest {
     protected final DiagramPoint point = new DiagramPoint(20, 10, 0);

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/exporters/AbstractNodeLineDiagramDataExporterTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/exporters/AbstractNodeLineDiagramDataExporterTest.java
@@ -15,7 +15,7 @@ import com.powsybl.triplestore.api.PropertyBags;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 abstract class AbstractNodeLineDiagramDataExporterTest extends AbstractCgmesDLExporterTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/exporters/AbstractVoltageLevelDiagramDataExporterTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/exporters/AbstractVoltageLevelDiagramDataExporterTest.java
@@ -14,7 +14,7 @@ import org.mockito.Mockito;
 
 /**
  *
- * @author Christian Biasuzzi <christian.biasuzzi@techrain.eu>
+ * @author Christian Biasuzzi {@literal <christian.biasuzzi@techrain.eu>}
  */
 abstract class AbstractVoltageLevelDiagramDataExporterTest extends AbstractCgmesDLExporterTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/exporters/BusDiagramDataExporterTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/exporters/BusDiagramDataExporterTest.java
@@ -17,7 +17,7 @@ import com.powsybl.triplestore.api.PropertyBags;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 class BusDiagramDataExporterTest extends AbstractNodeLineDiagramDataExporterTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/exporters/BusbarDiagramDataExporterTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/exporters/BusbarDiagramDataExporterTest.java
@@ -21,7 +21,7 @@ import com.powsybl.triplestore.api.PropertyBags;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 class BusbarDiagramDataExporterTest extends AbstractNodeLineDiagramDataExporterTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/exporters/DanglingLineDiagramDataExporterTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/exporters/DanglingLineDiagramDataExporterTest.java
@@ -17,7 +17,7 @@ import com.powsybl.triplestore.api.PropertyBags;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 class DanglingLineDiagramDataExporterTest extends AbstractNodeLineDiagramDataExporterTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/exporters/GeneratorDiagramDataExporterTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/exporters/GeneratorDiagramDataExporterTest.java
@@ -16,7 +16,7 @@ import com.powsybl.iidm.network.Generator;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 class GeneratorDiagramDataExporterTest extends AbstractInjectionDiagramDataExporterTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/exporters/HvdcLineDiagramDataExporterTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/exporters/HvdcLineDiagramDataExporterTest.java
@@ -17,7 +17,7 @@ import com.powsybl.triplestore.api.PropertyBags;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 class HvdcLineDiagramDataExporterTest extends AbstractNodeLineDiagramDataExporterTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/exporters/LineDiagramDataExporterTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/exporters/LineDiagramDataExporterTest.java
@@ -17,7 +17,7 @@ import com.powsybl.triplestore.api.PropertyBags;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 class LineDiagramDataExporterTest extends AbstractNodeLineDiagramDataExporterTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/exporters/LoadDiagramDataExporterTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/exporters/LoadDiagramDataExporterTest.java
@@ -16,7 +16,7 @@ import com.powsybl.iidm.network.Load;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 class LoadDiagramDataExporterTest extends AbstractInjectionDiagramDataExporterTest {
     private Load load;

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/exporters/ShuntDiagramDataExporterTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/exporters/ShuntDiagramDataExporterTest.java
@@ -16,7 +16,7 @@ import com.powsybl.iidm.network.ShuntCompensator;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 class ShuntDiagramDataExporterTest extends AbstractInjectionDiagramDataExporterTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/exporters/SvcDiagramDataExporterTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/exporters/SvcDiagramDataExporterTest.java
@@ -16,7 +16,7 @@ import com.powsybl.iidm.network.StaticVarCompensator;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 class SvcDiagramDataExporterTest extends AbstractInjectionDiagramDataExporterTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/exporters/SwitchDiagramDataExporterTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/exporters/SwitchDiagramDataExporterTest.java
@@ -17,7 +17,7 @@ import com.powsybl.iidm.network.Switch;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 class SwitchDiagramDataExporterTest extends AbstractCouplingDeviceDiagramDataExporterTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/exporters/Transformer3WDiagramDataExporterTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/exporters/Transformer3WDiagramDataExporterTest.java
@@ -22,7 +22,7 @@ import com.powsybl.triplestore.api.PropertyBags;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 class Transformer3WDiagramDataExporterTest extends AbstractCgmesDLExporterTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/exporters/TransformerDiagramDataExporterTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/exporters/TransformerDiagramDataExporterTest.java
@@ -17,7 +17,7 @@ import com.powsybl.iidm.network.TwoWindingsTransformer;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 class TransformerDiagramDataExporterTest extends AbstractCouplingDeviceDiagramDataExporterTest {
     private TwoWindingsTransformer twt;

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/exporters/VoltageLevelDiagramDataExporterTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/exporters/VoltageLevelDiagramDataExporterTest.java
@@ -22,7 +22,7 @@ import java.util.stream.Stream;
 
 /**
  *
- * @author Christian Biasuzzi <christian.biasuzzi@techrain.eu>
+ * @author Christian Biasuzzi {@literal <christian.biasuzzi@techrain.eu>}
  */
 class VoltageLevelDiagramDataExporterTest extends AbstractVoltageLevelDiagramDataExporterTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/main/java/com/powsybl/sld/cgmes/dl/iidm/extensions/CouplingDeviceDiagramData.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/main/java/com/powsybl/sld/cgmes/dl/iidm/extensions/CouplingDeviceDiagramData.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class CouplingDeviceDiagramData<T extends Identifiable<T>> extends AbstractExtension<T> {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/main/java/com/powsybl/sld/cgmes/dl/iidm/extensions/DiagramPoint.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/main/java/com/powsybl/sld/cgmes/dl/iidm/extensions/DiagramPoint.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class DiagramPoint implements Comparable<DiagramPoint> {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/main/java/com/powsybl/sld/cgmes/dl/iidm/extensions/DiagramTerminal.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/main/java/com/powsybl/sld/cgmes/dl/iidm/extensions/DiagramTerminal.java
@@ -8,7 +8,7 @@ package com.powsybl.sld.cgmes.dl.iidm.extensions;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public enum DiagramTerminal {
     TERMINAL1,

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/main/java/com/powsybl/sld/cgmes/dl/iidm/extensions/InjectionDiagramData.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/main/java/com/powsybl/sld/cgmes/dl/iidm/extensions/InjectionDiagramData.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class InjectionDiagramData<T extends Injection<T>> extends AbstractExtension<T> {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/main/java/com/powsybl/sld/cgmes/dl/iidm/extensions/LineDiagramData.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/main/java/com/powsybl/sld/cgmes/dl/iidm/extensions/LineDiagramData.java
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class LineDiagramData<T extends Identifiable<T>> extends AbstractExtension<T> {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/main/java/com/powsybl/sld/cgmes/dl/iidm/extensions/NetworkDiagramData.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/main/java/com/powsybl/sld/cgmes/dl/iidm/extensions/NetworkDiagramData.java
@@ -19,7 +19,7 @@ import com.powsybl.iidm.network.Network;
 
 /**
  *
- * @author Christian Biasuzzi <christian.biasuzzi@techrain.eu>
+ * @author Christian Biasuzzi {@literal <christian.biasuzzi@techrain.eu>}
  */
 public final class NetworkDiagramData extends AbstractExtension<Network> {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/main/java/com/powsybl/sld/cgmes/dl/iidm/extensions/NodeDiagramData.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/main/java/com/powsybl/sld/cgmes/dl/iidm/extensions/NodeDiagramData.java
@@ -15,7 +15,7 @@ import java.util.*;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class NodeDiagramData<T extends Identifiable<T>> extends AbstractExtension<T> {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/main/java/com/powsybl/sld/cgmes/dl/iidm/extensions/ThreeWindingsTransformerDiagramData.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/main/java/com/powsybl/sld/cgmes/dl/iidm/extensions/ThreeWindingsTransformerDiagramData.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class ThreeWindingsTransformerDiagramData extends AbstractExtension<ThreeWindingsTransformer> {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/main/java/com/powsybl/sld/cgmes/dl/iidm/extensions/VoltageLevelDiagramData.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/main/java/com/powsybl/sld/cgmes/dl/iidm/extensions/VoltageLevelDiagramData.java
@@ -13,7 +13,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import java.util.*;
 
 /**
- * @author Christian Biasuzzi <christian.biasuzzi@techrain.eu>
+ * @author Christian Biasuzzi {@literal <christian.biasuzzi@techrain.eu>}
  */
 public final class VoltageLevelDiagramData extends AbstractExtension<VoltageLevel> {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/AbstractCouplingDeviceDiagramDataTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/AbstractCouplingDeviceDiagramDataTest.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 abstract class AbstractCouplingDeviceDiagramDataTest {
     protected static String DIAGRAM_NAME = "default";

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/AbstractInjectionDiagramDataTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/AbstractInjectionDiagramDataTest.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 abstract class AbstractInjectionDiagramDataTest {
     protected static String DIAGRAM_NAME = "default";

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/AbstractLineDiagramDataTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/AbstractLineDiagramDataTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 abstract class AbstractLineDiagramDataTest {
     protected static final String DIAGRAM_NAME = "default";

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/AbstractNodeDiagramDataTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/AbstractNodeDiagramDataTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 abstract class AbstractNodeDiagramDataTest {
     protected static String DIAGRAM_NAME = "default";

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/BusDiagramDataTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/BusDiagramDataTest.java
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 class BusDiagramDataTest extends AbstractNodeDiagramDataTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/BusbarDiagramDataTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/BusbarDiagramDataTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 class BusbarDiagramDataTest extends AbstractNodeDiagramDataTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/DanglingLineDiagramDataTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/DanglingLineDiagramDataTest.java
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 class DanglingLineDiagramDataTest extends AbstractLineDiagramDataTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/GeneratorDiagramDataTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/GeneratorDiagramDataTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 class GeneratorDiagramDataTest extends AbstractInjectionDiagramDataTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/HvdcLineDiagramDataTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/HvdcLineDiagramDataTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 class HvdcLineDiagramDataTest extends AbstractLineDiagramDataTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/LineDiagramDataTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/LineDiagramDataTest.java
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 class LineDiagramDataTest extends AbstractLineDiagramDataTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/LoadDiagramDataTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/LoadDiagramDataTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 class LoadDiagramDataTest extends AbstractInjectionDiagramDataTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/NetworkDiagramDataTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/NetworkDiagramDataTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *
- * @author Christian Biasuzzi <christian.biasuzzi@techrain.eu>
+ * @author Christian Biasuzzi {@literal <christian.biasuzzi@techrain.eu>}
  */
 class NetworkDiagramDataTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/ShuntDiagramDataTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/ShuntDiagramDataTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 class ShuntDiagramDataTest extends AbstractInjectionDiagramDataTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/StaticVarCompensatorDiagramDataTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/StaticVarCompensatorDiagramDataTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 class StaticVarCompensatorDiagramDataTest extends AbstractInjectionDiagramDataTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/SwitchDiagramDataTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/SwitchDiagramDataTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 class SwitchDiagramDataTest extends AbstractCouplingDeviceDiagramDataTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/ThreeWindingsTransformerDiagramDataTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/ThreeWindingsTransformerDiagramDataTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 class ThreeWindingsTransformerDiagramDataTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/TransformerDiagramDataTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/TransformerDiagramDataTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 class TransformerDiagramDataTest extends AbstractCouplingDeviceDiagramDataTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/VoltageLevelDiagramDataTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-iidm-extensions/src/test/java/com/powsybl/sld/cgmes/dl/iidm/extensions/VoltageLevelDiagramDataTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *
- * @author Christian Biasuzzi <christian.biasuzzi@techrain.eu>
+ * @author Christian Biasuzzi {@literal <christian.biasuzzi@techrain.eu>}
  */
 class VoltageLevelDiagramDataTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/main/java/com/powsybl/sld/cgmes/layout/AbstractCgmesLayout.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/main/java/com/powsybl/sld/cgmes/layout/AbstractCgmesLayout.java
@@ -25,8 +25,8 @@ import static com.powsybl.sld.library.ComponentTypeName.*;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
- * @author Franck Lecuyer <franck.lecuyer@rte-france.com>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer@rte-france.com>}
  */
 public abstract class AbstractCgmesLayout implements Layout {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/main/java/com/powsybl/sld/cgmes/layout/CgmesSubstationLayout.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/main/java/com/powsybl/sld/cgmes/layout/CgmesSubstationLayout.java
@@ -22,8 +22,8 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public class CgmesSubstationLayout extends AbstractCgmesLayout {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/main/java/com/powsybl/sld/cgmes/layout/CgmesSubstationLayoutFactory.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/main/java/com/powsybl/sld/cgmes/layout/CgmesSubstationLayoutFactory.java
@@ -16,7 +16,7 @@ import java.util.Objects;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class CgmesSubstationLayoutFactory implements SubstationLayoutFactory {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/main/java/com/powsybl/sld/cgmes/layout/CgmesVoltageLevelLayout.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/main/java/com/powsybl/sld/cgmes/layout/CgmesVoltageLevelLayout.java
@@ -18,7 +18,7 @@ import java.util.Objects;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class CgmesVoltageLevelLayout extends AbstractCgmesLayout {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/main/java/com/powsybl/sld/cgmes/layout/CgmesVoltageLevelLayoutFactory.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/main/java/com/powsybl/sld/cgmes/layout/CgmesVoltageLevelLayoutFactory.java
@@ -15,7 +15,7 @@ import java.util.Objects;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class CgmesVoltageLevelLayoutFactory implements VoltageLevelLayoutFactory {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/main/java/com/powsybl/sld/cgmes/layout/CgmesVoltageLevelLayoutFactorySmartSelector.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/main/java/com/powsybl/sld/cgmes/layout/CgmesVoltageLevelLayoutFactorySmartSelector.java
@@ -18,7 +18,7 @@ import com.powsybl.sld.layout.VoltageLevelLayoutFactory;
 import com.powsybl.sld.layout.VoltageLevelLayoutFactorySmartSelector;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @AutoService(VoltageLevelLayoutFactorySmartSelector.class)
 public class CgmesVoltageLevelLayoutFactorySmartSelector implements VoltageLevelLayoutFactorySmartSelector {

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/main/java/com/powsybl/sld/cgmes/layout/CgmesZoneLayout.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/main/java/com/powsybl/sld/cgmes/layout/CgmesZoneLayout.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class CgmesZoneLayout extends AbstractCgmesLayout {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/main/java/com/powsybl/sld/cgmes/layout/CgmesZoneLayoutFactory.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/main/java/com/powsybl/sld/cgmes/layout/CgmesZoneLayoutFactory.java
@@ -16,7 +16,7 @@ import com.powsybl.sld.model.graphs.ZoneGraph;
 import java.util.Objects;
 
 /**
- * @author Christian Biasuzzi <christian.biasuzzi@techrain.eu>
+ * @author Christian Biasuzzi {@literal <christian.biasuzzi@techrain.eu>}
  */
 public class CgmesZoneLayoutFactory implements ZoneLayoutFactory {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/main/java/com/powsybl/sld/cgmes/layout/LayoutToCgmesDlExporterTool.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/main/java/com/powsybl/sld/cgmes/layout/LayoutToCgmesDlExporterTool.java
@@ -34,7 +34,7 @@ import static com.powsybl.sld.AbstractSingleLineDiagramCommand.INPUT_FILE;
 import static com.powsybl.sld.AbstractSingleLineDiagramCommand.OUTPUT_DIR;
 
 /**
- * @author Christian Biasuzzi <christian.biasuzzi@techrain.eu>
+ * @author Christian Biasuzzi {@literal <christian.biasuzzi@techrain.eu>}
  */
 @AutoService(Tool.class)
 public class LayoutToCgmesDlExporterTool implements Tool {

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/main/java/com/powsybl/sld/cgmes/layout/LayoutToCgmesExtensionsConverter.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/main/java/com/powsybl/sld/cgmes/layout/LayoutToCgmesExtensionsConverter.java
@@ -28,8 +28,8 @@ import java.util.stream.Stream;
 import static com.powsybl.sld.library.ComponentTypeName.*;
 
 /**
- * @author Christian Biasuzzi <christian.biasuzzi@techrain.eu>
- * @author Franck Lecuyer <franck.lecuyer@rte-france.com>
+ * @author Christian Biasuzzi {@literal <christian.biasuzzi@techrain.eu>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer@rte-france.com>}
  */
 public class LayoutToCgmesExtensionsConverter {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/test/java/com/powsybl/sld/cgmes/layout/AbstractCgmesVoltageLevelLayoutTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/test/java/com/powsybl/sld/cgmes/layout/AbstractCgmesVoltageLevelLayoutTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 abstract class AbstractCgmesVoltageLevelLayoutTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/test/java/com/powsybl/sld/cgmes/layout/AbstractNodeTopologyTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/test/java/com/powsybl/sld/cgmes/layout/AbstractNodeTopologyTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 abstract class AbstractNodeTopologyTest extends AbstractCgmesVoltageLevelLayoutTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/test/java/com/powsybl/sld/cgmes/layout/BusTopologyTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/test/java/com/powsybl/sld/cgmes/layout/BusTopologyTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 class BusTopologyTest extends AbstractCgmesVoltageLevelLayoutTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/test/java/com/powsybl/sld/cgmes/layout/CgmesZoneLayoutTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/test/java/com/powsybl/sld/cgmes/layout/CgmesZoneLayoutTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 class CgmesZoneLayoutTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/test/java/com/powsybl/sld/cgmes/layout/DoubleBusbarSectionTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/test/java/com/powsybl/sld/cgmes/layout/DoubleBusbarSectionTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Christian Biasuzzi <christian.biasuzzi@techrain.eu>
+ * @author Christian Biasuzzi {@literal <christian.biasuzzi@techrain.eu>}
  */
 class DoubleBusbarSectionTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/test/java/com/powsybl/sld/cgmes/layout/LayoutToCgmesDlExporterToolTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/test/java/com/powsybl/sld/cgmes/layout/LayoutToCgmesDlExporterToolTest.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 class LayoutToCgmesDlExporterToolTest extends AbstractToolTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/test/java/com/powsybl/sld/cgmes/layout/LayoutToCgmesExtensionsTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/test/java/com/powsybl/sld/cgmes/layout/LayoutToCgmesExtensionsTest.java
@@ -22,7 +22,7 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Christian Biasuzzi <christian.biasuzzi@techrain.eu>
+ * @author Christian Biasuzzi {@literal <christian.biasuzzi@techrain.eu>}
  */
 class LayoutToCgmesExtensionsTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/test/java/com/powsybl/sld/cgmes/layout/NodeTopologyHorizontalBusbarTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/test/java/com/powsybl/sld/cgmes/layout/NodeTopologyHorizontalBusbarTest.java
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 class NodeTopologyHorizontalBusbarTest extends AbstractNodeTopologyTest {
 

--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/test/java/com/powsybl/sld/cgmes/layout/NodeTopologyVerticalBusbarTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/test/java/com/powsybl/sld/cgmes/layout/NodeTopologyVerticalBusbarTest.java
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 class NodeTopologyVerticalBusbarTest extends AbstractNodeTopologyTest {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/AbstractSingleLineDiagramCommand.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/AbstractSingleLineDiagramCommand.java
@@ -11,7 +11,7 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractSingleLineDiagramCommand implements Command {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/SingleLineDiagram.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/SingleLineDiagram.java
@@ -36,7 +36,7 @@ import static com.powsybl.iidm.network.IdentifiableType.SUBSTATION;
 import static com.powsybl.iidm.network.IdentifiableType.VOLTAGE_LEVEL;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public final class SingleLineDiagram {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/SingleLineDiagramTool.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/SingleLineDiagramTool.java
@@ -31,7 +31,7 @@ import static com.powsybl.sld.AbstractSingleLineDiagramCommand.INPUT_FILE;
 import static com.powsybl.sld.AbstractSingleLineDiagramCommand.OUTPUT_DIR;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @AutoService(Tool.class)
 public class SingleLineDiagramTool implements Tool {

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/SldParameters.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/SldParameters.java
@@ -22,7 +22,7 @@ import java.util.Objects;
 
 /**
  *
- * @author Sophie Frasnedo <sophie.frasnedo at rte-france.com>
+ * @author Sophie Frasnedo {@literal <sophie.frasnedo at rte-france.com>}
  */
 public class SldParameters {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/builders/AbstractRawBuilder.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/builders/AbstractRawBuilder.java
@@ -22,7 +22,7 @@ import java.util.stream.*;
 import static com.powsybl.sld.model.nodes.NodeSide.*;
 
 /**
- * @author Thomas Adam <tadam at neverhack.com>
+ * @author Thomas Adam {@literal <tadam at neverhack.com>}
  */
 public abstract class AbstractRawBuilder implements BaseRawBuilder {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/builders/BaseRawBuilder.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/builders/BaseRawBuilder.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * @author Thomas Adam <tadam at neverhack.com>
+ * @author Thomas Adam {@literal <tadam at neverhack.com>}
  */
 public interface BaseRawBuilder {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/builders/GraphBuilder.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/builders/GraphBuilder.java
@@ -11,7 +11,7 @@ import java.util.List;
 import com.powsybl.sld.model.graphs.*;
 
 /**
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public interface GraphBuilder {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/builders/NetworkGraphBuilder.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/builders/NetworkGraphBuilder.java
@@ -27,8 +27,8 @@ import static com.powsybl.sld.model.coordinate.Direction.TOP;
 import static com.powsybl.sld.model.coordinate.Direction.UNDEFINED;
 
 /**
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
- * @author Slimane Amar <slimane.amar at rte-france.com>
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
+ * @author Slimane Amar {@literal <slimane.amar at rte-france.com>}
  */
 public class NetworkGraphBuilder implements GraphBuilder {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/builders/RawGraphBuilder.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/builders/RawGraphBuilder.java
@@ -11,7 +11,7 @@ import com.powsybl.sld.model.graphs.*;
 import java.util.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 
 public class RawGraphBuilder implements GraphBuilder {

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/builders/SubstationRawBuilder.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/builders/SubstationRawBuilder.java
@@ -23,8 +23,8 @@ import java.util.stream.Stream;
 
 /**
  *
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
- * @author Benoit Jeanson <Benoit.Jeanson at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
+ * @author Benoit Jeanson {@literal <Benoit.Jeanson at rte-france.com>}
  */
 
 public class SubstationRawBuilder extends AbstractRawBuilder {

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/builders/VoltageLevelRawBuilder.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/builders/VoltageLevelRawBuilder.java
@@ -16,8 +16,8 @@ import java.util.function.Function;
 
 /**
  *
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
- * @author Benoit Jeanson <Benoit.Jeanson at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
+ * @author Benoit Jeanson {@literal <Benoit.Jeanson at rte-france.com>}
  */
 public class VoltageLevelRawBuilder {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/AbstractBaseLayout.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/AbstractBaseLayout.java
@@ -18,7 +18,7 @@ import static com.powsybl.sld.model.coordinate.Direction.BOTTOM;
 import static com.powsybl.sld.model.coordinate.Direction.TOP;
 
 /**
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 public abstract class AbstractBaseLayout<T extends AbstractBaseGraph> extends AbstractLayout<T> {
     protected AbstractBaseLayout(T graph) {

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/AbstractLayout.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/AbstractLayout.java
@@ -19,8 +19,8 @@ import java.util.*;
 import java.util.function.BooleanSupplier;
 
 /**
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
- * @author Slimane Amar <slimane.amar at rte-france.com>
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
+ * @author Slimane Amar {@literal <slimane.amar at rte-france.com>}
  */
 public abstract class AbstractLayout<T extends AbstractBaseGraph> implements Layout {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/AbstractPositionFinder.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/AbstractPositionFinder.java
@@ -15,8 +15,8 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractPositionFinder implements PositionFinder {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/AbstractSubstationLayout.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/AbstractSubstationLayout.java
@@ -11,8 +11,8 @@ import com.powsybl.sld.model.graphs.*;
 import java.util.Objects;
 
 /**
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public abstract class AbstractSubstationLayout extends AbstractBaseLayout<SubstationGraph> {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/AbstractVoltageLevelLayout.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/AbstractVoltageLevelLayout.java
@@ -14,7 +14,7 @@ import org.jgrapht.alg.util.Pair;
 import java.util.List;
 
 /**
- * @author Slimane Amar <slimane.amar at rte-france.com>
+ * @author Slimane Amar {@literal <slimane.amar at rte-france.com>}
  */
 public abstract class AbstractVoltageLevelLayout extends AbstractLayout<VoltageLevelGraph> {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/AbstractZoneLayout.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/AbstractZoneLayout.java
@@ -14,7 +14,7 @@ import com.powsybl.sld.model.graphs.ZoneGraph;
 import java.util.Objects;
 
 /**
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 public abstract class AbstractZoneLayout extends AbstractBaseLayout<ZoneGraph> {
     protected SubstationLayoutFactory sLayoutFactory;

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/BlockOrganizer.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/BlockOrganizer.java
@@ -30,9 +30,9 @@ import static com.powsybl.sld.model.cells.Cell.CellType.INTERN;
 import static com.powsybl.sld.model.nodes.Node.NodeType.*;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class BlockOrganizer {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/BlockPositionner.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/BlockPositionner.java
@@ -20,7 +20,7 @@ import static com.powsybl.sld.model.coordinate.Position.Dimension.H;
 import static com.powsybl.sld.model.coordinate.Position.Dimension.V;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 class BlockPositionner {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/CalculateCellHeightBlockVisitor.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/CalculateCellHeightBlockVisitor.java
@@ -17,7 +17,7 @@ import com.powsybl.sld.model.nodes.Node;
 import static com.powsybl.sld.model.nodes.Node.NodeType.*;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 
 public final class CalculateCellHeightBlockVisitor implements BlockVisitor {

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/CalculateCoordBlockVisitor.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/CalculateCoordBlockVisitor.java
@@ -16,7 +16,7 @@ import static com.powsybl.sld.model.coordinate.Position.Dimension.*;
 import static com.powsybl.sld.model.coordinate.Coord.Dimension.*;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 public final class CalculateCoordBlockVisitor implements BlockVisitor {
     private final LayoutParameters layoutParameters;

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/CalculateCoordCellVisitor.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/CalculateCoordCellVisitor.java
@@ -20,7 +20,7 @@ import static com.powsybl.sld.model.coordinate.Coord.Dimension.*;
 import static com.powsybl.sld.model.blocks.Block.Extremity.*;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 public final class CalculateCoordCellVisitor implements CellVisitor {
     private final LayoutParameters layoutParameters;

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/CellBlockDecomposer.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/CellBlockDecomposer.java
@@ -23,9 +23,9 @@ import java.util.stream.Collectors;
 /**
  * Contain function to dispose components of cells based on Hierarchical Layout
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 final class CellBlockDecomposer {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/CellDetector.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/CellDetector.java
@@ -12,9 +12,9 @@ import com.powsybl.sld.model.graphs.VoltageLevelGraph;
  * this interface is implemented by classes determining the cells.
  * The expected result of CellDector is the creation and association of cell
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface CellDetector {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/GraphRefiner.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/GraphRefiner.java
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
  * Refines the graph so that it becomes consistent with the diagram layout.
  * In particular for cell detection: it inserts the {@link BusConnection} nodes and {@link InternalNode} hook nodes needed for it.
  *
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class GraphRefiner {
     private final boolean removeUnnecessaryFictitiousNodes;

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/GraphTraversal.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/GraphTraversal.java
@@ -15,7 +15,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 public final class GraphTraversal {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/HorizontalBusLane.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/HorizontalBusLane.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
  * LegBusSet in the cluster). Therefore startingIndex + length - 1 = the last position occupied by the HorizontalBusLane in
  * the LBSCluster.
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 public class HorizontalBusLane {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/HorizontalBusLaneManager.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/HorizontalBusLaneManager.java
@@ -7,7 +7,7 @@
 package com.powsybl.sld.layout;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 
 public interface HorizontalBusLaneManager {

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/HorizontalSubstationLayout.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/HorizontalSubstationLayout.java
@@ -17,8 +17,8 @@ import static com.powsybl.sld.model.coordinate.Direction.*;
 import java.util.List;
 
 /**
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
- * @author Slimane Amar <slimane.amar at rte-france.com>
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
+ * @author Slimane Amar {@literal <slimane.amar at rte-france.com>}
  */
 public class HorizontalSubstationLayout extends AbstractSubstationLayout {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/HorizontalSubstationLayoutFactory.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/HorizontalSubstationLayoutFactory.java
@@ -9,7 +9,7 @@ package com.powsybl.sld.layout;
 import com.powsybl.sld.model.graphs.SubstationGraph;
 
 /**
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public class HorizontalSubstationLayoutFactory implements SubstationLayoutFactory {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/HorizontalZoneLayout.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/HorizontalZoneLayout.java
@@ -20,7 +20,7 @@ import static com.powsybl.sld.model.coordinate.Direction.BOTTOM;
 import static com.powsybl.sld.model.coordinate.Direction.TOP;
 
 /**
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 public class HorizontalZoneLayout extends AbstractZoneLayout {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/HorizontalZoneLayoutFactory.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/HorizontalZoneLayoutFactory.java
@@ -10,7 +10,7 @@ package com.powsybl.sld.layout;
 import com.powsybl.sld.model.graphs.ZoneGraph;
 
 /**
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 public class HorizontalZoneLayoutFactory implements ZoneLayoutFactory {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/ImplicitCellDetector.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/ImplicitCellDetector.java
@@ -24,9 +24,9 @@ import static com.powsybl.sld.model.nodes.Node.NodeType.BUS;
 import static com.powsybl.sld.model.nodes.Node.NodeType.FEEDER;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class ImplicitCellDetector implements CellDetector {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/InfosNbSnakeLinesHorizontal.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/InfosNbSnakeLinesHorizontal.java
@@ -16,8 +16,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
- * @author Slimane Amar <slimane.amar at rte-france.com>
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
+ * @author Slimane Amar {@literal <slimane.amar at rte-france.com>}
  */
 public final class InfosNbSnakeLinesHorizontal {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/InfosNbSnakeLinesVertical.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/InfosNbSnakeLinesVertical.java
@@ -15,9 +15,9 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
- * @author Slimane Amar <slimane.amar at rte-france.com>
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
+ * @author Slimane Amar {@literal <slimane.amar at rte-france.com>}
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class InfosNbSnakeLinesVertical {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/InternCellSide.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/InternCellSide.java
@@ -10,7 +10,7 @@ import com.powsybl.sld.model.cells.InternCell;
 import com.powsybl.sld.model.coordinate.Side;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 public class InternCellSide {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LBSCluster.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LBSCluster.java
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
  * containing a single LBS.
  * LBSCluster handles the building of the horizontalBusLanes that are an horizontal strings of busNodes.
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 public class LBSCluster {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/Layout.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/Layout.java
@@ -7,7 +7,7 @@
 package com.powsybl.sld.layout;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public interface Layout {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LayoutContext.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LayoutContext.java
@@ -9,7 +9,7 @@ package com.powsybl.sld.layout;
 import com.powsybl.sld.model.coordinate.Direction;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 public final class LayoutContext {
     private final double firstBusY;

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LayoutParameters.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LayoutParameters.java
@@ -19,11 +19,11 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
- * @author Jacques Borsenberger <jacques.borsenberger at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
+ * @author Jacques Borsenberger {@literal <jacques.borsenberger at rte-france.com>}
  */
 public class LayoutParameters {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LegBusSet.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LegBusSet.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
  * connection included in the busNodeSet. It is embedded into a LBSCluster. It contains links to all the other
  * LegBusSet of the Graph.
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 public final class LegBusSet {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionByClusterVoltageLevelLayoutFactorySmartSelector.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionByClusterVoltageLevelLayoutFactorySmartSelector.java
@@ -12,7 +12,7 @@ import com.powsybl.iidm.network.VoltageLevel;
 import com.powsybl.sld.layout.positionbyclustering.PositionByClustering;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @AutoService(VoltageLevelLayoutFactorySmartSelector.class)
 public class PositionByClusterVoltageLevelLayoutFactorySmartSelector implements VoltageLevelLayoutFactorySmartSelector {

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionFinder.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionFinder.java
@@ -20,8 +20,8 @@ import java.util.Map;
  * <li>cell order and direction of each cell connected to Bus (ie all cells except Shunt ones)</li>
  * </ul>
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface PositionFinder {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionFromExtensionVoltageLevelLayoutFactorySmartSelector.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionFromExtensionVoltageLevelLayoutFactorySmartSelector.java
@@ -15,7 +15,7 @@ import com.powsybl.iidm.network.extensions.BusbarSectionPosition;
 import com.powsybl.iidm.network.extensions.ConnectablePosition;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @AutoService(VoltageLevelLayoutFactorySmartSelector.class)
 public class PositionFromExtensionVoltageLevelLayoutFactorySmartSelector implements VoltageLevelLayoutFactorySmartSelector {

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionVoltageLevelLayout.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionVoltageLevelLayout.java
@@ -23,10 +23,10 @@ import java.util.Map;
 import static com.powsybl.sld.model.coordinate.Position.Dimension.*;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public class PositionVoltageLevelLayout extends AbstractVoltageLevelLayout {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionVoltageLevelLayoutFactory.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionVoltageLevelLayoutFactory.java
@@ -15,9 +15,9 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class PositionVoltageLevelLayoutFactory implements VoltageLevelLayoutFactory {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/RandomVoltageLevelLayout.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/RandomVoltageLevelLayout.java
@@ -14,9 +14,9 @@ import java.util.Objects;
 import java.util.Random;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class RandomVoltageLevelLayout extends AbstractVoltageLevelLayout {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/RandomVoltageLevelLayoutFactory.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/RandomVoltageLevelLayoutFactory.java
@@ -11,9 +11,9 @@ import com.powsybl.sld.model.graphs.VoltageLevelGraph;
 import java.util.Random;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class RandomVoltageLevelLayoutFactory implements VoltageLevelLayoutFactory {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/SmartVoltageLevelLayoutFactory.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/SmartVoltageLevelLayoutFactory.java
@@ -13,7 +13,7 @@ import com.powsybl.sld.model.graphs.VoltageLevelGraph;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class SmartVoltageLevelLayoutFactory implements VoltageLevelLayoutFactory {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/Subsection.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/Subsection.java
@@ -21,7 +21,7 @@ import static com.powsybl.sld.model.coordinate.Side.LEFT;
 import static com.powsybl.sld.model.coordinate.Side.RIGHT;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 
 public class Subsection {

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/SubstationLayoutFactory.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/SubstationLayoutFactory.java
@@ -9,7 +9,7 @@ package com.powsybl.sld.layout;
 import com.powsybl.sld.model.graphs.SubstationGraph;
 
 /**
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public interface SubstationLayoutFactory {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/TopologicallyConnectedNodesSet.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/TopologicallyConnectedNodesSet.java
@@ -18,7 +18,7 @@ import java.util.Set;
  * The <code>borderNodes</code> holds the nodes that are at the border of this set, that is for which 1 adjacent node
  * (at least) is in the nodeSet, and for which 1 other adjacent node (at least) is not.
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 public class TopologicallyConnectedNodesSet {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/TopologyCalculation.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/TopologyCalculation.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 /**
  * Visit the graph to identifies the connected sets of nodes
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 public final class TopologyCalculation {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/VerticalSubstationLayout.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/VerticalSubstationLayout.java
@@ -18,7 +18,7 @@ import java.util.List;
 import static com.powsybl.sld.model.coordinate.Direction.*;
 
 /**
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public class VerticalSubstationLayout extends AbstractSubstationLayout {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/VerticalSubstationLayoutFactory.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/VerticalSubstationLayoutFactory.java
@@ -9,7 +9,7 @@ package com.powsybl.sld.layout;
 import com.powsybl.sld.model.graphs.SubstationGraph;
 
 /**
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public class VerticalSubstationLayoutFactory implements SubstationLayoutFactory {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/VerticalZoneLayout.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/VerticalZoneLayout.java
@@ -22,7 +22,7 @@ import static com.powsybl.sld.model.coordinate.Direction.BOTTOM;
 import static com.powsybl.sld.model.coordinate.Direction.TOP;
 
 /**
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 public class VerticalZoneLayout extends AbstractZoneLayout {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/VerticalZoneLayoutFactory.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/VerticalZoneLayoutFactory.java
@@ -10,7 +10,7 @@ package com.powsybl.sld.layout;
 import com.powsybl.sld.model.graphs.ZoneGraph;
 
 /**
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 public class VerticalZoneLayoutFactory implements ZoneLayoutFactory {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/VoltageLevelLayoutFactory.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/VoltageLevelLayoutFactory.java
@@ -9,9 +9,9 @@ package com.powsybl.sld.layout;
 import com.powsybl.sld.model.graphs.VoltageLevelGraph;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface VoltageLevelLayoutFactory {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/VoltageLevelLayoutFactoryCreator.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/VoltageLevelLayoutFactoryCreator.java
@@ -12,7 +12,7 @@ import com.powsybl.iidm.network.Network;
 
 /**
  *
- * @author Sophie Frasnedo <sophie.frasnedo at rte-france.com>
+ * @author Sophie Frasnedo {@literal <sophie.frasnedo at rte-france.com>}
  */
 
 @FunctionalInterface

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/VoltageLevelLayoutFactorySmartSelector.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/VoltageLevelLayoutFactorySmartSelector.java
@@ -18,7 +18,7 @@ import java.util.stream.StreamSupport;
 /**
  * {@link VoltageLevelLayoutFactory} smart selector.
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface VoltageLevelLayoutFactorySmartSelector {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/ZoneLayoutFactory.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/ZoneLayoutFactory.java
@@ -10,7 +10,7 @@ import com.powsybl.sld.model.graphs.ZoneGraph;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public interface ZoneLayoutFactory {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionbyclustering/HBLaneManagerByClustering.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionbyclustering/HBLaneManagerByClustering.java
@@ -17,7 +17,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 
 public class HBLaneManagerByClustering implements HorizontalBusLaneManager {

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionbyclustering/LBSClusterSide.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionbyclustering/LBSClusterSide.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 /**
  * LBSClusterSide is a ClusterConnector defined by one Side (LEFT/RIGHT) of a LBSCluster.
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 class LBSClusterSide {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionbyclustering/Link.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionbyclustering/Link.java
@@ -42,7 +42,7 @@ import java.util.stream.Collectors;
  * <p>
  * Sorting this way enables to foster merging of clusters according to the strength of the link.
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 
 class Link implements Comparable<Link> {

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionbyclustering/Links.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionbyclustering/Links.java
@@ -15,7 +15,7 @@ import java.util.*;
 /**
  * Manages the links between a list of lbsClusterSides.
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 final class Links {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionbyclustering/PositionByClustering.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionbyclustering/PositionByClustering.java
@@ -55,7 +55,7 @@ import static com.powsybl.sld.model.coordinate.Side.RIGHT;
  * </li>
  * </ul>
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 
 // WE ASSUME THAT IT IS POSSIBLE TO STACK ALL CELLS AND BE ABLE TO ORGANIZE THE VOLTAGELEVEL ACCORDINGLY

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionfromextension/HBLaneManagerByExtension.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionfromextension/HBLaneManagerByExtension.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Optional;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 
 public class HBLaneManagerByExtension implements HorizontalBusLaneManager {

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionfromextension/PositionFromExtension.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionfromextension/PositionFromExtension.java
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 import static com.powsybl.sld.model.cells.Cell.CellType.EXTERN;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 public class PositionFromExtension extends AbstractPositionFinder {
     private static final Logger LOGGER = LoggerFactory.getLogger(PositionFromExtension.class);

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/library/AnchorOrientation.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/library/AnchorOrientation.java
@@ -7,9 +7,9 @@
 package com.powsybl.sld.library;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public enum AnchorOrientation {
     VERTICAL,

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/library/AnchorPoint.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/library/AnchorPoint.java
@@ -14,11 +14,11 @@ import com.powsybl.sld.model.coordinate.Point;
 import java.util.Objects;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 public class AnchorPoint extends Point {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/library/Component.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/library/Component.java
@@ -14,11 +14,11 @@ import com.powsybl.sld.model.coordinate.Orientation;
 import java.util.*;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
- * @author Thomas Adam <tadam at silicom>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
+ * @author Thomas Adam {@literal <tadam at silicom>}
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class Component {

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/library/ComponentLibrary.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/library/ComponentLibrary.java
@@ -14,10 +14,10 @@ import java.net.URL;
 import java.util.*;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public interface ComponentLibrary {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/library/ComponentSize.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/library/ComponentSize.java
@@ -10,9 +10,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class ComponentSize {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/library/ComponentTypeName.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/library/ComponentTypeName.java
@@ -7,7 +7,7 @@
 package com.powsybl.sld.library;
 
 /**
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public final class ComponentTypeName {
     public static final String ARROW_ACTIVE = "ARROW_ACTIVE";

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/library/Components.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/library/Components.java
@@ -15,10 +15,10 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 public class Components {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/library/ConvergenceComponentLibrary.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/library/ConvergenceComponentLibrary.java
@@ -9,7 +9,7 @@ package com.powsybl.sld.library;
 import com.google.auto.service.AutoService;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @AutoService(ComponentLibrary.class)
 public class ConvergenceComponentLibrary extends ResourcesComponentLibrary {

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/library/FlatDesignLibrary.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/library/FlatDesignLibrary.java
@@ -10,7 +10,7 @@ package com.powsybl.sld.library;
 import com.google.auto.service.AutoService;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 @AutoService(ComponentLibrary.class)
 public class FlatDesignLibrary extends ResourcesComponentLibrary {

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/library/ResourcesComponentLibrary.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/library/ResourcesComponentLibrary.java
@@ -27,10 +27,10 @@ import java.util.*;
 /**
  * Library of resources components, that is, the SVG image files representing the components, together with the styles
  * associated to each component
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public class ResourcesComponentLibrary implements ComponentLibrary {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/library/SubComponent.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/library/SubComponent.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 
 /**
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public class SubComponent {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/AbstractBlock.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/AbstractBlock.java
@@ -19,10 +19,10 @@ import static com.powsybl.sld.model.blocks.Block.Extremity.END;
 import static com.powsybl.sld.model.blocks.Block.Extremity.START;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public abstract class AbstractBlock implements Block {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/AbstractComposedBlock.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/AbstractComposedBlock.java
@@ -18,8 +18,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public abstract class AbstractComposedBlock extends AbstractBlock implements ComposedBlock {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/AbstractParallelBlock.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/AbstractParallelBlock.java
@@ -14,10 +14,10 @@ import java.util.List;
 import static com.powsybl.sld.model.blocks.Block.Extremity.*;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 abstract class AbstractParallelBlock extends AbstractComposedBlock {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/AbstractPrimaryBlock.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/AbstractPrimaryBlock.java
@@ -18,10 +18,10 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public abstract class AbstractPrimaryBlock extends AbstractBlock implements PrimaryBlock {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/Block.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/Block.java
@@ -17,10 +17,10 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public interface Block {
     enum Type {

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/BlockVisitor.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/BlockVisitor.java
@@ -7,7 +7,7 @@
 package com.powsybl.sld.model.blocks;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 
 public interface BlockVisitor {

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/BodyParallelBlock.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/BodyParallelBlock.java
@@ -13,9 +13,9 @@ import static com.powsybl.sld.model.blocks.Block.Type.BODYPARALLEL;
 import static com.powsybl.sld.model.coordinate.Position.Dimension.*;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class BodyParallelBlock extends AbstractParallelBlock {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/BodyPrimaryBlock.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/BodyPrimaryBlock.java
@@ -15,9 +15,9 @@ import static com.powsybl.sld.model.coordinate.Orientation.*;
 import static com.powsybl.sld.model.coordinate.Position.Dimension.*;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class BodyPrimaryBlock extends AbstractPrimaryBlock {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/ComposedBlock.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/ComposedBlock.java
@@ -9,9 +9,9 @@ package com.powsybl.sld.model.blocks;
 import java.util.List;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface ComposedBlock extends Block {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/FeederPrimaryBlock.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/FeederPrimaryBlock.java
@@ -19,7 +19,7 @@ import static com.powsybl.sld.model.coordinate.Position.Dimension.V;
 import static com.powsybl.sld.model.nodes.Node.NodeType.FEEDER;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public final class FeederPrimaryBlock extends AbstractPrimaryBlock {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/LegBlock.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/LegBlock.java
@@ -12,9 +12,9 @@ import com.powsybl.sld.model.nodes.BusNode;
 import com.powsybl.sld.model.nodes.Node;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface LegBlock extends Block {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/LegParallelBlock.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/LegParallelBlock.java
@@ -15,9 +15,9 @@ import java.util.stream.Collectors;
 import static com.powsybl.sld.model.coordinate.Position.Dimension.*;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LegParallelBlock extends AbstractParallelBlock implements LegBlock {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/LegPrimaryBlock.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/LegPrimaryBlock.java
@@ -22,9 +22,9 @@ import static com.powsybl.sld.model.coordinate.Position.Dimension.V;
 import static com.powsybl.sld.model.nodes.Node.NodeType.BUS;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class LegPrimaryBlock extends AbstractPrimaryBlock implements LegBlock {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/PrimaryBlock.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/PrimaryBlock.java
@@ -11,7 +11,7 @@ import java.util.List;
 import com.powsybl.sld.model.nodes.Node;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 public interface PrimaryBlock extends Block {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/SerialBlock.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/SerialBlock.java
@@ -19,10 +19,10 @@ import static com.powsybl.sld.model.coordinate.Position.Dimension.H;
 import static com.powsybl.sld.model.coordinate.Position.Dimension.V;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public class SerialBlock extends AbstractComposedBlock {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/UndefinedBlock.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/UndefinedBlock.java
@@ -14,8 +14,8 @@ import java.util.Objects;
  * A block group that cannot be correctly decomposed anymore.
  * All subBlocks are superposed.
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public class UndefinedBlock extends AbstractComposedBlock {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/cells/AbstractBusCell.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/cells/AbstractBusCell.java
@@ -20,10 +20,10 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public abstract class AbstractBusCell extends AbstractCell implements BusCell {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/cells/AbstractCell.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/cells/AbstractCell.java
@@ -18,10 +18,10 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 
 public abstract class AbstractCell implements Cell {

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/cells/BusCell.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/cells/BusCell.java
@@ -16,9 +16,9 @@ import com.powsybl.sld.model.nodes.Node;
 import java.util.*;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface BusCell extends Cell {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/cells/Cell.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/cells/Cell.java
@@ -15,10 +15,10 @@ import java.io.IOException;
 import java.util.*;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public interface Cell {
     enum CellType {

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/cells/CellVisitor.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/cells/CellVisitor.java
@@ -7,7 +7,7 @@
 package com.powsybl.sld.model.cells;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 
 public interface CellVisitor {

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/cells/ExternCell.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/cells/ExternCell.java
@@ -25,9 +25,9 @@ import static com.powsybl.sld.model.coordinate.Side.RIGHT;
 import static com.powsybl.sld.model.nodes.Node.NodeType.FEEDER;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class ExternCell extends AbstractBusCell {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/cells/InternCell.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/cells/InternCell.java
@@ -24,10 +24,10 @@ import static com.powsybl.sld.model.coordinate.Position.Dimension.H;
 import static com.powsybl.sld.model.coordinate.Position.Dimension.V;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public class InternCell extends AbstractBusCell {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/cells/ShuntCell.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/cells/ShuntCell.java
@@ -23,9 +23,9 @@ import java.util.stream.Collectors;
 import static com.powsybl.sld.model.coordinate.Position.Dimension.*;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class ShuntCell extends AbstractCell {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/coordinate/Coord.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/coordinate/Coord.java
@@ -20,9 +20,9 @@ import static com.powsybl.sld.model.coordinate.Coord.Dimension.*;
 /**
  * class use to store relatives coordinates of a nodeBus
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class Coord {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/coordinate/Direction.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/coordinate/Direction.java
@@ -8,7 +8,7 @@
 package com.powsybl.sld.model.coordinate;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 public enum Direction {
     TOP, BOTTOM, MIDDLE, UNDEFINED;

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/coordinate/Orientation.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/coordinate/Orientation.java
@@ -7,9 +7,9 @@
 package com.powsybl.sld.model.coordinate;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public enum Orientation {
     UP,

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/coordinate/Point.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/coordinate/Point.java
@@ -12,8 +12,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class Point {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/coordinate/Position.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/coordinate/Position.java
@@ -18,10 +18,10 @@ import java.util.stream.Stream;
 import static com.powsybl.sld.model.coordinate.Position.Dimension.*;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public class Position {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/coordinate/Side.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/coordinate/Side.java
@@ -7,9 +7,9 @@
 package com.powsybl.sld.model.coordinate;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public enum Side {
     UNDEFINED,

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/graphs/AbstractBaseGraph.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/graphs/AbstractBaseGraph.java
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * @author Slimane Amar <slimane.amar at rte-france.com>
+ * @author Slimane Amar {@literal <slimane.amar at rte-france.com>}
  */
 public abstract class AbstractBaseGraph extends AbstractGraph implements BaseGraph {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/graphs/AbstractGraph.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/graphs/AbstractGraph.java
@@ -24,7 +24,7 @@ import java.nio.file.Path;
 import java.util.*;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public abstract class AbstractGraph implements Graph {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/graphs/BaseGraph.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/graphs/BaseGraph.java
@@ -13,7 +13,7 @@ import com.powsybl.sld.model.nodes.FeederNode;
 import com.powsybl.sld.model.nodes.MiddleTwtNode;
 
 /**
- * @author Slimane Amar <slimane.amar at rte-france.com>
+ * @author Slimane Amar {@literal <slimane.amar at rte-france.com>}
  */
 public interface BaseGraph extends Graph {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/graphs/Graph.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/graphs/Graph.java
@@ -20,7 +20,7 @@ import com.powsybl.sld.model.cells.Cell;
 import com.powsybl.sld.model.coordinate.Direction;
 
 /**
- * @author Slimane Amar <slimane.amar at rte-france.com>
+ * @author Slimane Amar {@literal <slimane.amar at rte-france.com>}
  */
 public interface Graph {
     String getId();

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/graphs/NodeFactory.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/graphs/NodeFactory.java
@@ -21,7 +21,7 @@ import java.util.Objects;
 import static com.powsybl.sld.library.ComponentTypeName.*;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 
 public final class NodeFactory {

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/graphs/SubstationGraph.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/graphs/SubstationGraph.java
@@ -22,7 +22,7 @@ import java.util.stream.Stream;
  * This class builds the connectivity among the voltageLevels of a substation
  * buildSubstationGraph establishes the List of nodes, edges
  *
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public class SubstationGraph extends AbstractBaseGraph {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/graphs/VoltageLevelGraph.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/graphs/VoltageLevelGraph.java
@@ -33,10 +33,10 @@ import static com.powsybl.sld.model.coordinate.Position.Dimension.V;
  * buildGraphAndDetectCell establishes the List of nodes, edges and nodeBuses
  * cells is built by the PatternCellDetector Class
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public class VoltageLevelGraph extends AbstractBaseGraph {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/graphs/VoltageLevelInfos.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/graphs/VoltageLevelInfos.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class VoltageLevelInfos {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/graphs/ZoneGraph.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/graphs/ZoneGraph.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 public class ZoneGraph extends AbstractBaseGraph {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/AbstractNode.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/AbstractNode.java
@@ -20,10 +20,10 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public abstract class AbstractNode implements Node {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/BranchEdge.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/BranchEdge.java
@@ -15,9 +15,9 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
- * @author Slimane Amar <slimane.amar at rte-france.com>
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
+ * @author Slimane Amar {@literal <slimane.amar at rte-france.com>}
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class BranchEdge extends Edge {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/BusNode.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/BusNode.java
@@ -15,10 +15,10 @@ import java.io.IOException;
 import static com.powsybl.sld.library.ComponentTypeName.BUSBAR_SECTION;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public class BusNode extends EquipmentNode {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/ConnectivityNode.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/ConnectivityNode.java
@@ -15,8 +15,8 @@ import java.io.IOException;
 import java.util.List;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 public class ConnectivityNode extends AbstractNode {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/Edge.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/Edge.java
@@ -14,9 +14,9 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class Edge {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/EquipmentNode.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/EquipmentNode.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import java.io.IOException;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class EquipmentNode extends AbstractNode {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/Feeder.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/Feeder.java
@@ -11,7 +11,7 @@ import java.io.IOException;
 import com.fasterxml.jackson.core.JsonGenerator;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 public interface Feeder {
     FeederType getFeederType();

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/FeederNode.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/FeederNode.java
@@ -14,10 +14,10 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public class FeederNode extends EquipmentNode {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/FeederType.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/FeederType.java
@@ -7,7 +7,7 @@
 package com.powsybl.sld.model.nodes;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public enum FeederType {
     INJECTION,

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/Internal2WTNode.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/Internal2WTNode.java
@@ -12,7 +12,7 @@ import com.powsybl.sld.model.coordinate.Orientation;
 import java.util.List;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class Internal2WTNode extends EquipmentNode {
     public Internal2WTNode(String id, String nameOrId, String componentType) {

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/Middle2WTNode.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/Middle2WTNode.java
@@ -11,7 +11,7 @@ import java.util.Objects;
 import com.powsybl.sld.model.graphs.VoltageLevelInfos;
 
 /**
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public class Middle2WTNode extends MiddleTwtNode {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/Middle3WTNode.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/Middle3WTNode.java
@@ -15,7 +15,7 @@ import java.util.Objects;
 import static com.powsybl.sld.library.ComponentTypeName.THREE_WINDINGS_TRANSFORMER;
 
 /**
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public class Middle3WTNode extends MiddleTwtNode {
     private final Map<Winding, NodeSide> windingMap = new EnumMap<>(Winding.class);

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/MiddleTwtNode.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/MiddleTwtNode.java
@@ -12,7 +12,7 @@ import com.powsybl.sld.model.graphs.VoltageLevelInfos;
 import java.io.IOException;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class MiddleTwtNode extends EquipmentNode {
     protected final VoltageLevelInfos[] voltageLevelInfosLeg;

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/Node.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/Node.java
@@ -18,10 +18,10 @@ import java.util.Optional;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 public interface Node {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/NodeSide.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/NodeSide.java
@@ -7,7 +7,7 @@
 package com.powsybl.sld.model.nodes;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public enum NodeSide {
     ONE(1),

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/SwitchNode.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/SwitchNode.java
@@ -16,10 +16,10 @@ import java.util.Optional;
 import static com.powsybl.sld.model.coordinate.Direction.UNDEFINED;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer@rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer@rte-france.com>}
  */
 public class SwitchNode extends EquipmentNode {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/feeders/BaseFeeder.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/feeders/BaseFeeder.java
@@ -14,10 +14,10 @@ import com.powsybl.sld.model.nodes.Feeder;
 import com.powsybl.sld.model.nodes.FeederType;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public class BaseFeeder implements Feeder {
     FeederType feederType;

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/feeders/FeederTwLeg.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/feeders/FeederTwLeg.java
@@ -11,7 +11,7 @@ import com.powsybl.sld.model.nodes.FeederType;
 import com.powsybl.sld.model.nodes.NodeSide;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class FeederTwLeg extends FeederWithSides {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/feeders/FeederWithSides.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/feeders/FeederWithSides.java
@@ -14,7 +14,7 @@ import com.powsybl.sld.model.nodes.FeederType;
 import com.powsybl.sld.model.nodes.NodeSide;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class FeederWithSides extends BaseFeeder {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/postprocessor/GraphBuildPostProcessor.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/postprocessor/GraphBuildPostProcessor.java
@@ -10,7 +10,7 @@ package com.powsybl.sld.postprocessor;
 import com.powsybl.sld.model.graphs.VoltageLevelGraph;
 
 /**
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public interface GraphBuildPostProcessor {
     String getId();

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/postprocessor/GraphBuildPostProcessorMock.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/postprocessor/GraphBuildPostProcessorMock.java
@@ -13,7 +13,7 @@ import com.powsybl.sld.model.graphs.VoltageLevelGraph;
 import java.util.Objects;
 
 /**
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 @AutoService(GraphBuildPostProcessor.class)
 public class GraphBuildPostProcessorMock implements GraphBuildPostProcessor {

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/AbstractFeederInfo.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/AbstractFeederInfo.java
@@ -17,8 +17,8 @@ import java.util.Optional;
  * </ul>
  * Each of these two element part is optional
  *
- * @author Giovanni Ferrari <giovanni.ferrari at techrain.eu>
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Giovanni Ferrari {@literal <giovanni.ferrari at techrain.eu>}
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 public abstract class AbstractFeederInfo implements FeederInfo {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/AbstractLabelProvider.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/AbstractLabelProvider.java
@@ -21,7 +21,7 @@ import static com.powsybl.sld.model.coordinate.Direction.TOP;
 import static com.powsybl.sld.model.coordinate.Direction.UNDEFINED;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public abstract class AbstractLabelProvider implements LabelProvider {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/BusInfo.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/BusInfo.java
@@ -20,7 +20,7 @@ import java.util.Optional;
  * </ul>
  * Each of these two labels part is optional
  *
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 public class BusInfo {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultLabelProvider.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultLabelProvider.java
@@ -27,8 +27,8 @@ import static com.powsybl.sld.library.ComponentTypeName.*;
 import static com.powsybl.sld.model.coordinate.Direction.BOTTOM;
 
 /**
- * @author Giovanni Ferrari <giovanni.ferrari at techrain.eu>
- * @author Franck Lecuyer <franck.lecuyer at franck.lecuyer@rte-france.com>
+ * @author Giovanni Ferrari {@literal <giovanni.ferrari at techrain.eu>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at franck.lecuyer@rte-france.com>}
  */
 public class DefaultLabelProvider extends AbstractLabelProvider {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
@@ -50,11 +50,11 @@ import static com.powsybl.sld.util.IdUtil.escapeClassName;
 import static com.powsybl.sld.util.IdUtil.escapeId;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class DefaultSVGWriter implements SVGWriter {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DirectionalFeederInfo.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DirectionalFeederInfo.java
@@ -15,7 +15,7 @@ import java.util.function.DoubleFunction;
  * Class used to specify a directional element
  * (see FeederInfo & AbstractFeederInfo)
  *
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 public class DirectionalFeederInfo extends AbstractFeederInfo {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/ElectricalNodeInfo.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/ElectricalNodeInfo.java
@@ -8,7 +8,7 @@
 package com.powsybl.sld.svg;
 
 /**
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public class ElectricalNodeInfo {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/FeederInfo.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/FeederInfo.java
@@ -9,7 +9,7 @@ package com.powsybl.sld.svg;
 import java.util.Optional;
 
 /**
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 public interface FeederInfo {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/GraphMetadata.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/GraphMetadata.java
@@ -24,10 +24,10 @@ import java.nio.file.Path;
 import java.util.*;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public class GraphMetadata {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/LabelPosition.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/LabelPosition.java
@@ -9,8 +9,8 @@ package com.powsybl.sld.svg;
 import java.util.Objects;
 
 /**
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
- * @author Jacques Borsenberger <jacques.borsenberger at rte-france.com>
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
+ * @author Jacques Borsenberger {@literal <jacques.borsenberger at rte-france.com>}
  */
 public class LabelPosition {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/LabelProvider.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/LabelProvider.java
@@ -19,8 +19,8 @@ import java.util.Map;
 import java.util.Optional;
 
 /**
- * @author Giovanni Ferrari <giovanni.ferrari at techrain.eu>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Giovanni Ferrari {@literal <giovanni.ferrari at techrain.eu>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public interface LabelProvider {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/LabelProviderFactory.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/LabelProviderFactory.java
@@ -13,7 +13,7 @@ import com.powsybl.sld.library.ComponentLibrary;
 
 /**
  *
- * @author Sophie Frasnedo <sophie.frasnedo at rte-france.com>
+ * @author Sophie Frasnedo {@literal <sophie.frasnedo at rte-france.com>}
  */
 
 @FunctionalInterface

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/SVGWriter.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/SVGWriter.java
@@ -13,8 +13,8 @@ import com.powsybl.sld.svg.styles.StyleProvider;
 import java.io.Writer;
 
 /**
- * @author Gilles Brada <gilles.brada at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Gilles Brada {@literal <gilles.brada at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public interface SVGWriter {
     GraphMetadata write(Graph graph, LabelProvider initProvider, StyleProvider styleProvider, Writer writer);

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/SvgParameters.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/SvgParameters.java
@@ -14,7 +14,7 @@ import java.util.Objects;
 
 /**
  *
- * @author Sophie Frasnedo <sophie.frasnedo at rte-france.com>
+ * @author Sophie Frasnedo {@literal <sophie.frasnedo at rte-france.com>}
  */
 public class SvgParameters {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/WireConnection.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/WireConnection.java
@@ -23,10 +23,10 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public final class WireConnection {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/AbstractStyleProvider.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/AbstractStyleProvider.java
@@ -28,7 +28,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public abstract class AbstractStyleProvider implements StyleProvider {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/AbstractVoltageStyleProvider.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/AbstractVoltageStyleProvider.java
@@ -21,9 +21,9 @@ import java.util.*;
 import static com.powsybl.sld.svg.styles.StyleClassConstants.WIRE_STYLE_CLASS;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public abstract class AbstractVoltageStyleProvider extends AbstractStyleProvider {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/AnimatedFeederInfoStyleProvider.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/AnimatedFeederInfoStyleProvider.java
@@ -16,7 +16,7 @@ import java.util.List;
 import static com.powsybl.sld.svg.styles.StyleClassConstants.STYLE_PREFIX;
 
 /**
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 public class AnimatedFeederInfoStyleProvider extends EmptyStyleProvider {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/BasicStyleProvider.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/BasicStyleProvider.java
@@ -20,8 +20,8 @@ import static com.powsybl.sld.svg.styles.StyleClassConstants.NODE_INFOS;
 import static com.powsybl.sld.svg.styles.StyleClassConstants.WIRE_STYLE_CLASS;
 
 /**
- * @author Giovanni Ferrari <giovanni.ferrari at techrain.eu>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Giovanni Ferrari {@literal <giovanni.ferrari at techrain.eu>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public class BasicStyleProvider extends AbstractStyleProvider {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/DefaultStyleProviderFactory.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/DefaultStyleProviderFactory.java
@@ -14,7 +14,7 @@ import com.powsybl.sld.svg.styles.iidm.TopologicalStyleProvider;
 
 /**
  *
- * @author Sophie Frasnedo <sophie.frasnedo at rte-france.com>
+ * @author Sophie Frasnedo {@literal <sophie.frasnedo at rte-france.com>}
  */
 
 public class DefaultStyleProviderFactory implements StyleProviderFactory {

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/EmptyStyleProvider.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/EmptyStyleProvider.java
@@ -22,7 +22,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class EmptyStyleProvider implements StyleProvider {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/NominalVoltageStyleProvider.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/NominalVoltageStyleProvider.java
@@ -22,8 +22,8 @@ import java.util.Optional;
 import static com.powsybl.sld.svg.styles.StyleClassConstants.NODE_INFOS;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public class NominalVoltageStyleProvider extends AbstractVoltageStyleProvider {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/NominalVoltageStyleProviderFactory.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/NominalVoltageStyleProviderFactory.java
@@ -12,7 +12,7 @@ import com.powsybl.iidm.network.Network;
 
 /**
  *
- * @author Sophie Frasnedo <sophie.frasnedo at rte-france.com>
+ * @author Sophie Frasnedo {@literal <sophie.frasnedo at rte-france.com>}
  */
 
 public class NominalVoltageStyleProviderFactory implements StyleProviderFactory {

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/StyleClassConstants.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/StyleClassConstants.java
@@ -11,7 +11,7 @@ import com.powsybl.sld.model.cells.InternCell;
 import com.powsybl.sld.model.coordinate.Direction;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public final class StyleClassConstants {
     public static final String STYLE_PREFIX = "sld-";

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/StyleProvider.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/StyleProvider.java
@@ -23,8 +23,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * @author Giovanni Ferrari <giovanni.ferrari at techrain.eu>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Giovanni Ferrari {@literal <giovanni.ferrari at techrain.eu>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public interface StyleProvider {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/StyleProviderFactory.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/StyleProviderFactory.java
@@ -12,7 +12,7 @@ import com.powsybl.iidm.network.Network;
 
 /**
  *
- * @author Sophie Frasnedo <sophie.frasnedo at rte-france.com>
+ * @author Sophie Frasnedo {@literal <sophie.frasnedo at rte-france.com>}
  */
 
 @FunctionalInterface

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/StyleProvidersList.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/StyleProvidersList.java
@@ -24,7 +24,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class StyleProvidersList implements StyleProvider {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/iidm/HighlightLineStateStyleProvider.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/iidm/HighlightLineStateStyleProvider.java
@@ -18,8 +18,8 @@ import com.powsybl.sld.svg.styles.StyleClassConstants;
 import java.util.*;
 
 /**
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class HighlightLineStateStyleProvider extends EmptyStyleProvider {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/iidm/TopologicalStyleProvider.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/iidm/TopologicalStyleProvider.java
@@ -23,9 +23,9 @@ import java.util.stream.Collectors;
 import static com.powsybl.sld.svg.styles.StyleClassConstants.NODE_INFOS;
 
 /**
- * @author Giovanni Ferrari <giovanni.ferrari at techrain.eu>
- * @author Franck Lecuyer <franck.lecuyer@rte-france.com>
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Giovanni Ferrari {@literal <giovanni.ferrari at techrain.eu>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer@rte-france.com>}
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class TopologicalStyleProvider extends AbstractVoltageStyleProvider {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/util/DomUtil.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/util/DomUtil.java
@@ -23,7 +23,7 @@ import javax.xml.transform.stream.StreamResult;
 import java.io.Writer;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class DomUtil {
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/util/IdUtil.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/util/IdUtil.java
@@ -14,7 +14,7 @@ import java.io.UncheckedIOException;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class IdUtil {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
@@ -28,7 +28,7 @@ import java.util.Objects;
 import java.util.regex.Pattern;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 public abstract class AbstractTestCase {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/SingleLineDiagramToolTest.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/SingleLineDiagramToolTest.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 class SingleLineDiagramToolTest extends AbstractToolTest {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/builders/NetworkGraphBuilderTest.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/builders/NetworkGraphBuilderTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class NetworkGraphBuilderTest {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/AbstractTestCaseIidm.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/AbstractTestCaseIidm.java
@@ -25,10 +25,10 @@ import com.powsybl.sld.svg.styles.iidm.HighlightLineStateStyleProvider;
 import com.powsybl.sld.svg.styles.iidm.TopologicalStyleProvider;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 public abstract class AbstractTestCaseIidm extends AbstractTestCase {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestBattery.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestBattery.java
@@ -18,7 +18,7 @@ import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Sophie Frasnedo <sophie.frasnedo at rte-france.com>
+ * @author Sophie Frasnedo {@literal <sophie.frasnedo at rte-france.com>}
  */
 class TestBattery extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase1.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase1.java
@@ -30,10 +30,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * ------ bbs
  * </PRE>
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 class TestCase1 extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase10TestBreakerToBus.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase10TestBreakerToBus.java
@@ -24,10 +24,10 @@ import com.powsybl.iidm.network.extensions.ConnectablePosition;
  * ------ bbs
  * </PRE>
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 class TestCase10TestBreakerToBus extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase11FlatDesignComponents.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase11FlatDesignComponents.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class TestCase11FlatDesignComponents extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase11SubstationGraph.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase11SubstationGraph.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 class TestCase11SubstationGraph extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase12GraphWith3WT.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase12GraphWith3WT.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 class TestCase12GraphWith3WT extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase13ZoneGraph.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase13ZoneGraph.java
@@ -21,7 +21,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Christian Biasuzzi <christian.biasuzzi@techrain.eu>
+ * @author Christian Biasuzzi {@literal <christian.biasuzzi@techrain.eu>}
  */
 class TestCase13ZoneGraph extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase15GraphWithVoltageIndicator.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase15GraphWithVoltageIndicator.java
@@ -32,7 +32,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 class TestCase15GraphWithVoltageIndicator extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase1BusBreaker.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase1BusBreaker.java
@@ -16,9 +16,9 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class TestCase1BusBreaker extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase1inverted.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase1inverted.java
@@ -31,10 +31,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * ------ bbs
  * </PRE>
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 class TestCase1inverted extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase2StackedCell.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase2StackedCell.java
@@ -31,10 +31,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  * </pre>
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 class TestCase2StackedCell extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase3Coupling.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase3Coupling.java
@@ -28,10 +28,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  * </pre>
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 class TestCase3Coupling extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase3TripleCoupling.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase3TripleCoupling.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  * </pre>
  *
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class TestCase3TripleCoupling extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase4NotParallelel.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase4NotParallelel.java
@@ -39,10 +39,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * <p>
  * the branch c is to cover the merging part of SubSections class (and use of generator)
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 class TestCase4NotParallelel extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase5ShuntHorizontal.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase5ShuntHorizontal.java
@@ -32,10 +32,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  * </pre>
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 class TestCase5ShuntHorizontal extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase5ShuntVertical.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase5ShuntVertical.java
@@ -32,10 +32,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  * </pre>
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 class TestCase5ShuntVertical extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase6CouplingNonFlatHorizontal.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase6CouplingNonFlatHorizontal.java
@@ -28,10 +28,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  * </pre>
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 class TestCase6CouplingNonFlatHorizontal extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase6InternalConnection.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase6InternalConnection.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  * </pre>
  *
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class TestCase6InternalConnection extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase7CellDetectionIssue.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase7CellDetectionIssue.java
@@ -27,10 +27,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * ------ bbs
  * </PRE>
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 class TestCase7CellDetectionIssue extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase7DoubleDJ.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase7DoubleDJ.java
@@ -16,10 +16,10 @@ import com.powsybl.iidm.network.*;
  *
  * </pre>
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 class TestCase7DoubleDJ extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase8JumpOverStacked.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase8JumpOverStacked.java
@@ -21,10 +21,10 @@ import com.powsybl.iidm.network.*;
  *
  * </pre>
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 class TestCase8JumpOverStacked extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCaseConsecutiveShunts.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCaseConsecutiveShunts.java
@@ -25,7 +25,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class TestCaseConsecutiveShunts extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCaseFictitiousBus.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCaseFictitiousBus.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  * </pre>
  *
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 class TestCaseFictitiousBus extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCaseGraphAdaptCellHeightToContent.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCaseGraphAdaptCellHeightToContent.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 class TestCaseGraphAdaptCellHeightToContent extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCaseLoadBreakSwitch.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCaseLoadBreakSwitch.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 class TestCaseLoadBreakSwitch extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCaseMissingBusbarPosition.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCaseMissingBusbarPosition.java
@@ -28,10 +28,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * ------ bbs
  * </PRE>
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 class TestCaseMissingBusbarPosition extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestComplexParallelLegs.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestComplexParallelLegs.java
@@ -18,7 +18,7 @@ import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class TestComplexParallelLegs extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestComplexParallelLegsInternalPst.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestComplexParallelLegsInternalPst.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class TestComplexParallelLegsInternalPst extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestDisconnectedComponentsBusBreaker.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestDisconnectedComponentsBusBreaker.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Sophie Frasnedo <sophie.frasnedo at rte-france.com>
+ * @author Sophie Frasnedo {@literal <sophie.frasnedo at rte-france.com>}
  */
 
 class TestDisconnectedComponentsBusBreaker extends AbstractTestCaseIidm {

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestDoubleForkNode.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestDoubleForkNode.java
@@ -18,7 +18,7 @@ import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class TestDoubleForkNode extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestFeederInfos.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestFeederInfos.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * ------ bbs
  * </PRE>
  *
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 class TestFeederInfos extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestFlatSection.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestFlatSection.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class TestFlatSection extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestInternalBranchesBusBreaker.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestInternalBranchesBusBreaker.java
@@ -27,7 +27,7 @@ import java.nio.file.Path;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Slimane Amar <slimane.amar at rte-france.com>
+ * @author Slimane Amar {@literal <slimane.amar at rte-france.com>}
  */
 class TestInternalBranchesBusBreaker extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestInternalBranchesNodeBreaker.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestInternalBranchesNodeBreaker.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Slimane Amar <slimane.amar at rte-france.com>
+ * @author Slimane Amar {@literal <slimane.amar at rte-france.com>}
  */
 class TestInternalBranchesNodeBreaker extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestNodeDecoratorsBusBreaker.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestNodeDecoratorsBusBreaker.java
@@ -16,8 +16,8 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
- * @author Slimane Amar <slimane.amar at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
+ * @author Slimane Amar {@literal <slimane.amar at rte-france.com>}
  */
 class TestNodeDecoratorsBusBreaker extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestNodeDecoratorsNodeBreaker.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestNodeDecoratorsNodeBreaker.java
@@ -28,8 +28,8 @@ import java.util.Objects;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
- * @author Slimane Amar <slimane.amar at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
+ * @author Slimane Amar {@literal <slimane.amar at rte-france.com>}
  */
 class TestNodeDecoratorsNodeBreaker extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSVGWriter.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSVGWriter.java
@@ -35,7 +35,7 @@ import static com.powsybl.sld.model.nodes.NodeSide.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 class TestSVGWriter extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSerialBlock.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSerialBlock.java
@@ -36,8 +36,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 class TestSerialBlock extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSerialParallelBlock.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSerialParallelBlock.java
@@ -36,8 +36,8 @@ import static com.powsybl.sld.model.nodes.Node.NodeType.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 class TestSerialParallelBlock extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSingleLineDiagramClass.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSingleLineDiagramClass.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class TestSingleLineDiagramClass extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestTieLine.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestTieLine.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Sophie Frasnedo <sophie.frasnedo at rte-france.com>
+ * @author Sophie Frasnedo {@literal <sophie.frasnedo at rte-france.com>}
  */
 class TestTieLine extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestTopologyCalculation.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestTopologyCalculation.java
@@ -37,10 +37,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * bbs 2.1 ----------x-d21-x-b2-x-d22-x---x------------x--- bbs 2.2
  * </PRE>
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 class TestTopologyCalculation extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestUnicityNodeIdWithMutipleNetwork.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestUnicityNodeIdWithMutipleNetwork.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 class TestUnicityNodeIdWithMutipleNetwork extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestUnknownComponent.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestUnknownComponent.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 class TestUnknownComponent extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestViewBox.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestViewBox.java
@@ -19,7 +19,7 @@ import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Thomas Adam <tadam at neverhack.com>
+ * @author Thomas Adam {@literal <tadam at neverhack.com>}
  */
 class TestViewBox extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/layout/ComponentsOnBusTest.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/layout/ComponentsOnBusTest.java
@@ -21,7 +21,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class ComponentsOnBusTest extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/layout/LayoutParametersTest.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/layout/LayoutParametersTest.java
@@ -14,9 +14,9 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Giovanni Ferrari <giovanni.ferrari at techrain.eu>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
- * @author Jacques Borsenberger <jacques.borsenberger at rte-france.com>
+ * @author Giovanni Ferrari {@literal <giovanni.ferrari at techrain.eu>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
+ * @author Jacques Borsenberger {@literal <jacques.borsenberger at rte-france.com>}
  */
 class LayoutParametersTest {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/layout/PositionVoltageLevelLayoutFactoryTest.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/layout/PositionVoltageLevelLayoutFactoryTest.java
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 class PositionVoltageLevelLayoutFactoryTest {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/layout/SmartVoltageLevelLayoutFactoryTest.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/layout/SmartVoltageLevelLayoutFactoryTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class SmartVoltageLevelLayoutFactoryTest {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/library/AnchorPointTest.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/library/AnchorPointTest.java
@@ -12,9 +12,9 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class AnchorPointTest {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/library/ComponentLibraryTest.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/library/ComponentLibraryTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class ComponentLibraryTest {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/library/ComponentsTest.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/library/ComponentsTest.java
@@ -17,10 +17,10 @@ import static com.powsybl.sld.library.ComponentTypeName.BREAKER;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 class ComponentsTest {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/library/TestLoadInvalidExternalComponent.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/library/TestLoadInvalidExternalComponent.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 class TestLoadInvalidExternalComponent {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/model/AddNodeGraphTest.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/model/AddNodeGraphTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class AddNodeGraphTest extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/model/ZoneGraphTest.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/model/ZoneGraphTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  *
- * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
+ * @author Massimo Ferraro {@literal <massimo.ferraro@techrain.eu>}
  */
 class ZoneGraphTest {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/AbstractTestCaseRaw.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/AbstractTestCaseRaw.java
@@ -28,7 +28,7 @@ import static com.powsybl.sld.library.ComponentTypeName.ARROW_ACTIVE;
 import static com.powsybl.sld.library.ComponentTypeName.ARROW_REACTIVE;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 public abstract class AbstractTestCaseRaw extends AbstractTestCase {
     protected RawGraphBuilder rawGraphBuilder = new RawGraphBuilder();

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/RawGraphBuilderUtils.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/RawGraphBuilderUtils.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import static com.powsybl.sld.model.coordinate.Direction.*;
 
 /*
- * @author Thomas Adam <tadam at neverhack.com>
+ * @author Thomas Adam {@literal <tadam at neverhack.com>}
  */
 public final class RawGraphBuilderUtils {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestAddBatteries.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestAddBatteries.java
@@ -22,7 +22,7 @@ import static com.powsybl.sld.model.coordinate.Direction.TOP;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Sophie Frasnedo <sophie.frasnedo at rte-france.com>
+ * @author Sophie Frasnedo {@literal <sophie.frasnedo at rte-france.com>}
  */
 class TestAddBatteries extends AbstractTestCaseRaw {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestAddExternalComponent.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestAddExternalComponent.java
@@ -23,7 +23,7 @@ import static com.powsybl.sld.model.coordinate.Direction.TOP;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 class TestAddExternalComponent extends AbstractTestCaseRaw {
     private static final String CHEESE = "CHEESE";

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase1.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase1.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * ------ bbs
  * </PRE>
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 class TestCase1 extends AbstractTestCaseRaw {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase11SubstationGraph.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase11SubstationGraph.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 /*
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 class TestCase11SubstationGraph extends AbstractTestCaseRaw {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase12ZoneGraph.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase12ZoneGraph.java
@@ -17,7 +17,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /*
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 class TestCase12ZoneGraph extends AbstractTestCaseRaw {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase2.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase2.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  * </pre>
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 class TestCase2 extends AbstractTestCaseRaw {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase3.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase3.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  * </pre>
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 
 class TestCase3 extends AbstractTestCaseRaw {

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase4.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase4.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * <p>
  * the branch c is to cover the merging part of SubSections class (and use of generator)
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 
 class TestCase4 extends AbstractTestCaseRaw {

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase5H.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase5H.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  * </pre>
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 class TestCase5H extends AbstractTestCaseRaw {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase5V.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase5V.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  * </pre>
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 class TestCase5V extends AbstractTestCaseRaw {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase6.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase6.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  * </pre>
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 
 class TestCase6 extends AbstractTestCaseRaw {

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase7CellDetectionIssue.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase7CellDetectionIssue.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * ------ bbs
  * </PRE>
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 class TestCase7CellDetectionIssue extends AbstractTestCaseRaw {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCaseComplexCoupling.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCaseComplexCoupling.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 
 class TestCaseComplexCoupling extends AbstractTestCaseRaw {

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCaseShuntArrangement.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCaseShuntArrangement.java
@@ -20,7 +20,7 @@ import static com.powsybl.sld.model.coordinate.Direction.TOP;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 class TestCaseShuntArrangement extends AbstractTestCaseRaw {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestIncompleteFeederIssue.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestIncompleteFeederIssue.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * ------ bbs
  * </PRE>
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class TestIncompleteFeederIssue extends AbstractTestCaseRaw {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestInsertFictitiousNodesAtFeeder.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestInsertFictitiousNodesAtFeeder.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * line
  * </PRE>
  *
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class TestInsertFictitiousNodesAtFeeder extends AbstractTestCaseRaw {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestInternCellExplicitPosition.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestInternCellExplicitPosition.java
@@ -19,7 +19,7 @@ import static com.powsybl.sld.model.coordinate.Direction.TOP;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 class TestInternCellExplicitPosition extends AbstractTestCaseRaw {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestInternCellShapes.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestInternCellShapes.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 
 class TestInternCellShapes extends AbstractTestCaseRaw {

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestLanesWithUnileg.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestLanesWithUnileg.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 
 class TestLanesWithUnileg extends AbstractTestCaseRaw {

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestOrderConsistency.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestOrderConsistency.java
@@ -21,7 +21,7 @@ import static com.powsybl.sld.model.coordinate.Direction.TOP;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 
 class TestOrderConsistency extends AbstractTestCaseRaw {

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestParallelFeedersOnBus.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestParallelFeedersOnBus.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class TestParallelFeedersOnBus extends AbstractTestCaseRaw {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestParallelFeedersOrders.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestParallelFeedersOrders.java
@@ -19,7 +19,7 @@ import static com.powsybl.sld.model.coordinate.Direction.TOP;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 class TestParallelFeedersOrders extends AbstractTestCaseRaw {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestSerialBlocksInternCells.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestSerialBlocksInternCells.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 class TestSerialBlocksInternCells extends AbstractTestCaseRaw {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestUndefinedBlockExternCell.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestUndefinedBlockExternCell.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * ------ bbs
  * </PRE>
  *
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 class TestUndefinedBlockExternCell extends AbstractTestCaseRaw {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestUnhandledPatternInternCell.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestUnhandledPatternInternCell.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  */
 class TestUnhandledPatternInternCell extends AbstractTestCaseRaw {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/svg/FeederInfoProviderTest.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/svg/FeederInfoProviderTest.java
@@ -26,8 +26,8 @@ import static com.powsybl.sld.library.ComponentTypeName.ARROW_REACTIVE;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Giovanni Ferrari <giovanni.ferrari at techrain.eu>
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Giovanni Ferrari {@literal <giovanni.ferrari at techrain.eu>}
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 class FeederInfoProviderTest extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/svg/GraphMetadataTest.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/svg/GraphMetadataTest.java
@@ -33,10 +33,10 @@ import java.util.List;
 import static com.powsybl.sld.library.ComponentTypeName.*;
 
 /**
- * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Benoit Jeanson {@literal <benoit.jeanson at rte-france.com>}
  * @author Nicolas Duchene
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 class GraphMetadataTest {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/svg/IdUtilTest.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/svg/IdUtilTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Giovanni Ferrari <giovanni.ferrari at techrain.eu>
+ * @author Giovanni Ferrari {@literal <giovanni.ferrari at techrain.eu>}
  */
 class IdUtilTest {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/svg/SvgParametersTest.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/svg/SvgParametersTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Sophie Frasnedo <sophie.frasnedo at rte-france.com>
+ * @author Sophie Frasnedo {@literal <sophie.frasnedo at rte-france.com>}
  */
 class SvgParametersTest {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/util/NominalVoltageStyleTest.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/util/NominalVoltageStyleTest.java
@@ -34,8 +34,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author Giovanni Ferrari <giovanni.ferrari at techrain.eu>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Giovanni Ferrari {@literal <giovanni.ferrari at techrain.eu>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 class NominalVoltageStyleTest extends AbstractTestCaseIidm {
 

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/util/TopologicalStyleTest.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/util/TopologicalStyleTest.java
@@ -28,8 +28,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author Giovanni Ferrari <giovanni.ferrari at techrain.eu>
- * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ * @author Giovanni Ferrari {@literal <giovanni.ferrari at techrain.eu>}
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
 class TopologicalStyleTest extends AbstractTestCaseIidm {
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines

**Does this PR already have an issue describing the problem?**
No, but similar to https://github.com/powsybl/powsybl-core/pull/2753

**What kind of change does this PR introduce?**
Bug fix for javadoc generation.

**What is the current behavior?**
Errors related to the author's email address formatting occur when generating the javadoc.
Email addresses were written as @author Name Surname <author at email.address>


**What is the new behavior (if this is a feature change)?**
No more errors related to that when generating the javadoc. 
Email addresses are written as @author Name Surname {@literal <author at email.address>}
