### PR TITLE
Detect inconsistent busNodes positions

### DIFF
--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LegBusSet.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LegBusSet.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.sld.layout;
 
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.sld.model.cells.Cell;
 import com.powsybl.sld.model.cells.ExternCell;
 import com.powsybl.sld.model.cells.InternCell;
@@ -18,6 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -99,12 +101,22 @@ public final class LegBusSet {
         return internCellSides;
     }
 
-    void setExtendedNodeSet(Collection<BusNode> busNodes) {
+    void addToExtendedNodeSet(Collection<BusNode> busNodes) {
         if (busNodes.containsAll(busNodeSet)) {
-            extendedNodeSet.addAll(busNodes.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+            // The given busNodes correspond to all vertical bus nodes for a specific index of the horizontalBusLanes:
+            // those nodes correspond to a slice of busbars.
+            // There can't be more than one busNode per busbar index, we check this by creating the following map with
+            // an exception-throwing merge method
+            Map<Integer, BusNode> indexToBusNode = busNodes.stream().filter(Objects::nonNull)
+                    .collect(Collectors.toMap(BusNode::getBusbarIndex, Function.identity(), this::detectConflictingBusNodes));
+            extendedNodeSet.addAll(indexToBusNode.values());
         } else {
             LOGGER.error("ExtendedNodeSet inconsistent with NodeBusSet");
         }
+    }
+
+    private BusNode detectConflictingBusNodes(BusNode busNode1, BusNode busNode2) {
+        throw new PowsyblException("Inconsistent legBusSet: extended node set contains two busNodes with same index");
     }
 
     Set<BusNode> getExtendedNodeSet() {

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/Subsection.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/Subsection.java
@@ -93,7 +93,7 @@ public class Subsection {
         subsections.add(currentSubsection);
         int i = 0;
         for (LegBusSet lbs : lbsCluster.getLbsList()) {
-            lbs.setExtendedNodeSet(lbsCluster.getVerticalBuseNodes(i));
+            lbs.addToExtendedNodeSet(lbsCluster.getVerticalBuseNodes(i));
             if (!currentSubsection.checkAbsorbability(lbs)) {
                 currentSubsection = new Subsection(vSize);
                 subsections.add(currentSubsection);

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionbyclustering/PositionByClustering.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionbyclustering/PositionByClustering.java
@@ -73,6 +73,7 @@ public class PositionByClustering extends AbstractPositionFinder {
                 .sorted(Comparator.comparing(BusNode::getId))
                 .collect(Collectors.toList())) {
             busToNb.put(n, i);
+            n.setBusBarIndexSectionIndex(0, 0);
             i++;
         }
         return busToNb;

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCaseExternCellOnTwoSections.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCaseExternCellOnTwoSections.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.sld.iidm;
+
+import com.powsybl.diagram.test.Networks;
+import com.powsybl.iidm.network.Country;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.SwitchKind;
+import com.powsybl.iidm.network.TopologyKind;
+import com.powsybl.iidm.network.extensions.ConnectablePosition;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
+import com.powsybl.sld.model.graphs.VoltageLevelGraph;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * <PRE>
+ *         l
+ *         |
+ *     ___ b ____
+ *    |          |
+ *    |          |
+ * --d1--  x  --d2--
+ *  bbs1  dc   bbs2
+ * </PRE>
+ *
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
+ */
+class TestCaseExternCellOnTwoSections extends AbstractTestCaseIidm {
+
+    @BeforeEach
+    public void setUp() {
+        network = Network.create("test", "test");
+        graphBuilder = new NetworkGraphBuilder(network);
+        substation = Networks.createSubstation(network, "s", "s", Country.FR);
+        vl = Networks.createVoltageLevel(substation, "vl", "vl", TopologyKind.NODE_BREAKER, 225);
+        Networks.createBusBarSection(vl, "bbs1", "bbs1", 0, 1, 1);
+        Networks.createBusBarSection(vl, "bbs2", "bbs2", 1, 1, 2);
+        Networks.createLoad(vl, "l", "l", "l", 0, ConnectablePosition.Direction.TOP, 2, 10, 10);
+        Networks.createSwitch(vl, "d1", "d1", SwitchKind.DISCONNECTOR, false, false, false, 0, 3);
+        Networks.createSwitch(vl, "d2", "d2", SwitchKind.DISCONNECTOR, false, false, false, 1, 3);
+        Networks.createSwitch(vl, "dc", "dc", SwitchKind.DISCONNECTOR, false, false, false, 0, 1);
+        Networks.createSwitch(vl, "b", "b", SwitchKind.BREAKER, false, false, false, 3, 2);
+    }
+
+    @Test
+    void test() {
+        VoltageLevelGraph g = graphBuilder.buildVoltageLevelGraph(vl.getId());
+        voltageLevelGraphLayout(g);
+        assertEquals(toString("/TestCaseExternCellOnTwoSections.svg"), toSVG(g, "/TestCaseExternCellOnTwoSections.svg"));
+    }
+}

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/TestCaseExternCellOnTwoSections.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/TestCaseExternCellOnTwoSections.svg
@@ -1,0 +1,237 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg height="332.0" viewBox="0 0 230.0 332.0" width="230.0" xmlns="http://www.w3.org/2000/svg">
+    <style><![CDATA[
+/* ----------------------------------------------------------------------- */
+/* File: tautologies.css ------------------------------------------------- */
+.sld-out .sld-arrow-in {visibility: hidden}
+.sld-in .sld-arrow-out {visibility: hidden}
+.sld-closed .sld-sw-open {visibility: hidden}
+.sld-open .sld-sw-closed {visibility: hidden}
+.sld-hidden-node {visibility: hidden}
+.sld-top-feeder .sld-label {dominant-baseline: auto}
+.sld-bottom-feeder .sld-label {dominant-baseline: hanging}
+.sld-active-power .sld-label {dominant-baseline: mathematical}
+.sld-reactive-power .sld-label {dominant-baseline: mathematical}
+.sld-current .sld-label {dominant-baseline: mathematical}
+/* ----------------------------------------------------------------------- */
+/* File: topologicalBaseVoltages.css ------------------------------------- */
+.sld-disconnected {--sld-vl-color: #808080}
+.sld-vl300to500-0 {--sld-vl-color: #FF0000}
+.sld-vl300to500-1 {--sld-vl-color: #7F6C00}
+.sld-vl300to500-2 {--sld-vl-color: #F6B2FF}
+.sld-vl300to500-3 {--sld-vl-color: #996700}
+.sld-vl300to500-4 {--sld-vl-color: #FF85EB}
+.sld-vl300to500-5 {--sld-vl-color: #B25B00}
+.sld-vl300to500-6 {--sld-vl-color: #FF59B5}
+.sld-vl300to500-7 {--sld-vl-color: #CC4400}
+.sld-vl300to500-8 {--sld-vl-color: #FF2C67}
+.sld-vl300to500-9 {--sld-vl-color: #E52600}
+.sld-vl180to300-0 {--sld-vl-color: #218B21}
+.sld-vl180to300-1 {--sld-vl-color: #0D4940}
+.sld-vl180to300-2 {--sld-vl-color: #DFDAB9}
+.sld-vl180to300-3 {--sld-vl-color: #105640}
+.sld-vl180to300-4 {--sld-vl-color: #C2CB92}
+.sld-vl180to300-5 {--sld-vl-color: #14643C}
+.sld-vl180to300-6 {--sld-vl-color: #95B66B}
+.sld-vl180to300-7 {--sld-vl-color: #187036}
+.sld-vl180to300-8 {--sld-vl-color: #5FA046}
+.sld-vl180to300-9 {--sld-vl-color: #1C7E2D}
+.sld-vl120to180-0 {--sld-vl-color: #00AFAE}
+.sld-vl120to180-1 {--sld-vl-color: #000D58}
+.sld-vl120to180-2 {--sld-vl-color: #B8E7B2}
+.sld-vl120to180-3 {--sld-vl-color: #002169}
+.sld-vl120to180-4 {--sld-vl-color: #85D993}
+.sld-vl120to180-5 {--sld-vl-color: #003C7B}
+.sld-vl120to180-6 {--sld-vl-color: #59CB8B}
+.sld-vl120to180-7 {--sld-vl-color: #005C8C}
+.sld-vl120to180-8 {--sld-vl-color: #2CBD94}
+.sld-vl120to180-9 {--sld-vl-color: #00839E}
+.sld-vl70to120-0 {--sld-vl-color: #CC5500}
+.sld-vl70to120-1 {--sld-vl-color: #4A6600}
+.sld-vl70to120-2 {--sld-vl-color: #EFB2DD}
+.sld-vl70to120-3 {--sld-vl-color: #6E7A00}
+.sld-vl70to120-4 {--sld-vl-color: #E685AE}
+.sld-vl70to120-5 {--sld-vl-color: #8E8400}
+.sld-vl70to120-6 {--sld-vl-color: #DD596B}
+.sld-vl70to120-7 {--sld-vl-color: #A37B00}
+.sld-vl70to120-8 {--sld-vl-color: #D4432C}
+.sld-vl70to120-9 {--sld-vl-color: #B76B00}
+.sld-vl50to70-0 {--sld-vl-color: #A020EF}
+.sld-vl50to70-1 {--sld-vl-color: #7F0848}
+.sld-vl50to70-2 {--sld-vl-color: #B7DBFE}
+.sld-vl50to70-3 {--sld-vl-color: #960C6D}
+.sld-vl50to70-4 {--sld-vl-color: #8DA6FE}
+.sld-vl50to70-5 {--sld-vl-color: #AD109A}
+.sld-vl50to70-6 {--sld-vl-color: #6F66FB}
+.sld-vl50to70-7 {--sld-vl-color: #BC14C4}
+.sld-vl50to70-8 {--sld-vl-color: #7F42F6}
+.sld-vl50to70-9 {--sld-vl-color: #B11AD9}
+.sld-vl30to50-0 {--sld-vl-color: #FF8290}
+.sld-vl30to50-1 {--sld-vl-color: #7F6F41}
+.sld-vl30to50-2 {--sld-vl-color: #F6D9FF}
+.sld-vl30to50-3 {--sld-vl-color: #99784E}
+.sld-vl30to50-4 {--sld-vl-color: #FFC3FB}
+.sld-vl30to50-5 {--sld-vl-color: #B27D5B}
+.sld-vl30to50-6 {--sld-vl-color: #FFADE3}
+.sld-vl30to50-7 {--sld-vl-color: #CC7E68}
+.sld-vl30to50-8 {--sld-vl-color: #FF97BF}
+.sld-vl30to50-9 {--sld-vl-color: #E57B75}
+.sld-vl0to30-0 {--sld-vl-color: #AAAE27}
+.sld-vl0to30-1 {--sld-vl-color: #195B0F}
+.sld-vl0to30-2 {--sld-vl-color: #EABABE}
+.sld-vl0to30-3 {--sld-vl-color: #2D6C13}
+.sld-vl0to30-4 {--sld-vl-color: #DDA193}
+.sld-vl0to30-5 {--sld-vl-color: #477D17}
+.sld-vl0to30-6 {--sld-vl-color: #CE9A6E}
+.sld-vl0to30-7 {--sld-vl-color: #648D1C}
+.sld-vl0to30-8 {--sld-vl-color: #BEA04A}
+.sld-vl0to30-9 {--sld-vl-color: #869D22}
+/* ----------------------------------------------------------------------- */
+/* File : highlightLineStates.css ---------------------------------------- */
+.sld-wire.sld-feeder-disconnected {stroke: black}
+.sld-wire.sld-feeder-connected-disconnected {stroke-dasharray: 3,3}
+.sld-wire.sld-feeder-disconnected-connected {stroke: black; stroke-dasharray: 3,3}
+/* ----------------------------------------------------------------------- */
+/* File : components.css ------------------------------------------------- */
+/* Stroke black */
+.sld-disconnector {stroke-width: 3; stroke: black; fill: none}
+/* Stroke blue */
+.sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: white}
+/* Stroke --sld-vl-color with fallback black */
+.sld-bus-connection {fill: var(--sld-vl-color, black)}
+.sld-cell-shape-flat .sld-bus-connection {visibility: hidden}
+.sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
+/* Stroke --sld-vl-color with fallback red */
+.sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
+/* Stroke --sld-vl-color with fallback blue */
+.sld-load {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-battery {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-three-wt {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-winding {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-capacitor {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-inductor {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-pst {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-pst-arrow {stroke: black; fill: none}
+.sld-svc {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-vsc {stroke: var(--sld-vl-color, blue); font-size: 7.43px; fill: none}
+.sld-lcc {stroke: var(--sld-vl-color, blue); font-size: 7.43px; fill: none}
+/* Stroke none & fill: --sld-vl-color */
+.sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
+/* Stroke none & fill: black */
+.sld-node {stroke: none; fill: black}
+.sld-flash {stroke: none; fill: black}
+.sld-lock {stroke: none; fill: black}
+.sld-unknown {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px serif}
+.sld-angle, .sld-voltage {font: 10px serif}
+.sld-graph-label {font: 12px serif}
+/* Specific */
+.sld-grid {stroke: #003700; stroke-dasharray: 1,10}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
+.sld-feeder-info.sld-current {fill:purple}
+.sld-frame {fill: var(--sld-background-color, transparent)}
+/* Stroke maroon for fictitious switch */
+.sld-breaker.sld-fictitious {stroke: maroon}
+.sld-disconnector.sld-fictitious {stroke: maroon}
+.sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
+
+]]></style>
+    <rect class="sld-frame" height="100%" width="100%"/>
+    <g>
+        <g class="sld-busbar-section sld-vl180to300-0" id="idbbs1" transform="translate(52.5,252.0)">
+            <line x1="0" x2="25.0" y1="0" y2="0"/>
+            <text class="sld-label" id="bbs1_NW_LABEL" x="-5.0" y="-5.0">bbs1</text>
+        </g>
+        <g class="sld-busbar-section sld-vl180to300-0" id="idbbs2" transform="translate(152.5,252.0)">
+            <line x1="0" x2="25.0" y1="0" y2="0"/>
+            <text class="sld-label" id="bbs2_NW_LABEL" x="-5.0" y="-5.0">bbs2</text>
+        </g>
+        <g class="sld-intern-cell sld-cell-shape-flat" id="idINTERN_32_0">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl_95_bbs1_95_BUSCO_95_bbs1_95_dc">
+                <polyline points="77.5,252.0,90.0,252.0"/>
+            </g>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl_95_INTERNAL_95_vl_95_BUSCO_95_bbs1_95_dc_45_dc_95_dc">
+                <polyline points="90.0,252.0,115.0,252.0"/>
+            </g>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl_95_dc_95_INTERNAL_95_vl_95_BUSCO_95_bbs2_95_dc_45_dc">
+                <polyline points="115.0,252.0,140.0,252.0"/>
+            </g>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl_95_BUSCO_95_bbs2_95_dc_95_bbs2">
+                <polyline points="140.0,252.0,152.5,252.0"/>
+            </g>
+            <g class="sld-bus-connection sld-fictitious sld-vl180to300-0" id="idBUSCO_95_bbs1_95_dc" transform="translate(86.0,248.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl_95_BUSCO_95_bbs1_95_dc_45_dc" transform="translate(86.0,248.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-disconnector sld-closed sld-vl180to300-0" id="iddc" transform="translate(111.0,248.0)">
+                <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
+                <path class="sld-sw-open" d="M8,0 0,8"/>
+            </g>
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl_95_BUSCO_95_bbs2_95_dc_45_dc" transform="translate(136.0,248.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-bus-connection sld-fictitious sld-vl180to300-0" id="idBUSCO_95_bbs2_95_dc" transform="translate(136.0,248.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+        </g>
+        <g class="sld-extern-cell sld-cell-direction-top" id="idEXTERN_32_1">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl_95_d1_95_INTERNAL_95_vl_95_3">
+                <polyline points="15.0,252.0,15.0,222.0"/>
+            </g>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl_95_d2_95_INTERNAL_95_vl_95_3">
+                <polyline points="15.0,252.0,15.0,222.0"/>
+            </g>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl_95_INTERNAL_95_vl_95_3_95_b">
+                <polyline points="15.0,222.0,15.0,192.0"/>
+            </g>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl_95_b_95_INTERNAL_95_vl_95_l">
+                <polyline points="15.0,172.0,15.0,142.0"/>
+            </g>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl_95_INTERNAL_95_vl_95_l_95_l">
+                <polyline points="15.0,142.0,15.0,84.5"/>
+            </g>
+            <g class="sld-active-power sld-feeder-info sld-in" id="idl_ARROW_ACTIVE" transform="translate(10.0,99.5)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">—</text>
+            </g>
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idl_ARROW_REACTIVE" transform="translate(10.0,119.5)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">—</text>
+            </g>
+            <g class="sld-disconnector sld-closed sld-vl180to300-0" id="idd1" transform="translate(11.0,248.0)">
+                <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
+                <path class="sld-sw-open" d="M8,0 0,8"/>
+            </g>
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl_95_3" transform="translate(11.0,218.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-disconnector sld-closed sld-vl180to300-0" id="idd2" transform="translate(11.0,248.0)">
+                <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
+                <path class="sld-sw-open" d="M8,0 0,8"/>
+            </g>
+            <g class="sld-breaker sld-closed sld-vl180to300-0" id="idb" transform="translate(5.0,172.0)">
+                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
+                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+            </g>
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl_95_l" transform="translate(11.0,138.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-load sld-top-feeder sld-vl180to300-0" id="idl" transform="translate(7.0,75.5)">
+                <rect height="9" width="16"/>
+                <line x1="0" x2="16" y1="0" y2="9"/>
+                <line x1="16" x2="0" y1="0" y2="9"/>
+                <text class="sld-label" id="l_N_LABEL" x="-5.0" y="-5.0">l</text>
+            </g>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No



**What kind of change does this PR introduce?**
Bug fix



**What is the current behavior?**
When an extern cell is on two busbars A & B with same busbar index the resulting diagram is completely wrong: one of the two busbars (say A) loses all its cells on the layout hence on the displayed svg, leading to the following dangerous consequences:
- the problematic extern cell is displayed as if it were only on busbar B
- all the extern cells of A are displayed on B
- the intern cell between A & B are displayed as if they were solely on B


**What is the new behavior (if this is a feature change)?**
While waiting for a better solution which would need a lot of work, such problematic extern cells are detected, an error log is displayed, and they are displayed as squashed at abscissa 0.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**Other information**:
More generally, the hypotheses on the busbar/section indices given by the users are far too strong:
- they're supposed to be coherent but checks are missing
- they need to be >0, a zero value means not set
- the code works with arrays of size of the index maximum
- the layout processes the busNodes based on their indices whatever their LBSCluster (leading in the current problematic case to an empty busbar instead of overlapping busbars)
