### PR TITLE
Nominal voltage filter on whole network

### DIFF
--- a/network-area-diagram/src/main/java/com/powsybl/nad/build/iidm/VoltageLevelFilter.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/build/iidm/VoltageLevelFilter.java
@@ -77,14 +77,14 @@ public class VoltageLevelFilter implements Predicate<VoltageLevel> {
     public static VoltageLevelFilter createNominalVoltageFilter(Network network, List<String> voltageLevelIds,
                                                                 double nominalVoltageLowerBound, double nominalVoltageUpperBound,
                                                                 int depth) {
-        return createVoltageLevelFilterWithPredicate(network, voltageLevelIds, depth, getPredicateFromVoltageBounds(nominalVoltageLowerBound, nominalVoltageUpperBound));
+        return createVoltageLevelFilterWithPredicate(network, voltageLevelIds, depth, getPredicateFromNominalVoltageBounds(nominalVoltageLowerBound, nominalVoltageUpperBound));
     }
 
     public static VoltageLevelFilter createNominalVoltageFilter(Network network, double nominalVoltageLowerBound, double nominalVoltageUpperBound) {
-        return createNominalVoltageFilterWithPredicate(network, getPredicateFromVoltageBounds(nominalVoltageLowerBound, nominalVoltageUpperBound));
+        return createNominalVoltageFilterWithPredicate(network, getPredicateFromNominalVoltageBounds(nominalVoltageLowerBound, nominalVoltageUpperBound));
     }
 
-    private static Predicate<VoltageLevel> getPredicateFromVoltageBounds(double nominalVoltageLowerBound, double nominalVoltageUpperBound) {
+    private static Predicate<VoltageLevel> getPredicateFromNominalVoltageBounds(double nominalVoltageLowerBound, double nominalVoltageUpperBound) {
         checkVoltageBoundValues(nominalVoltageLowerBound, nominalVoltageUpperBound);
         return voltageLevel -> voltageLevel.getNominalV() >= nominalVoltageLowerBound && voltageLevel.getNominalV() <= nominalVoltageUpperBound;
     }

--- a/network-area-diagram/src/test/java/com/powsybl/nad/NetworkAreaDiagramTest.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/NetworkAreaDiagramTest.java
@@ -119,8 +119,8 @@ class NetworkAreaDiagramTest extends AbstractTest {
     void testVoltageFilteredDiagramLowerBoundNoVoltageLevelIdInput() {
         Network network = IeeeCdfNetworkFactory.create14();
         Path svgFileVoltageFilter = fileSystem.getPath("nad-test-voltage-filter.svg");
-        NetworkAreaDiagram.draw(network, svgFileVoltageFilter, new NadParameters(), VoltageLevelFilter.createNominalVoltageLowerBoundFilter(network, 120));
-        assertEquals(toString("/IEEE_14_bus_voltage_filter1.svg"), getContentFile(svgFileVoltageFilter));
+        NetworkAreaDiagram.draw(network, svgFileVoltageFilter, new NadParameters(), VoltageLevelFilter.createNominalVoltageLowerBoundFilter(network, 20));
+        assertEquals(toString("/IEEE_14_bus_voltage_filter5.svg"), getContentFile(svgFileVoltageFilter));
     }
 
     @Test

--- a/network-area-diagram/src/test/java/com/powsybl/nad/NetworkAreaDiagramTest.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/NetworkAreaDiagramTest.java
@@ -92,7 +92,7 @@ class NetworkAreaDiagramTest extends AbstractTest {
     }
 
     @Test
-    void testVoltageFilteredDiagramLowBound() {
+    void testVoltageFilteredDiagramLowerBound() {
         Network network = IeeeCdfNetworkFactory.create14();
         Path svgFileVoltageFilter = fileSystem.getPath("nad-test-voltage-filter.svg");
         NetworkAreaDiagram.draw(network, svgFileVoltageFilter, new NadParameters(), VoltageLevelFilter.createNominalVoltageLowerBoundFilter(network, List.of("VL4"), 120, 2));
@@ -100,11 +100,35 @@ class NetworkAreaDiagramTest extends AbstractTest {
     }
 
     @Test
-    void testVoltageFilteredDiagramHighBound() {
+    void testVoltageFilteredDiagramUpperBound() {
         Network network = IeeeCdfNetworkFactory.create14();
         Path svgFileVoltageFilter = fileSystem.getPath("nad-test-voltage-filter.svg");
         NetworkAreaDiagram.draw(network, svgFileVoltageFilter, new NadParameters(), VoltageLevelFilter.createNominalVoltageUpperBoundFilter(network, List.of("VL4"), 180, 2));
         assertEquals(toString("/IEEE_14_bus_voltage_filter2.svg"), getContentFile(svgFileVoltageFilter));
+    }
+
+    @Test
+    void testVoltageFilteredDiagramNoVoltageLevelIdInput() {
+        Network network = IeeeCdfNetworkFactory.create14();
+        Path svgFileVoltageFilter = fileSystem.getPath("nad-test-voltage-filter.svg");
+        NetworkAreaDiagram.draw(network, svgFileVoltageFilter, new NadParameters(), VoltageLevelFilter.createNominalVoltageFilter(network, 120, 180));
+        assertEquals(toString("/IEEE_14_bus_voltage_filter1.svg"), getContentFile(svgFileVoltageFilter));
+    }
+
+    @Test
+    void testVoltageFilteredDiagramLowerBoundNoVoltageLevelIdInput() {
+        Network network = IeeeCdfNetworkFactory.create14();
+        Path svgFileVoltageFilter = fileSystem.getPath("nad-test-voltage-filter.svg");
+        NetworkAreaDiagram.draw(network, svgFileVoltageFilter, new NadParameters(), VoltageLevelFilter.createNominalVoltageLowerBoundFilter(network, 120));
+        assertEquals(toString("/IEEE_14_bus_voltage_filter1.svg"), getContentFile(svgFileVoltageFilter));
+    }
+
+    @Test
+    void testVoltageFilteredDiagramUpperBoundNoVoltageLevelIdInput() {
+        Network network = IeeeCdfNetworkFactory.create14();
+        Path svgFileVoltageFilter = fileSystem.getPath("nad-test-voltage-filter.svg");
+        NetworkAreaDiagram.draw(network, svgFileVoltageFilter, new NadParameters(), VoltageLevelFilter.createNominalVoltageUpperBoundFilter(network, 90));
+        assertEquals(toString("/IEEE_14_bus_voltage_filter4.svg"), getContentFile(svgFileVoltageFilter));
     }
 
     @Test

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter4.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter4.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg viewBox="-1271.02 -554.58 2865.69 1241.72" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="-836.56 -581.45 2545.77 1745.17" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
@@ -127,17 +127,17 @@
                 <nad:busNode svgId="21" equipmentId="VL5_0"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node svgId="0" equipmentId="VL10" x="38.96" y="-339.58"/>
-                <nad:node svgId="2" equipmentId="VL11" x="-393.78" y="-299.50"/>
-                <nad:node svgId="4" equipmentId="VL12" x="-678.92" y="487.14"/>
-                <nad:node svgId="6" equipmentId="VL13" x="-331.31" y="376.24"/>
-                <nad:node svgId="8" equipmentId="VL14" x="117.34" y="308.90"/>
-                <nad:node svgId="10" equipmentId="VL6" x="-661.03" y="86.51"/>
-                <nad:node svgId="12" equipmentId="VL7" x="889.53" y="3.81"/>
-                <nad:node svgId="14" equipmentId="VL8" x="1294.67" y="39.93"/>
-                <nad:node svgId="16" equipmentId="VL9" x="424.89" y="-51.77"/>
-                <nad:node svgId="18" equipmentId="VL4" x="721.16" y="-299.60"/>
-                <nad:node svgId="20" equipmentId="VL5" x="-1071.02" y="-36.46"/>
+                <nad:node svgId="0" equipmentId="VL10" x="352.22" y="-28.13"/>
+                <nad:node svgId="2" equipmentId="VL11" x="-50.16" y="123.49"/>
+                <nad:node svgId="4" equipmentId="VL12" x="-156.66" y="963.72"/>
+                <nad:node svgId="6" equipmentId="VL13" x="159.52" y="784.70"/>
+                <nad:node svgId="8" equipmentId="VL14" x="568.23" y="608.74"/>
+                <nad:node svgId="10" equipmentId="VL6" x="-216.52" y="563.72"/>
+                <nad:node svgId="12" equipmentId="VL7" x="1140.00" y="-72.87"/>
+                <nad:node svgId="14" equipmentId="VL8" x="1409.21" y="-366.45"/>
+                <nad:node svgId="16" equipmentId="VL9" x="776.85" y="184.48"/>
+                <nad:node svgId="18" equipmentId="VL4" x="1161.75" y="280.20"/>
+                <nad:node svgId="20" equipmentId="VL5" x="-636.56" y="503.37"/>
             </nad:nodes>
             <nad:edges>
                 <nad:edge svgId="22" equipmentId="L9-10-1" node1="16" node2="0"/>
@@ -157,239 +157,239 @@
         </nad:nad>
     </metadata>
     <g class="nad-vl-nodes">
-        <g transform="translate(38.96,-339.58)" id="0">
+        <g transform="translate(352.22,-28.13)" id="0">
             <circle r="27.50" id="1" class="nad-vl0to30-0 nad-busnode"/>
         </g>
-        <g transform="translate(-393.78,-299.50)" id="2">
+        <g transform="translate(-50.16,123.49)" id="2">
             <circle r="27.50" id="3" class="nad-vl0to30-0 nad-busnode"/>
         </g>
-        <g transform="translate(-678.92,487.14)" id="4">
+        <g transform="translate(-156.66,963.72)" id="4">
             <circle r="27.50" id="5" class="nad-vl0to30-0 nad-busnode"/>
         </g>
-        <g transform="translate(-331.31,376.24)" id="6">
+        <g transform="translate(159.52,784.70)" id="6">
             <circle r="27.50" id="7" class="nad-vl0to30-0 nad-busnode"/>
         </g>
-        <g transform="translate(117.34,308.90)" id="8">
+        <g transform="translate(568.23,608.74)" id="8">
             <circle r="27.50" id="9" class="nad-vl0to30-0 nad-busnode"/>
         </g>
-        <g transform="translate(-661.03,86.51)" id="10">
+        <g transform="translate(-216.52,563.72)" id="10">
             <circle r="27.50" id="11" class="nad-vl0to30-0 nad-busnode"/>
         </g>
-        <g transform="translate(889.53,3.81)" id="12">
+        <g transform="translate(1140.00,-72.87)" id="12">
             <circle r="27.50" id="13" class="nad-vl0to30-0 nad-busnode"/>
         </g>
-        <g transform="translate(1294.67,39.93)" id="14">
+        <g transform="translate(1409.21,-366.45)" id="14">
             <circle r="27.50" id="15" class="nad-vl0to30-0 nad-busnode"/>
         </g>
-        <g transform="translate(424.89,-51.77)" id="16">
+        <g transform="translate(776.85,184.48)" id="16">
             <circle r="27.50" id="17" class="nad-vl0to30-0 nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="22">
             <g id="22.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="402.84,-68.21 231.92,-195.67"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(376.79,-87.64)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="752.26,172.17 564.54,78.17"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(723.20,157.62)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-53.29)">
+                        <g transform="rotate(-63.40)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-323.29)" x="-19.00" style="text-anchor:end"></text>
+                        <text transform="rotate(-333.40)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
             <g id="22.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="61.00,-323.14 231.92,-195.67"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(87.06,-303.71)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="376.81,-15.82 564.54,78.17"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(405.87,-1.27)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(126.71)">
+                        <g transform="rotate(116.60)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(36.71)" x="19.00"></text>
+                        <text transform="rotate(26.60)" x="19.00"></text>
                     </g>
                 </g>
             </g>
         </g>
         <g id="23">
             <g id="23.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="11.58,-337.04 -177.41,-319.54"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-20.79,-334.05)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="326.49,-18.44 151.03,47.68"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(296.08,-6.98)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-95.29)">
+                        <g transform="rotate(-110.65)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-5.29)" x="-19.00" style="text-anchor:end"></text>
+                        <text transform="rotate(-20.65)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
             <g id="23.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-366.40,-302.04 -177.41,-319.54"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-334.04,-305.03)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-24.43,113.79 151.03,47.68"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(5.98,102.33)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(84.71)">
+                        <g transform="rotate(69.35)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-5.29)" x="19.00"></text>
+                        <text transform="rotate(-20.65)" x="19.00"></text>
                     </g>
                 </g>
             </g>
         </g>
         <g id="24">
             <g id="24.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-645.37,63.90 -527.41,-106.50"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-626.87,37.18)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-206.80,538.00 -133.34,343.61"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-195.31,507.60)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(34.70)">
+                        <g transform="rotate(20.70)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-55.30)" x="19.00"></text>
+                        <text transform="rotate(-69.30)" x="19.00"></text>
                     </g>
                 </g>
             </g>
             <g id="24.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-409.44,-276.89 -527.41,-106.50"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-427.94,-250.17)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-59.89,149.21 -133.34,343.61"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-71.37,179.62)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-145.30)">
+                        <g transform="rotate(-159.30)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-55.30)" x="-19.00" style="text-anchor:end"></text>
+                        <text transform="rotate(-69.30)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
         </g>
         <g id="25">
             <g id="25.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-662.25,113.98 -669.98,286.83"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-663.70,146.45)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-212.45,590.92 -186.59,763.72"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-207.64,623.06)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-177.44)">
+                        <g transform="rotate(171.49)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-87.44)" x="-19.00" style="text-anchor:end"></text>
+                        <text transform="rotate(81.49)" x="19.00"></text>
                     </g>
                 </g>
             </g>
             <g id="25.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-677.70,459.67 -669.98,286.83"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-676.25,427.20)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-160.73,936.53 -186.59,763.72"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-165.54,904.38)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(2.56)">
+                        <g transform="rotate(-8.51)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-87.44)" x="19.00"></text>
+                        <text transform="rotate(-278.51)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
         </g>
         <g id="26">
             <g id="26.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-652.72,478.79 -505.12,431.69"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-621.76,468.91)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-132.73,950.17 1.43,874.21"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-104.45,934.16)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(72.30)">
+                        <g transform="rotate(60.48)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-17.70)" x="19.00"></text>
+                        <text transform="rotate(-29.52)" x="19.00"></text>
                     </g>
                 </g>
             </g>
             <g id="26.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-357.51,384.60 -505.12,431.69"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-388.47,394.48)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="135.59,798.25 1.43,874.21"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(107.31,814.27)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-107.70)">
+                        <g transform="rotate(-119.52)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-17.70)" x="-19.00" style="text-anchor:end"></text>
+                        <text transform="rotate(-29.52)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
         </g>
         <g id="27">
             <g id="27.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-640.37,104.66 -496.17,231.37"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-615.96,126.11)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-192.81,577.66 -28.50,674.21"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-164.79,594.12)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(131.31)">
+                        <g transform="rotate(120.44)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(41.31)" x="19.00"></text>
+                        <text transform="rotate(30.44)" x="19.00"></text>
                     </g>
                 </g>
             </g>
             <g id="27.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-351.97,358.09 -496.17,231.37"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-376.38,336.63)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="135.81,770.77 -28.50,674.21"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(107.79,754.30)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-48.69)">
+                        <g transform="rotate(-59.56)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-318.69)" x="-19.00" style="text-anchor:end"></text>
+                        <text transform="rotate(-329.56)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
         </g>
         <g id="28">
             <g id="28.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-304.11,372.16 -106.99,342.57"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-271.97,367.33)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="184.78,773.83 363.88,696.72"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(214.63,760.98)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(81.46)">
+                        <g transform="rotate(66.71)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-8.54)" x="19.00"></text>
+                        <text transform="rotate(-23.29)" x="19.00"></text>
                     </g>
                 </g>
             </g>
             <g id="28.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="90.14,312.98 -106.99,342.57"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(58.00,317.80)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="542.98,619.61 363.88,696.72"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(513.12,632.47)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-98.54)">
+                        <g transform="rotate(-113.29)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-8.54)" x="-19.00" style="text-anchor:end"></text>
+                        <text transform="rotate(-23.29)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
         </g>
         <g id="29">
             <g id="29.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="407.05,-30.84 271.11,128.56"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(385.96,-6.11)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="764.72,209.16 672.54,396.61"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(750.37,238.32)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-139.54)">
+                        <g transform="rotate(-153.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-49.54)" x="-19.00" style="text-anchor:end"></text>
+                        <text transform="rotate(-63.82)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
             <g id="29.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="135.18,287.97 271.11,128.56"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(156.27,263.24)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="580.37,584.06 672.54,396.61"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(594.71,554.90)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(40.46)">
+                        <g transform="rotate(26.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-49.54)" x="19.00"></text>
+                        <text transform="rotate(-63.82)" x="19.00"></text>
                     </g>
                 </g>
             </g>
@@ -397,70 +397,70 @@
         <g id="30">
             <g id="30.1" class="nad-vl120to180-line"></g>
             <g id="30.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-687.37,78.61 -837.29,33.64"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-718.50,69.27)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-243.74,559.81 -396.85,537.81"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-275.91,555.19)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-73.30)">
+                        <g transform="rotate(-81.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-343.30)" x="-19.00" style="text-anchor:end"></text>
+                        <text transform="rotate(-351.82)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
             <g class="nad-glued-center">
-                <circle class="nad-vl120to180-line nad-winding" cx="-875.60" cy="22.15" r="20.00"/>
-                <circle class="nad-vl0to30-line nad-winding" cx="-856.44" cy="27.90" r="20.00"/>
+                <circle class="nad-vl120to180-line nad-winding" cx="-436.44" cy="532.12" r="20.00"/>
+                <circle class="nad-vl0to30-line nad-winding" cx="-416.64" cy="534.97" r="20.00"/>
             </g>
         </g>
         <g id="31">
             <g id="31.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="916.92,6.25 1092.10,21.87"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(949.30,9.14)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1158.58,-93.14 1274.60,-219.66"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1180.55,-117.09)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(95.09)">
+                        <g transform="rotate(42.52)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(5.09)" x="19.00"></text>
+                        <text transform="rotate(-47.48)" x="19.00"></text>
                     </g>
                 </g>
             </g>
             <g id="31.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1267.28,37.49 1092.10,21.87"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1234.91,34.60)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1390.62,-346.18 1274.60,-219.66"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1368.66,-322.23)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-84.91)">
+                        <g transform="rotate(-137.48)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-354.91)" x="-19.00" style="text-anchor:end"></text>
+                        <text transform="rotate(-47.48)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
         </g>
         <g id="32">
             <g id="32.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="862.23,0.55 657.21,-23.98"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(829.96,-3.31)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1117.56,-56.97 958.42,55.80"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(1091.05,-38.18)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-83.18)">
+                        <g transform="rotate(-125.32)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-353.18)" x="-19.00" style="text-anchor:end"></text>
+                        <text transform="rotate(-35.32)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
             <g id="32.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="452.19,-48.50 657.21,-23.98"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(484.46,-44.64)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="799.29,168.58 958.42,55.80"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(825.80,149.79)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(96.82)">
+                        <g transform="rotate(54.68)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(6.82)" x="19.00"></text>
+                        <text transform="rotate(-35.32)" x="19.00"></text>
                     </g>
                 </g>
             </g>
@@ -468,55 +468,55 @@
         <g id="33">
             <g id="33.1" class="nad-vl120to180-line"></g>
             <g id="33.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="876.19,-20.23 819.90,-121.66"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(860.42,-48.65)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1141.69,-45.42 1149.03,73.72"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1143.69,-12.98)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-29.03)">
+                        <g transform="rotate(176.48)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-299.03)" x="-19.00" style="text-anchor:end"></text>
+                        <text transform="rotate(86.48)" x="19.00"></text>
                     </g>
                 </g>
             </g>
             <g class="nad-glued-center">
-                <circle class="nad-vl120to180-line nad-winding" cx="800.49" cy="-156.64" r="20.00"/>
-                <circle class="nad-vl0to30-line nad-winding" cx="810.20" cy="-139.15" r="20.00"/>
+                <circle class="nad-vl120to180-line nad-winding" cx="1151.49" cy="113.65" r="20.00"/>
+                <circle class="nad-vl0to30-line nad-winding" cx="1150.26" cy="93.68" r="20.00"/>
             </g>
         </g>
         <g id="34">
             <g id="34.1" class="nad-vl120to180-line"></g>
             <g id="34.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="445.98,-69.41 550.01,-156.44"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(470.91,-90.26)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="803.54,191.12 940.18,225.10"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(835.08,198.96)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(50.09)">
+                        <g transform="rotate(103.97)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-39.91)" x="19.00"></text>
+                        <text transform="rotate(13.97)" x="19.00"></text>
                     </g>
                 </g>
             </g>
             <g class="nad-glued-center">
-                <circle class="nad-vl120to180-line nad-winding" cx="580.69" cy="-182.10" r="20.00"/>
-                <circle class="nad-vl0to30-line nad-winding" cx="565.35" cy="-169.27" r="20.00"/>
+                <circle class="nad-vl120to180-line nad-winding" cx="979.00" cy="234.75" r="20.00"/>
+                <circle class="nad-vl0to30-line nad-winding" cx="959.59" cy="229.93" r="20.00"/>
             </g>
         </g>
     </g>
     <g class="nad-text-edges">
-        <polyline id="0-textedge" points="68.63,-344.03 138.96,-354.58"/>
-        <polyline id="2-textedge" points="-364.11,-303.95 -293.78,-314.50"/>
-        <polyline id="4-textedge" points="-649.25,482.69 -578.92,472.14"/>
-        <polyline id="6-textedge" points="-301.64,371.79 -231.31,361.24"/>
-        <polyline id="8-textedge" points="147.00,304.45 217.34,293.90"/>
-        <polyline id="10-textedge" points="-631.36,82.06 -561.03,71.51"/>
-        <polyline id="12-textedge" points="919.20,-0.64 989.53,-11.19"/>
-        <polyline id="14-textedge" points="1324.34,35.48 1394.67,24.93"/>
-        <polyline id="16-textedge" points="454.56,-56.22 524.89,-66.77"/>
+        <polyline id="0-textedge" points="381.89,-32.58 452.22,-43.13"/>
+        <polyline id="2-textedge" points="-20.50,119.04 49.84,108.49"/>
+        <polyline id="4-textedge" points="-127.00,959.27 -56.66,948.72"/>
+        <polyline id="6-textedge" points="189.19,780.25 259.52,769.70"/>
+        <polyline id="8-textedge" points="597.90,604.29 668.23,593.74"/>
+        <polyline id="10-textedge" points="-186.85,559.27 -116.52,548.72"/>
+        <polyline id="12-textedge" points="1169.67,-77.32 1240.00,-87.87"/>
+        <polyline id="14-textedge" points="1438.88,-370.90 1509.21,-381.45"/>
+        <polyline id="16-textedge" points="806.52,180.03 876.85,169.48"/>
     </g>
     <g class="nad-text-nodes">
-        <foreignObject id="0-textnode" y="-379.58" x="138.96" height="1" width="1">
+        <foreignObject id="0-textnode" y="-68.13" x="452.22" height="1" width="1">
             <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
                 <div>VL10</div>
                 <table>
@@ -529,7 +529,7 @@
                 </table>
             </div>
         </foreignObject>
-        <foreignObject id="2-textnode" y="-339.50" x="-293.78" height="1" width="1">
+        <foreignObject id="2-textnode" y="83.49" x="49.84" height="1" width="1">
             <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
                 <div>VL11</div>
                 <table>
@@ -542,7 +542,7 @@
                 </table>
             </div>
         </foreignObject>
-        <foreignObject id="4-textnode" y="447.14" x="-578.92" height="1" width="1">
+        <foreignObject id="4-textnode" y="923.72" x="-56.66" height="1" width="1">
             <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
                 <div>VL12</div>
                 <table>
@@ -555,7 +555,7 @@
                 </table>
             </div>
         </foreignObject>
-        <foreignObject id="6-textnode" y="336.24" x="-231.31" height="1" width="1">
+        <foreignObject id="6-textnode" y="744.70" x="259.52" height="1" width="1">
             <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
                 <div>VL13</div>
                 <table>
@@ -568,7 +568,7 @@
                 </table>
             </div>
         </foreignObject>
-        <foreignObject id="8-textnode" y="268.90" x="217.34" height="1" width="1">
+        <foreignObject id="8-textnode" y="568.74" x="668.23" height="1" width="1">
             <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
                 <div>VL14</div>
                 <table>
@@ -581,7 +581,7 @@
                 </table>
             </div>
         </foreignObject>
-        <foreignObject id="10-textnode" y="46.51" x="-561.03" height="1" width="1">
+        <foreignObject id="10-textnode" y="523.72" x="-116.52" height="1" width="1">
             <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
                 <div>VL6</div>
                 <table>
@@ -594,7 +594,7 @@
                 </table>
             </div>
         </foreignObject>
-        <foreignObject id="12-textnode" y="-36.19" x="989.53" height="1" width="1">
+        <foreignObject id="12-textnode" y="-112.87" x="1240.00" height="1" width="1">
             <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
                 <div>VL7</div>
                 <table>
@@ -607,7 +607,7 @@
                 </table>
             </div>
         </foreignObject>
-        <foreignObject id="14-textnode" y="-0.07" x="1394.67" height="1" width="1">
+        <foreignObject id="14-textnode" y="-406.45" x="1509.21" height="1" width="1">
             <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
                 <div>VL8</div>
                 <table>
@@ -620,7 +620,7 @@
                 </table>
             </div>
         </foreignObject>
-        <foreignObject id="16-textnode" y="-91.77" x="524.89" height="1" width="1">
+        <foreignObject id="16-textnode" y="144.48" x="876.85" height="1" width="1">
             <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
                 <div>VL9</div>
                 <table>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter4.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter4.svg
@@ -1,0 +1,637 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="-1271.02 -554.58 2865.69 1241.72" xmlns="http://www.w3.org/2000/svg">
+    <style><![CDATA[
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-text-edges {stroke: black; stroke-width: 3; stroke-dasharray: 6,7}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightgrey)}
+.nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-width: 5; stroke-dasharray: 5,5; fill: none}
+.nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 40}
+.nad-branch-edges .nad-tie-line-edge .nad-edge-path {stroke-width: 7}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
+.nad-state-out .nad-arrow-in {visibility: hidden}
+.nad-state-in .nad-arrow-out {visibility: hidden}
+.nad-active path {stroke: none; fill: #546e7a}
+.nad-reactive path {stroke: none; fill: #0277bd}
+.nad-current path {stroke: none; fill: #bd4802}
+.nad-text-background {flood-color: #90a4aeaa}
+.nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
+.nad-text-nodes foreignObject {overflow: visible; color: black}
+.nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-legend-square {width: 20px; height: 20px; background: var(--nad-vl-color, black);}
+.nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in text {fill: #b71c1c}
+.nad-edge-infos .nad-state-out text {fill: #2e7d32}
+.nad-disconnected {--nad-vl-color: #808080}
+.nad-vl0to30-line {--nad-vl-color: #afb42b}
+.nad-vl0to30-0 {--nad-vl-color: #827717}
+.nad-vl0to30-1 {--nad-vl-color: #d4e157}
+.nad-vl0to30-2 {--nad-vl-color: #e6ee9c}
+.nad-vl0to30-3 {--nad-vl-color: #c0ca33}
+.nad-vl0to30-4 {--nad-vl-color: #f0fc83}
+.nad-vl0to30-5 {--nad-vl-color: #9e9d24}
+.nad-vl0to30-6 {--nad-vl-color: #cddc39}
+.nad-vl0to30-7 {--nad-vl-color: #dce775}
+.nad-vl0to30-8 {--nad-vl-color: #ddfc88}
+.nad-vl30to50-line {--nad-vl-color: #ef9a9a}
+.nad-vl30to50-0 {--nad-vl-color: #c2185b}
+.nad-vl30to50-1 {--nad-vl-color: #f06292}
+.nad-vl30to50-2 {--nad-vl-color: #d81b60}
+.nad-vl30to50-3 {--nad-vl-color: #ec407a}
+.nad-vl30to50-4 {--nad-vl-color: #880e4f}
+.nad-vl30to50-5 {--nad-vl-color: #ad1457}
+.nad-vl30to50-6 {--nad-vl-color: #e91e63}
+.nad-vl30to50-7 {--nad-vl-color: #f48fb1}
+.nad-vl30to50-8 {--nad-vl-color: #f8bbd0}
+.nad-vl50to70-line {--nad-vl-color: #9c27b0}
+.nad-vl50to70-0 {--nad-vl-color: #7b1fa2}
+.nad-vl50to70-1 {--nad-vl-color: #ba68c8}
+.nad-vl50to70-2 {--nad-vl-color: #512da8}
+.nad-vl50to70-3 {--nad-vl-color: #ab47bc}
+.nad-vl50to70-4 {--nad-vl-color: #e1bee7}
+.nad-vl50to70-5 {--nad-vl-color: #6a1b9a}
+.nad-vl50to70-6 {--nad-vl-color: #4a148c}
+.nad-vl50to70-7 {--nad-vl-color: #ce93d8}
+.nad-vl50to70-8 {--nad-vl-color: #9575cd}
+.nad-vl70to120-line {--nad-vl-color: #e65100}
+.nad-vl70to120-0 {--nad-vl-color: #fb8c00}
+.nad-vl70to120-1 {--nad-vl-color: #ffb74d}
+.nad-vl70to120-2 {--nad-vl-color: #f57c00}
+.nad-vl70to120-3 {--nad-vl-color: #ffa726}
+.nad-vl70to120-4 {--nad-vl-color: #ffe0b2}
+.nad-vl70to120-5 {--nad-vl-color: #ef6c00}
+.nad-vl70to120-6 {--nad-vl-color: #ff9800}
+.nad-vl70to120-7 {--nad-vl-color: #ffcc80}
+.nad-vl70to120-8 {--nad-vl-color: #fff3e0}
+.nad-vl120to180-line {--nad-vl-color: #00ACC1}
+.nad-vl120to180-0 {--nad-vl-color: #4fc3f7}
+.nad-vl120to180-1 {--nad-vl-color: #01579b}
+.nad-vl120to180-2 {--nad-vl-color: #b3e5fc}
+.nad-vl120to180-3 {--nad-vl-color: #039be5}
+.nad-vl120to180-4 {--nad-vl-color: #81d4fa}
+.nad-vl120to180-5 {--nad-vl-color: #0288d1}
+.nad-vl120to180-6 {--nad-vl-color: #29b6f6}
+.nad-vl120to180-7 {--nad-vl-color: #0277bd}
+.nad-vl120to180-8 {--nad-vl-color: #03a9f4}
+.nad-vl180to300-line {--nad-vl-color: #2e7d32}
+.nad-vl180to300-0 {--nad-vl-color: #81c784}
+.nad-vl180to300-1 {--nad-vl-color: #558b2f}
+.nad-vl180to300-2 {--nad-vl-color: #c8e6c9}
+.nad-vl180to300-3 {--nad-vl-color: #43a047}
+.nad-vl180to300-4 {--nad-vl-color: #a5d6a7}
+.nad-vl180to300-5 {--nad-vl-color: #388e3c}
+.nad-vl180to300-6 {--nad-vl-color: #66bb6a}
+.nad-vl180to300-7 {--nad-vl-color: #1b5e20}
+.nad-vl180to300-8 {--nad-vl-color: #4caf50}
+.nad-vl300to500-line {--nad-vl-color: #d32f2f}
+.nad-vl300to500-0 {--nad-vl-color: #ef5350}
+.nad-vl300to500-1 {--nad-vl-color: #ef9a9a}
+.nad-vl300to500-2 {--nad-vl-color: #b71c1c}
+.nad-vl300to500-3 {--nad-vl-color: #e57373}
+.nad-vl300to500-4 {--nad-vl-color: #e53935}
+.nad-vl300to500-5 {--nad-vl-color: #ff8a80}
+.nad-vl300to500-6 {--nad-vl-color: #f44336}
+.nad-vl300to500-7 {--nad-vl-color: #ffcdd2}
+.nad-vl300to500-8 {--nad-vl-color: #c62828}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
+.nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
+.nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+
+@keyframes line-blink {
+  0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}
+  40% {stroke: #FFEB3B; stroke-width: 15}
+}
+@keyframes node-over-blink {
+  0%, 80%, 100% {stroke: white; stroke-width: 0}
+  40% {stroke: #ff5722; stroke-width: 15}
+}
+@keyframes node-under-blink {
+  0%, 80%, 100% {stroke: white; stroke-width: 0}
+  40% {stroke: #00BCD4; stroke-width: 15}
+}
+]]></style>
+    <metadata>
+        <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
+            <nad:busNodes>
+                <nad:busNode svgId="1" equipmentId="VL10_0"/>
+                <nad:busNode svgId="3" equipmentId="VL11_0"/>
+                <nad:busNode svgId="5" equipmentId="VL12_0"/>
+                <nad:busNode svgId="7" equipmentId="VL13_0"/>
+                <nad:busNode svgId="9" equipmentId="VL14_0"/>
+                <nad:busNode svgId="11" equipmentId="VL6_0"/>
+                <nad:busNode svgId="13" equipmentId="VL7_0"/>
+                <nad:busNode svgId="15" equipmentId="VL8_0"/>
+                <nad:busNode svgId="17" equipmentId="VL9_0"/>
+                <nad:busNode svgId="19" equipmentId="VL4_0"/>
+                <nad:busNode svgId="21" equipmentId="VL5_0"/>
+            </nad:busNodes>
+            <nad:nodes>
+                <nad:node svgId="0" equipmentId="VL10" x="38.96" y="-339.58"/>
+                <nad:node svgId="2" equipmentId="VL11" x="-393.78" y="-299.50"/>
+                <nad:node svgId="4" equipmentId="VL12" x="-678.92" y="487.14"/>
+                <nad:node svgId="6" equipmentId="VL13" x="-331.31" y="376.24"/>
+                <nad:node svgId="8" equipmentId="VL14" x="117.34" y="308.90"/>
+                <nad:node svgId="10" equipmentId="VL6" x="-661.03" y="86.51"/>
+                <nad:node svgId="12" equipmentId="VL7" x="889.53" y="3.81"/>
+                <nad:node svgId="14" equipmentId="VL8" x="1294.67" y="39.93"/>
+                <nad:node svgId="16" equipmentId="VL9" x="424.89" y="-51.77"/>
+                <nad:node svgId="18" equipmentId="VL4" x="721.16" y="-299.60"/>
+                <nad:node svgId="20" equipmentId="VL5" x="-1071.02" y="-36.46"/>
+            </nad:nodes>
+            <nad:edges>
+                <nad:edge svgId="22" equipmentId="L9-10-1" node1="16" node2="0"/>
+                <nad:edge svgId="23" equipmentId="L10-11-1" node1="0" node2="2"/>
+                <nad:edge svgId="24" equipmentId="L6-11-1" node1="10" node2="2"/>
+                <nad:edge svgId="25" equipmentId="L6-12-1" node1="10" node2="4"/>
+                <nad:edge svgId="26" equipmentId="L12-13-1" node1="4" node2="6"/>
+                <nad:edge svgId="27" equipmentId="L6-13-1" node1="10" node2="6"/>
+                <nad:edge svgId="28" equipmentId="L13-14-1" node1="6" node2="8"/>
+                <nad:edge svgId="29" equipmentId="L9-14-1" node1="16" node2="8"/>
+                <nad:edge svgId="30" equipmentId="T5-6-1" node1="20" node2="10"/>
+                <nad:edge svgId="31" equipmentId="L7-8-1" node1="12" node2="14"/>
+                <nad:edge svgId="32" equipmentId="L7-9-1" node1="12" node2="16"/>
+                <nad:edge svgId="33" equipmentId="T4-7-1" node1="18" node2="12"/>
+                <nad:edge svgId="34" equipmentId="T4-9-1" node1="18" node2="16"/>
+            </nad:edges>
+        </nad:nad>
+    </metadata>
+    <g class="nad-vl-nodes">
+        <g transform="translate(38.96,-339.58)" id="0">
+            <circle r="27.50" id="1" class="nad-vl0to30-0 nad-busnode"/>
+        </g>
+        <g transform="translate(-393.78,-299.50)" id="2">
+            <circle r="27.50" id="3" class="nad-vl0to30-0 nad-busnode"/>
+        </g>
+        <g transform="translate(-678.92,487.14)" id="4">
+            <circle r="27.50" id="5" class="nad-vl0to30-0 nad-busnode"/>
+        </g>
+        <g transform="translate(-331.31,376.24)" id="6">
+            <circle r="27.50" id="7" class="nad-vl0to30-0 nad-busnode"/>
+        </g>
+        <g transform="translate(117.34,308.90)" id="8">
+            <circle r="27.50" id="9" class="nad-vl0to30-0 nad-busnode"/>
+        </g>
+        <g transform="translate(-661.03,86.51)" id="10">
+            <circle r="27.50" id="11" class="nad-vl0to30-0 nad-busnode"/>
+        </g>
+        <g transform="translate(889.53,3.81)" id="12">
+            <circle r="27.50" id="13" class="nad-vl0to30-0 nad-busnode"/>
+        </g>
+        <g transform="translate(1294.67,39.93)" id="14">
+            <circle r="27.50" id="15" class="nad-vl0to30-0 nad-busnode"/>
+        </g>
+        <g transform="translate(424.89,-51.77)" id="16">
+            <circle r="27.50" id="17" class="nad-vl0to30-0 nad-busnode"/>
+        </g>
+    </g>
+    <g class="nad-branch-edges">
+        <g id="22">
+            <g id="22.1" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="402.84,-68.21 231.92,-195.67"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(376.79,-87.64)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-53.29)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-323.29)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="22.2" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="61.00,-323.14 231.92,-195.67"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(87.06,-303.71)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(126.71)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(36.71)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="23">
+            <g id="23.1" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="11.58,-337.04 -177.41,-319.54"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-20.79,-334.05)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-95.29)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-5.29)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="23.2" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-366.40,-302.04 -177.41,-319.54"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-334.04,-305.03)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(84.71)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-5.29)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="24">
+            <g id="24.1" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-645.37,63.90 -527.41,-106.50"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-626.87,37.18)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(34.70)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-55.30)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="24.2" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-409.44,-276.89 -527.41,-106.50"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-427.94,-250.17)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-145.30)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-55.30)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="25">
+            <g id="25.1" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-662.25,113.98 -669.98,286.83"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-663.70,146.45)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-177.44)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-87.44)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="25.2" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-677.70,459.67 -669.98,286.83"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-676.25,427.20)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(2.56)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-87.44)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="26">
+            <g id="26.1" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-652.72,478.79 -505.12,431.69"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-621.76,468.91)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(72.30)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-17.70)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="26.2" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-357.51,384.60 -505.12,431.69"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-388.47,394.48)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-107.70)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-17.70)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="27">
+            <g id="27.1" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-640.37,104.66 -496.17,231.37"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-615.96,126.11)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(131.31)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(41.31)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="27.2" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-351.97,358.09 -496.17,231.37"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-376.38,336.63)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-48.69)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-318.69)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="28">
+            <g id="28.1" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-304.11,372.16 -106.99,342.57"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-271.97,367.33)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(81.46)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-8.54)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="28.2" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="90.14,312.98 -106.99,342.57"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(58.00,317.80)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-98.54)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-8.54)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="29">
+            <g id="29.1" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="407.05,-30.84 271.11,128.56"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(385.96,-6.11)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-139.54)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-49.54)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="29.2" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="135.18,287.97 271.11,128.56"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(156.27,263.24)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(40.46)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-49.54)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="30">
+            <g id="30.1" class="nad-vl120to180-line"></g>
+            <g id="30.2" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-687.37,78.61 -837.29,33.64"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-718.50,69.27)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-73.30)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-343.30)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-glued-center">
+                <circle class="nad-vl120to180-line nad-winding" cx="-875.60" cy="22.15" r="20.00"/>
+                <circle class="nad-vl0to30-line nad-winding" cx="-856.44" cy="27.90" r="20.00"/>
+            </g>
+        </g>
+        <g id="31">
+            <g id="31.1" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="916.92,6.25 1092.10,21.87"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(949.30,9.14)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(95.09)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(5.09)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="31.2" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1267.28,37.49 1092.10,21.87"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(1234.91,34.60)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-84.91)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-354.91)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="32">
+            <g id="32.1" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="862.23,0.55 657.21,-23.98"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(829.96,-3.31)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-83.18)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-353.18)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="32.2" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="452.19,-48.50 657.21,-23.98"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(484.46,-44.64)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(96.82)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(6.82)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="33">
+            <g id="33.1" class="nad-vl120to180-line"></g>
+            <g id="33.2" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="876.19,-20.23 819.90,-121.66"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(860.42,-48.65)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-29.03)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-299.03)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-glued-center">
+                <circle class="nad-vl120to180-line nad-winding" cx="800.49" cy="-156.64" r="20.00"/>
+                <circle class="nad-vl0to30-line nad-winding" cx="810.20" cy="-139.15" r="20.00"/>
+            </g>
+        </g>
+        <g id="34">
+            <g id="34.1" class="nad-vl120to180-line"></g>
+            <g id="34.2" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="445.98,-69.41 550.01,-156.44"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(470.91,-90.26)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(50.09)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-39.91)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-glued-center">
+                <circle class="nad-vl120to180-line nad-winding" cx="580.69" cy="-182.10" r="20.00"/>
+                <circle class="nad-vl0to30-line nad-winding" cx="565.35" cy="-169.27" r="20.00"/>
+            </g>
+        </g>
+    </g>
+    <g class="nad-text-edges">
+        <polyline id="0-textedge" points="68.63,-344.03 138.96,-354.58"/>
+        <polyline id="2-textedge" points="-364.11,-303.95 -293.78,-314.50"/>
+        <polyline id="4-textedge" points="-649.25,482.69 -578.92,472.14"/>
+        <polyline id="6-textedge" points="-301.64,371.79 -231.31,361.24"/>
+        <polyline id="8-textedge" points="147.00,304.45 217.34,293.90"/>
+        <polyline id="10-textedge" points="-631.36,82.06 -561.03,71.51"/>
+        <polyline id="12-textedge" points="919.20,-0.64 989.53,-11.19"/>
+        <polyline id="14-textedge" points="1324.34,35.48 1394.67,24.93"/>
+        <polyline id="16-textedge" points="454.56,-56.22 524.89,-66.77"/>
+    </g>
+    <g class="nad-text-nodes">
+        <foreignObject id="0-textnode" y="-379.58" x="138.96" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>VL10</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-vl0to30-0 nad-legend-square"/>
+                        </td>
+                        <td>12.6 kV / -15.1°</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+        <foreignObject id="2-textnode" y="-339.50" x="-293.78" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>VL11</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-vl0to30-0 nad-legend-square"/>
+                        </td>
+                        <td>12.7 kV / -14.8°</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+        <foreignObject id="4-textnode" y="447.14" x="-578.92" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>VL12</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-vl0to30-0 nad-legend-square"/>
+                        </td>
+                        <td>12.7 kV / -15.1°</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+        <foreignObject id="6-textnode" y="336.24" x="-231.31" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>VL13</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-vl0to30-0 nad-legend-square"/>
+                        </td>
+                        <td>12.6 kV / -15.2°</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+        <foreignObject id="8-textnode" y="268.90" x="217.34" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>VL14</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-vl0to30-0 nad-legend-square"/>
+                        </td>
+                        <td>12.4 kV / -16.0°</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+        <foreignObject id="10-textnode" y="46.51" x="-561.03" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>VL6</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-vl0to30-0 nad-legend-square"/>
+                        </td>
+                        <td>12.8 kV / -14.2°</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+        <foreignObject id="12-textnode" y="-36.19" x="989.53" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>VL7</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-vl0to30-0 nad-legend-square"/>
+                        </td>
+                        <td>14.9 kV / -13.4°</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+        <foreignObject id="14-textnode" y="-0.07" x="1394.67" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>VL8</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-vl0to30-0 nad-legend-square"/>
+                        </td>
+                        <td>21.8 kV / -13.4°</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+        <foreignObject id="16-textnode" y="-91.77" x="524.89" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>VL9</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-vl0to30-0 nad-legend-square"/>
+                        </td>
+                        <td>12.7 kV / -14.9°</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+    </g>
+</svg>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter5.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter5.svg
@@ -1,0 +1,516 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="-255.23 -557.48 1451.16 1614.08" xmlns="http://www.w3.org/2000/svg">
+    <style><![CDATA[
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-text-edges {stroke: black; stroke-width: 3; stroke-dasharray: 6,7}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightgrey)}
+.nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-width: 5; stroke-dasharray: 5,5; fill: none}
+.nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 40}
+.nad-branch-edges .nad-tie-line-edge .nad-edge-path {stroke-width: 7}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
+.nad-state-out .nad-arrow-in {visibility: hidden}
+.nad-state-in .nad-arrow-out {visibility: hidden}
+.nad-active path {stroke: none; fill: #546e7a}
+.nad-reactive path {stroke: none; fill: #0277bd}
+.nad-current path {stroke: none; fill: #bd4802}
+.nad-text-background {flood-color: #90a4aeaa}
+.nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
+.nad-text-nodes foreignObject {overflow: visible; color: black}
+.nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-legend-square {width: 20px; height: 20px; background: var(--nad-vl-color, black);}
+.nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in text {fill: #b71c1c}
+.nad-edge-infos .nad-state-out text {fill: #2e7d32}
+.nad-disconnected {--nad-vl-color: #808080}
+.nad-vl0to30-line {--nad-vl-color: #afb42b}
+.nad-vl0to30-0 {--nad-vl-color: #827717}
+.nad-vl0to30-1 {--nad-vl-color: #d4e157}
+.nad-vl0to30-2 {--nad-vl-color: #e6ee9c}
+.nad-vl0to30-3 {--nad-vl-color: #c0ca33}
+.nad-vl0to30-4 {--nad-vl-color: #f0fc83}
+.nad-vl0to30-5 {--nad-vl-color: #9e9d24}
+.nad-vl0to30-6 {--nad-vl-color: #cddc39}
+.nad-vl0to30-7 {--nad-vl-color: #dce775}
+.nad-vl0to30-8 {--nad-vl-color: #ddfc88}
+.nad-vl30to50-line {--nad-vl-color: #ef9a9a}
+.nad-vl30to50-0 {--nad-vl-color: #c2185b}
+.nad-vl30to50-1 {--nad-vl-color: #f06292}
+.nad-vl30to50-2 {--nad-vl-color: #d81b60}
+.nad-vl30to50-3 {--nad-vl-color: #ec407a}
+.nad-vl30to50-4 {--nad-vl-color: #880e4f}
+.nad-vl30to50-5 {--nad-vl-color: #ad1457}
+.nad-vl30to50-6 {--nad-vl-color: #e91e63}
+.nad-vl30to50-7 {--nad-vl-color: #f48fb1}
+.nad-vl30to50-8 {--nad-vl-color: #f8bbd0}
+.nad-vl50to70-line {--nad-vl-color: #9c27b0}
+.nad-vl50to70-0 {--nad-vl-color: #7b1fa2}
+.nad-vl50to70-1 {--nad-vl-color: #ba68c8}
+.nad-vl50to70-2 {--nad-vl-color: #512da8}
+.nad-vl50to70-3 {--nad-vl-color: #ab47bc}
+.nad-vl50to70-4 {--nad-vl-color: #e1bee7}
+.nad-vl50to70-5 {--nad-vl-color: #6a1b9a}
+.nad-vl50to70-6 {--nad-vl-color: #4a148c}
+.nad-vl50to70-7 {--nad-vl-color: #ce93d8}
+.nad-vl50to70-8 {--nad-vl-color: #9575cd}
+.nad-vl70to120-line {--nad-vl-color: #e65100}
+.nad-vl70to120-0 {--nad-vl-color: #fb8c00}
+.nad-vl70to120-1 {--nad-vl-color: #ffb74d}
+.nad-vl70to120-2 {--nad-vl-color: #f57c00}
+.nad-vl70to120-3 {--nad-vl-color: #ffa726}
+.nad-vl70to120-4 {--nad-vl-color: #ffe0b2}
+.nad-vl70to120-5 {--nad-vl-color: #ef6c00}
+.nad-vl70to120-6 {--nad-vl-color: #ff9800}
+.nad-vl70to120-7 {--nad-vl-color: #ffcc80}
+.nad-vl70to120-8 {--nad-vl-color: #fff3e0}
+.nad-vl120to180-line {--nad-vl-color: #00ACC1}
+.nad-vl120to180-0 {--nad-vl-color: #4fc3f7}
+.nad-vl120to180-1 {--nad-vl-color: #01579b}
+.nad-vl120to180-2 {--nad-vl-color: #b3e5fc}
+.nad-vl120to180-3 {--nad-vl-color: #039be5}
+.nad-vl120to180-4 {--nad-vl-color: #81d4fa}
+.nad-vl120to180-5 {--nad-vl-color: #0288d1}
+.nad-vl120to180-6 {--nad-vl-color: #29b6f6}
+.nad-vl120to180-7 {--nad-vl-color: #0277bd}
+.nad-vl120to180-8 {--nad-vl-color: #03a9f4}
+.nad-vl180to300-line {--nad-vl-color: #2e7d32}
+.nad-vl180to300-0 {--nad-vl-color: #81c784}
+.nad-vl180to300-1 {--nad-vl-color: #558b2f}
+.nad-vl180to300-2 {--nad-vl-color: #c8e6c9}
+.nad-vl180to300-3 {--nad-vl-color: #43a047}
+.nad-vl180to300-4 {--nad-vl-color: #a5d6a7}
+.nad-vl180to300-5 {--nad-vl-color: #388e3c}
+.nad-vl180to300-6 {--nad-vl-color: #66bb6a}
+.nad-vl180to300-7 {--nad-vl-color: #1b5e20}
+.nad-vl180to300-8 {--nad-vl-color: #4caf50}
+.nad-vl300to500-line {--nad-vl-color: #d32f2f}
+.nad-vl300to500-0 {--nad-vl-color: #ef5350}
+.nad-vl300to500-1 {--nad-vl-color: #ef9a9a}
+.nad-vl300to500-2 {--nad-vl-color: #b71c1c}
+.nad-vl300to500-3 {--nad-vl-color: #e57373}
+.nad-vl300to500-4 {--nad-vl-color: #e53935}
+.nad-vl300to500-5 {--nad-vl-color: #ff8a80}
+.nad-vl300to500-6 {--nad-vl-color: #f44336}
+.nad-vl300to500-7 {--nad-vl-color: #ffcdd2}
+.nad-vl300to500-8 {--nad-vl-color: #c62828}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
+.nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
+.nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+
+@keyframes line-blink {
+  0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}
+  40% {stroke: #FFEB3B; stroke-width: 15}
+}
+@keyframes node-over-blink {
+  0%, 80%, 100% {stroke: white; stroke-width: 0}
+  40% {stroke: #ff5722; stroke-width: 15}
+}
+@keyframes node-under-blink {
+  0%, 80%, 100% {stroke: white; stroke-width: 0}
+  40% {stroke: #00BCD4; stroke-width: 15}
+}
+]]></style>
+    <metadata>
+        <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
+            <nad:busNodes>
+                <nad:busNode svgId="1" equipmentId="VL1_0"/>
+                <nad:busNode svgId="3" equipmentId="VL2_0"/>
+                <nad:busNode svgId="5" equipmentId="VL3_0"/>
+                <nad:busNode svgId="7" equipmentId="VL4_0"/>
+                <nad:busNode svgId="9" equipmentId="VL5_0"/>
+                <nad:busNode svgId="11" equipmentId="VL8_0"/>
+                <nad:busNode svgId="13" equipmentId="VL6_0"/>
+                <nad:busNode svgId="15" equipmentId="VL7_0"/>
+                <nad:busNode svgId="17" equipmentId="VL9_0"/>
+            </nad:busNodes>
+            <nad:nodes>
+                <nad:node svgId="0" equipmentId="VL1" x="23.85" y="710.79"/>
+                <nad:node svgId="2" equipmentId="VL2" x="46.58" y="332.54"/>
+                <nad:node svgId="4" equipmentId="VL3" x="-55.23" y="-26.22"/>
+                <nad:node svgId="6" equipmentId="VL4" x="352.75" y="79.13"/>
+                <nad:node svgId="8" equipmentId="VL5" x="389.84" y="509.69"/>
+                <nad:node svgId="10" equipmentId="VL8" x="810.79" y="856.60"/>
+                <nad:node svgId="12" equipmentId="VL6" x="995.93" y="543.20"/>
+                <nad:node svgId="14" equipmentId="VL7" x="735.37" y="321.12"/>
+                <nad:node svgId="16" equipmentId="VL9" x="483.38" y="-357.48"/>
+            </nad:nodes>
+            <nad:edges>
+                <nad:edge svgId="18" equipmentId="L1-2-1" node1="0" node2="2"/>
+                <nad:edge svgId="19" equipmentId="L1-5-1" node1="0" node2="8"/>
+                <nad:edge svgId="20" equipmentId="L2-3-1" node1="2" node2="4"/>
+                <nad:edge svgId="21" equipmentId="L2-4-1" node1="2" node2="6"/>
+                <nad:edge svgId="22" equipmentId="L2-5-1" node1="2" node2="8"/>
+                <nad:edge svgId="23" equipmentId="L3-4-1" node1="4" node2="6"/>
+                <nad:edge svgId="24" equipmentId="L4-5-1" node1="6" node2="8"/>
+                <nad:edge svgId="25" equipmentId="T4-7-1" node1="6" node2="14"/>
+                <nad:edge svgId="26" equipmentId="T4-9-1" node1="6" node2="16"/>
+                <nad:edge svgId="27" equipmentId="T5-6-1" node1="8" node2="12"/>
+                <nad:edge svgId="28" equipmentId="L7-8-1" node1="14" node2="10"/>
+            </nad:edges>
+        </nad:nad>
+    </metadata>
+    <g class="nad-vl-nodes">
+        <g transform="translate(23.85,710.79)" id="0">
+            <circle r="27.50" id="1" class="nad-vl120to180-0 nad-busnode"/>
+        </g>
+        <g transform="translate(46.58,332.54)" id="2">
+            <circle r="27.50" id="3" class="nad-vl120to180-0 nad-busnode"/>
+        </g>
+        <g transform="translate(-55.23,-26.22)" id="4">
+            <circle r="27.50" id="5" class="nad-vl120to180-0 nad-busnode"/>
+        </g>
+        <g transform="translate(352.75,79.13)" id="6">
+            <circle r="27.50" id="7" class="nad-vl120to180-0 nad-busnode"/>
+        </g>
+        <g transform="translate(389.84,509.69)" id="8">
+            <circle r="27.50" id="9" class="nad-vl120to180-0 nad-busnode"/>
+        </g>
+        <g transform="translate(810.79,856.60)" id="10">
+            <circle r="27.50" id="11" class="nad-vl0to30-0 nad-busnode"/>
+        </g>
+    </g>
+    <g class="nad-branch-edges">
+        <g id="18">
+            <g id="18.1" class="nad-vl120to180-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="25.50,683.34 35.21,521.67"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(27.45,650.90)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(3.44)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-86.56)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="18.2" class="nad-vl120to180-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="44.93,359.99 35.21,521.67"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(42.98,392.43)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-176.56)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-86.56)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="19">
+            <g id="19.1" class="nad-vl120to180-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="47.95,697.55 206.85,610.24"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(76.44,681.90)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(61.21)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-28.79)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="19.2" class="nad-vl120to180-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="365.74,522.94 206.85,610.24"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(337.26,538.59)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-118.79)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-28.79)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="20">
+            <g id="20.1" class="nad-vl120to180-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="39.07,306.08 -4.33,153.16"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(30.20,274.82)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-15.84)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-285.84)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="20.2" class="nad-vl120to180-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-47.72,0.23 -4.33,153.16"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-38.85,31.50)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(164.16)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(74.16)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="21">
+            <g id="21.1" class="nad-vl120to180-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="67.76,315.01 199.66,205.83"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(92.80,294.28)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(50.39)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-39.61)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="21.2" class="nad-vl120to180-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="331.56,96.66 199.66,205.83"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(306.52,117.38)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-129.61)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-39.61)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="22">
+            <g id="22.1" class="nad-vl120to180-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="71.01,345.15 218.21,421.12"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(99.89,360.06)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(117.30)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(27.30)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="22.2" class="nad-vl120to180-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="365.40,497.08 218.21,421.12"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(336.52,482.18)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-62.70)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-332.70)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="23">
+            <g id="23.1" class="nad-vl120to180-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-28.60,-19.35 148.76,26.45"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(2.86,-11.22)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(104.48)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(14.48)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="23.2" class="nad-vl120to180-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="326.12,72.25 148.76,26.45"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(294.65,64.12)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-75.52)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-345.52)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="24">
+            <g id="24.1" class="nad-vl120to180-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="355.11,106.52 371.29,294.41"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(357.90,138.90)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(175.08)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(85.08)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="24.2" class="nad-vl120to180-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="387.48,482.30 371.29,294.41"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(384.69,449.92)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-4.92)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-274.92)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="25">
+            <g id="25.1" class="nad-vl120to180-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="375.99,93.83 518.70,184.09"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(403.46,111.20)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(122.31)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(32.31)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="25.2" class="nad-vl0to30-line"></g>
+            <g class="nad-glued-center">
+                <circle class="nad-vl120to180-line nad-winding" cx="535.61" cy="194.78" r="20.00"/>
+                <circle class="nad-vl0to30-line nad-winding" cx="552.51" cy="205.47" r="20.00"/>
+            </g>
+        </g>
+        <g id="26">
+            <g id="26.1" class="nad-vl120to180-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="360.63,52.78 409.46,-110.43"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(369.95,21.64)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(16.66)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-73.34)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="26.2" class="nad-vl0to30-line"></g>
+            <g class="nad-glued-center">
+                <circle class="nad-vl120to180-line nad-winding" cx="415.20" cy="-129.59" r="20.00"/>
+                <circle class="nad-vl0to30-line nad-winding" cx="420.93" cy="-148.76" r="20.00"/>
+            </g>
+        </g>
+        <g id="27">
+            <g id="27.1" class="nad-vl120to180-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="417.30,511.21 662.93,524.79"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(449.75,513.01)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(93.16)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(3.16)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="27.2" class="nad-vl0to30-line"></g>
+            <g class="nad-glued-center">
+                <circle class="nad-vl120to180-line nad-winding" cx="682.90" cy="525.89" r="20.00"/>
+                <circle class="nad-vl0to30-line nad-winding" cx="702.87" cy="527.00" r="20.00"/>
+            </g>
+        </g>
+        <g id="28">
+            <g id="28.2" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="806.95,829.37 773.08,588.86"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(802.42,797.19)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-8.02)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-278.02)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+    <g class="nad-text-edges">
+        <polyline id="0-textedge" points="53.52,706.34 123.85,695.79"/>
+        <polyline id="2-textedge" points="76.24,328.09 146.58,317.54"/>
+        <polyline id="4-textedge" points="-25.56,-30.67 44.77,-41.22"/>
+        <polyline id="6-textedge" points="382.41,74.68 452.75,64.13"/>
+        <polyline id="8-textedge" points="419.51,505.24 489.84,494.69"/>
+        <polyline id="10-textedge" points="840.46,852.15 910.79,841.60"/>
+    </g>
+    <g class="nad-text-nodes">
+        <foreignObject id="0-textnode" y="670.79" x="123.85" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>VL1</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-vl120to180-0 nad-legend-square"/>
+                        </td>
+                        <td>143.1 kV / 0.0°</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+        <foreignObject id="2-textnode" y="292.54" x="146.58" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>VL2</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-vl120to180-0 nad-legend-square"/>
+                        </td>
+                        <td>141.1 kV / -5.0°</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+        <foreignObject id="4-textnode" y="-66.22" x="44.77" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>VL3</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-vl120to180-0 nad-legend-square"/>
+                        </td>
+                        <td>136.3 kV / -12.7°</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+        <foreignObject id="6-textnode" y="39.13" x="452.75" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>VL4</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-vl120to180-0 nad-legend-square"/>
+                        </td>
+                        <td>137.6 kV / -10.3°</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+        <foreignObject id="8-textnode" y="469.69" x="489.84" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>VL5</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-vl120to180-0 nad-legend-square"/>
+                        </td>
+                        <td>137.7 kV / -8.8°</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+        <foreignObject id="10-textnode" y="816.60" x="910.79" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>VL8</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-vl0to30-0 nad-legend-square"/>
+                        </td>
+                        <td>21.8 kV / -13.4°</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+    </g>
+</svg>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No


**What kind of change does this PR introduce?**
Feature


**What is the current behavior?**
It is not possible to use a nominal voltage filter on NAD with no voltage level id list.


**What is the new behavior (if this is a feature change)?**
It is possible to use a nominal voltage filter with no voltage level id list.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No