### PR TITLE
Remove pathfinder layoutparameters

### DIFF
--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LayoutParameters.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LayoutParameters.java
@@ -49,7 +49,6 @@ public class LayoutParameters {
     private String cgmesDiagramName = null;
     private boolean cgmesUseNames = true;
     private int zoneLayoutSnakeLinePadding = 90;
-    private PathFinderType zoneLayoutPathFinder = PathFinderType.DIJKSTRA;
 
     @JsonIgnore
     private Map<String, ComponentSize> componentsSize;
@@ -80,8 +79,7 @@ public class LayoutParameters {
                             @JsonProperty("cgmesScaleFactor") double cgmesScaleFactor,
                             @JsonProperty("cgmesDiagramName") String cgmesDiagramName,
                             @JsonProperty("cgmesUseNames") boolean cgmesUseNames,
-                            @JsonProperty("zoneLayoutSnakeLinePadding") int zoneLayoutSnakeLinePadding,
-                            @JsonProperty("zoneLayoutPathFinder") PathFinderType zoneLayoutPathFinder) {
+                            @JsonProperty("zoneLayoutSnakeLinePadding") int zoneLayoutSnakeLinePadding) {
 
         this.verticalSpaceBus = verticalSpaceBus;
         this.horizontalBusPadding = horizontalBusPadding;
@@ -105,7 +103,6 @@ public class LayoutParameters {
         this.cgmesScaleFactor = cgmesScaleFactor;
         this.cgmesUseNames = cgmesUseNames;
         this.zoneLayoutSnakeLinePadding = zoneLayoutSnakeLinePadding;
-        this.zoneLayoutPathFinder = zoneLayoutPathFinder;
     }
 
     public LayoutParameters(LayoutParameters other) {
@@ -133,7 +130,6 @@ public class LayoutParameters {
         cgmesDiagramName = other.cgmesDiagramName;
         cgmesUseNames = other.cgmesUseNames;
         zoneLayoutSnakeLinePadding = other.zoneLayoutSnakeLinePadding;
-        zoneLayoutPathFinder = other.zoneLayoutPathFinder;
     }
 
     public double getVerticalSpaceBus() {
@@ -345,19 +341,6 @@ public class LayoutParameters {
     public LayoutParameters setZoneLayoutSnakeLinePadding(int zoneLayoutSnakeLinePadding) {
         this.zoneLayoutSnakeLinePadding = zoneLayoutSnakeLinePadding;
         return this;
-    }
-
-    public PathFinderType getZoneLayoutPathFinder() {
-        return zoneLayoutPathFinder;
-    }
-
-    public LayoutParameters setZoneLayoutPathFinder(PathFinderType zoneLayoutPathFinder) {
-        this.zoneLayoutPathFinder = zoneLayoutPathFinder;
-        return this;
-    }
-
-    public enum PathFinderType {
-        DIJKSTRA
     }
 
     public enum Alignment {

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/layout/LayoutParametersTest.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/layout/LayoutParametersTest.java
@@ -44,8 +44,7 @@ class LayoutParametersTest {
                 .setCgmesScaleFactor(2)
                 .setCgmesDiagramName("diag")
                 .setCgmesUseNames(true)
-                .setZoneLayoutSnakeLinePadding(120)
-                .setZoneLayoutPathFinder(LayoutParameters.PathFinderType.DIJKSTRA);
+                .setZoneLayoutSnakeLinePadding(120);
 
         layoutParameters.setComponentsSize(null);
 
@@ -72,7 +71,6 @@ class LayoutParametersTest {
         assertEquals(layoutParameters.getCgmesDiagramName(), layoutParameters2.getCgmesDiagramName());
         assertEquals(layoutParameters.isCgmesUseNames(), layoutParameters2.isCgmesUseNames());
         assertEquals(layoutParameters.getZoneLayoutSnakeLinePadding(), layoutParameters2.getZoneLayoutSnakeLinePadding());
-        assertEquals(layoutParameters.getZoneLayoutPathFinder(), layoutParameters2.getZoneLayoutPathFinder());
     }
 
     @Test

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/TestSldClassSubstationMetadata.json
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/TestSldClassSubstationMetadata.json
@@ -567,8 +567,7 @@
     "cgmesScaleFactor" : 1.0,
     "cgmesDiagramName" : null,
     "cgmesUseNames" : true,
-    "zoneLayoutSnakeLinePadding" : 90,
-    "zoneLayoutPathFinder" : "DIJKSTRA"
+    "zoneLayoutSnakeLinePadding" : 90
   },
   "svgParams" : {
     "prefixId" : "",

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/TestSldClassVlMetadata.json
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/TestSldClassVlMetadata.json
@@ -326,8 +326,7 @@
     "cgmesScaleFactor" : 1.0,
     "cgmesDiagramName" : null,
     "cgmesUseNames" : true,
-    "zoneLayoutSnakeLinePadding" : 90,
-    "zoneLayoutPathFinder" : "DIJKSTRA"
+    "zoneLayoutSnakeLinePadding" : 90
   },
   "svgParams" : {
     "prefixId" : "",

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/substDiag_metadata.json
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/substDiag_metadata.json
@@ -2949,8 +2949,7 @@
     "cgmesScaleFactor" : 1.0,
     "cgmesDiagramName" : null,
     "cgmesUseNames" : true,
-    "zoneLayoutSnakeLinePadding" : 90,
-    "zoneLayoutPathFinder" : "DIJKSTRA"
+    "zoneLayoutSnakeLinePadding" : 90
   },
   "svgParams" : {
     "prefixId" : "",

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/substDiag_with_hvdc_line_metadata.json
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/substDiag_with_hvdc_line_metadata.json
@@ -297,8 +297,7 @@
     "cgmesScaleFactor" : 1.0,
     "cgmesDiagramName" : null,
     "cgmesUseNames" : true,
-    "zoneLayoutSnakeLinePadding" : 90,
-    "zoneLayoutPathFinder" : "DIJKSTRA"
+    "zoneLayoutSnakeLinePadding" : 90
   },
   "svgParams" : {
     "prefixId" : "",

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/vlDiag_metadata.json
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/vlDiag_metadata.json
@@ -1482,8 +1482,7 @@
     "cgmesScaleFactor" : 1.0,
     "cgmesDiagramName" : null,
     "cgmesUseNames" : true,
-    "zoneLayoutSnakeLinePadding" : 90,
-    "zoneLayoutPathFinder" : "DIJKSTRA"
+    "zoneLayoutSnakeLinePadding" : 90
   },
   "svgParams" : {
     "prefixId" : "",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines


**What kind of change does this PR introduce?**
Quality

This PR removes an unused parameter in the `LayoutParameters` class.

Previously, the `PathFinderType` (the algorithm used to draw the snakelines between substations in multi-substations diagrams) was an attribute of the `LayoutParameters` class and it was not easily customizable. 

This approach was replaced by another one (using a `ZoneLayoutPathFinderFactory` attribute in the `SldParameters` class) but the attribute `PathFinderType` was kept by mistake in `LayoutParameters`.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
