### PR TITLE
Fix bug on fictitious busNodes

### DIFF
--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/iidm/HighlightLineStateStyleProvider.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/iidm/HighlightLineStateStyleProvider.java
@@ -40,13 +40,17 @@ public class HighlightLineStateStyleProvider extends EmptyStyleProvider {
 
     @Override
     public List<String> getNodeStyles(VoltageLevelGraph graph, Node node, ComponentLibrary componentLibrary, boolean showInternalNodes) {
-        if (node instanceof BusNode busNode && !isBusOrBbsConnected(busNode.getEquipmentId())) {
+        if (node instanceof BusNode busNode && !isBusOrBbsConnected(busNode)) {
             return List.of(StyleClassConstants.BUS_DISCONNECTED);
         }
         return Collections.emptyList();
     }
 
-    private boolean isBusOrBbsConnected(String equipmentId) {
+    private boolean isBusOrBbsConnected(BusNode busNode) {
+        if (busNode.isFictitious()) {
+            return true; // always displayed like a connected bbs
+        }
+        String equipmentId = busNode.getEquipmentId();
         BusbarSection busbarSection = network.getBusbarSection(equipmentId);
         if (busbarSection != null) {
             return busbarSection.getTerminal().isConnected();
@@ -55,7 +59,7 @@ public class HighlightLineStateStyleProvider extends EmptyStyleProvider {
             if (bus != null) {
                 return bus.getConnectedTerminalStream().anyMatch(Terminal::isConnected);
             }
-            return false;
+            return true; // should not happen
         }
     }
 

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/TestCaseFictitiousBus.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/TestCaseFictitiousBus.svg
@@ -153,7 +153,7 @@
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>
     <g>
-        <g class="sld-busbar-section sld-fictitious sld-vl50to70-0 sld-bus-disconnected" id="idINTERNAL_95_vl_95_0_95_FictitiousBus" transform="translate(65.0,252.0)">
+        <g class="sld-busbar-section sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl_95_0_95_FictitiousBus" transform="translate(65.0,252.0)">
             <line x1="0" x2="100.0" y1="0" y2="0"/>
         </g>
         <g class="sld-extern-cell sld-cell-direction-top" id="idEXTERN_32_0">


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior?**
All fictitious busNode are displayed as disconnected as they always carry the class sld-bus-disconnected

**What is the new behavior (if this is a feature change)?**
Fictitious busNode are never displayed as disconnected

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No