### PR TITLE
Set layout node positions getting them from JSON metadata in network area diagram

### DIFF
--- a/network-area-diagram/src/main/java/com/powsybl/nad/layout/AbstractLayout.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/layout/AbstractLayout.java
@@ -20,10 +20,7 @@ public abstract class AbstractLayout implements Layout {
 
     private Map<String, Point> initialNodePositions = Collections.emptyMap();
     private Set<String> nodesWithFixedPosition = Collections.emptySet();
-    private Map<String, TextPosition> textNodesWithFixedPosition = new HashMap<>();
-
-    record TextPosition(Point topLeftPosition, Point edgeConnection) {
-    }
+    private final Map<String, TextPosition> textNodesWithFixedPosition = new HashMap<>();
 
     @Override
     public void run(Graph graph, LayoutParameters layoutParameters) {

--- a/network-area-diagram/src/main/java/com/powsybl/nad/layout/FixedLayoutFactory.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/layout/FixedLayoutFactory.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.nad.layout;
 
+import com.powsybl.nad.layout.AbstractLayout.TextPosition;
 import com.powsybl.nad.model.Point;
 
 import java.util.Map;
@@ -18,13 +19,23 @@ public class FixedLayoutFactory implements LayoutFactory {
 
     private final Map<String, Point> fixedPositions;
     private final LayoutFactory layoutFactory;
+    private final Map<String, TextPosition> textNodesWithFixedPosition;
 
     public FixedLayoutFactory(Map<String, Point> fixedPositions) {
         this(fixedPositions, BasicFixedLayout::new);
     }
 
     public FixedLayoutFactory(Map<String, Point> fixedPositions, LayoutFactory layoutFactory) {
+        this(fixedPositions, Map.of(), layoutFactory);
+    }
+
+    public FixedLayoutFactory(Map<String, Point> fixedPositions, Map<String, TextPosition> textNodesWithFixedPosition) {
+        this(fixedPositions, textNodesWithFixedPosition, BasicFixedLayout::new);
+    }
+
+    public FixedLayoutFactory(Map<String, Point> fixedPositions, Map<String, TextPosition> textNodesWithFixedPosition, LayoutFactory layoutFactory) {
         this.fixedPositions = Objects.requireNonNull(fixedPositions);
+        this.textNodesWithFixedPosition = Objects.requireNonNull(textNodesWithFixedPosition);
         this.layoutFactory = Objects.requireNonNull(layoutFactory);
     }
 
@@ -33,6 +44,7 @@ public class FixedLayoutFactory implements LayoutFactory {
         Layout layout = layoutFactory.create();
         layout.setInitialNodePositions(fixedPositions);
         layout.setNodesWithFixedPosition(fixedPositions.keySet());
+        textNodesWithFixedPosition.forEach((k, v) -> layout.setTextNodeFixedPosition(k, v.topLeftPosition(), v.edgeConnection()));
         return layout;
     }
 }

--- a/network-area-diagram/src/main/java/com/powsybl/nad/layout/FixedLayoutFactory.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/layout/FixedLayoutFactory.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.nad.layout;
 
-import com.powsybl.nad.layout.AbstractLayout.TextPosition;
 import com.powsybl.nad.model.Point;
 
 import java.util.Map;

--- a/network-area-diagram/src/main/java/com/powsybl/nad/layout/FixedLayoutFactoryUtils.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/layout/FixedLayoutFactoryUtils.java
@@ -15,7 +15,6 @@ import java.io.Reader;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * @author Massimo Ferraro {@literal <massimo.ferraro at soft.it>}
@@ -28,56 +27,48 @@ public final class FixedLayoutFactoryUtils {
     private static Map<String, Point> getFixedPositions(DiagramMetadata diagramMetadata) {
         Map<String, Point> fixedPositions = new HashMap<>();
         diagramMetadata.getNodesMetadata()
-                       .forEach(node -> fixedPositions.put(node.getEquipmentId(),
-                                                           new Point(node.getX(),
-                                                                     node.getY())));
+                .forEach(node -> fixedPositions.put(node.getEquipmentId(), new Point(node.getX(), node.getY())));
         return fixedPositions;
     }
 
     private static Map<String, TextPosition> getTextNodesWithFixedPosition(DiagramMetadata diagramMetadata) {
         Map<String, TextPosition> textNodesWithFixedPosition = new HashMap<>();
         diagramMetadata.getTextNodesMetadata()
-                       .forEach(textNode -> textNodesWithFixedPosition.put(textNode.getEquipmentId(),
-                                                                           new TextPosition(new Point(textNode.getShiftX(),
-                                                                                                      textNode.getShiftY()),
-                                                                                            new Point(textNode.getConnectionShiftX(),
-                                                                                                      textNode.getConnectionShiftY()))));
+                .forEach(textNode -> textNodesWithFixedPosition.put(textNode.getEquipmentId(),
+                        new TextPosition(new Point(textNode.getShiftX(), textNode.getShiftY()),
+                                new Point(textNode.getConnectionShiftX(), textNode.getConnectionShiftY()))));
         return textNodesWithFixedPosition;
     }
 
-    public static FixedLayoutFactory create(InputStream metadataIS, LayoutFactory layoutFactory) {
-        Objects.requireNonNull(metadataIS);
-        DiagramMetadata diagramMetadata = DiagramMetadata.parseJson(metadataIS);
+    private static FixedLayoutFactory createFixedLayoutFactory(LayoutFactory layoutFactory, DiagramMetadata diagramMetadata) {
         return new FixedLayoutFactory(getFixedPositions(diagramMetadata), getTextNodesWithFixedPosition(diagramMetadata), layoutFactory);
     }
 
-    public static FixedLayoutFactory create(InputStream metadataIS) {
-        Objects.requireNonNull(metadataIS);
-        DiagramMetadata diagramMetadata = DiagramMetadata.parseJson(metadataIS);
+    private static FixedLayoutFactory createFixedLayoutFactory(DiagramMetadata diagramMetadata) {
         return new FixedLayoutFactory(getFixedPositions(diagramMetadata), getTextNodesWithFixedPosition(diagramMetadata));
+    }
+
+    public static FixedLayoutFactory create(InputStream metadataIs, LayoutFactory layoutFactory) {
+        return createFixedLayoutFactory(layoutFactory, DiagramMetadata.parseJson(metadataIs));
+    }
+
+    public static FixedLayoutFactory create(InputStream metadataIs) {
+        return createFixedLayoutFactory(DiagramMetadata.parseJson(metadataIs));
     }
 
     public static FixedLayoutFactory create(Path metadataFile, LayoutFactory layoutFactory) {
-        Objects.requireNonNull(metadataFile);
-        DiagramMetadata diagramMetadata = DiagramMetadata.parseJson(metadataFile);
-        return new FixedLayoutFactory(getFixedPositions(diagramMetadata), getTextNodesWithFixedPosition(diagramMetadata), layoutFactory);
+        return createFixedLayoutFactory(layoutFactory, DiagramMetadata.parseJson(metadataFile));
     }
 
     public static FixedLayoutFactory create(Path metadataFile) {
-        Objects.requireNonNull(metadataFile);
-        DiagramMetadata diagramMetadata = DiagramMetadata.parseJson(metadataFile);
-        return new FixedLayoutFactory(getFixedPositions(diagramMetadata), getTextNodesWithFixedPosition(diagramMetadata));
+        return createFixedLayoutFactory(DiagramMetadata.parseJson(metadataFile));
     }
 
     public static FixedLayoutFactory create(Reader metadataReader, LayoutFactory layoutFactory) {
-        Objects.requireNonNull(metadataReader);
-        DiagramMetadata diagramMetadata = DiagramMetadata.parseJson(metadataReader);
-        return new FixedLayoutFactory(getFixedPositions(diagramMetadata), getTextNodesWithFixedPosition(diagramMetadata), layoutFactory);
+        return createFixedLayoutFactory(layoutFactory, DiagramMetadata.parseJson(metadataReader));
     }
 
     public static FixedLayoutFactory create(Reader metadataReader) {
-        Objects.requireNonNull(metadataReader);
-        DiagramMetadata diagramMetadata = DiagramMetadata.parseJson(metadataReader);
-        return new FixedLayoutFactory(getFixedPositions(diagramMetadata), getTextNodesWithFixedPosition(diagramMetadata));
+        return createFixedLayoutFactory(DiagramMetadata.parseJson(metadataReader));
     }
 }

--- a/network-area-diagram/src/main/java/com/powsybl/nad/layout/FixedLayoutFactoryUtils.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/layout/FixedLayoutFactoryUtils.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.nad.layout;
+
+import java.io.InputStream;
+import java.io.Reader;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import com.powsybl.nad.layout.AbstractLayout.TextPosition;
+import com.powsybl.nad.model.Point;
+import com.powsybl.nad.svg.metadata.DiagramMetadata;
+
+/**
+ * @author Massimo Ferraro {@literal <massimo.ferraro at soft.it>}
+ */
+public final class FixedLayoutFactoryUtils {
+
+    private FixedLayoutFactoryUtils() {
+    }
+
+    private static Map<String, Point> getFixedPositions(DiagramMetadata diagramMetadata) {
+        Map<String, Point> fixedPositions = new HashMap<>();
+        diagramMetadata.getNodesMetadata()
+                       .forEach(node -> fixedPositions.put(node.getEquipmentId(),
+                                                           new Point(node.getX(),
+                                                                     node.getY())));
+        return fixedPositions;
+    }
+
+    private static Map<String, TextPosition> getTextNodesWithFixedPosition(DiagramMetadata diagramMetadata) {
+        Map<String, TextPosition> textNodesWithFixedPosition = new HashMap<>();
+        diagramMetadata.getTextNodesMetadata()
+                       .forEach(textNode -> textNodesWithFixedPosition.put(textNode.getEquipmentId(),
+                                                                           new TextPosition(new Point(textNode.getShiftX(),
+                                                                                                      textNode.getShiftY()),
+                                                                                            new Point(textNode.getConnectionShiftX(),
+                                                                                                      textNode.getConnectionShiftY()))));
+        return textNodesWithFixedPosition;
+    }
+
+    public static FixedLayoutFactory create(InputStream metadataIS, LayoutFactory layoutFactory) {
+        Objects.requireNonNull(metadataIS);
+        DiagramMetadata diagramMetadata = DiagramMetadata.parseJson(metadataIS);
+        return new FixedLayoutFactory(getFixedPositions(diagramMetadata), getTextNodesWithFixedPosition(diagramMetadata), layoutFactory);
+    }
+
+    public static FixedLayoutFactory create(InputStream metadataIS) {
+        Objects.requireNonNull(metadataIS);
+        DiagramMetadata diagramMetadata = DiagramMetadata.parseJson(metadataIS);
+        return new FixedLayoutFactory(getFixedPositions(diagramMetadata), getTextNodesWithFixedPosition(diagramMetadata));
+    }
+
+    public static FixedLayoutFactory create(Path metadataFile, LayoutFactory layoutFactory) {
+        Objects.requireNonNull(metadataFile);
+        DiagramMetadata diagramMetadata = DiagramMetadata.parseJson(metadataFile);
+        return new FixedLayoutFactory(getFixedPositions(diagramMetadata), getTextNodesWithFixedPosition(diagramMetadata), layoutFactory);
+    }
+
+    public static FixedLayoutFactory create(Path metadataFile) {
+        Objects.requireNonNull(metadataFile);
+        DiagramMetadata diagramMetadata = DiagramMetadata.parseJson(metadataFile);
+        return new FixedLayoutFactory(getFixedPositions(diagramMetadata), getTextNodesWithFixedPosition(diagramMetadata));
+    }
+
+    public static FixedLayoutFactory create(Reader metadataReader, LayoutFactory layoutFactory) {
+        Objects.requireNonNull(metadataReader);
+        DiagramMetadata diagramMetadata = DiagramMetadata.parseJson(metadataReader);
+        return new FixedLayoutFactory(getFixedPositions(diagramMetadata), getTextNodesWithFixedPosition(diagramMetadata), layoutFactory);
+    }
+
+    public static FixedLayoutFactory create(Reader metadataReader) {
+        Objects.requireNonNull(metadataReader);
+        DiagramMetadata diagramMetadata = DiagramMetadata.parseJson(metadataReader);
+        return new FixedLayoutFactory(getFixedPositions(diagramMetadata), getTextNodesWithFixedPosition(diagramMetadata));
+    }
+}

--- a/network-area-diagram/src/main/java/com/powsybl/nad/layout/FixedLayoutFactoryUtils.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/layout/FixedLayoutFactoryUtils.java
@@ -7,14 +7,11 @@
  */
 package com.powsybl.nad.layout;
 
-import com.powsybl.nad.model.Point;
 import com.powsybl.nad.svg.metadata.DiagramMetadata;
 
 import java.io.InputStream;
 import java.io.Reader;
 import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * @author Massimo Ferraro {@literal <massimo.ferraro at soft.it>}
@@ -24,28 +21,12 @@ public final class FixedLayoutFactoryUtils {
     private FixedLayoutFactoryUtils() {
     }
 
-    private static Map<String, Point> getFixedPositions(DiagramMetadata diagramMetadata) {
-        Map<String, Point> fixedPositions = new HashMap<>();
-        diagramMetadata.getNodesMetadata()
-                .forEach(node -> fixedPositions.put(node.getEquipmentId(), new Point(node.getX(), node.getY())));
-        return fixedPositions;
-    }
-
-    private static Map<String, TextPosition> getTextNodesWithFixedPosition(DiagramMetadata diagramMetadata) {
-        Map<String, TextPosition> textNodesWithFixedPosition = new HashMap<>();
-        diagramMetadata.getTextNodesMetadata()
-                .forEach(textNode -> textNodesWithFixedPosition.put(textNode.getEquipmentId(),
-                        new TextPosition(new Point(textNode.getShiftX(), textNode.getShiftY()),
-                                new Point(textNode.getConnectionShiftX(), textNode.getConnectionShiftY()))));
-        return textNodesWithFixedPosition;
-    }
-
     private static FixedLayoutFactory createFixedLayoutFactory(LayoutFactory layoutFactory, DiagramMetadata diagramMetadata) {
-        return new FixedLayoutFactory(getFixedPositions(diagramMetadata), getTextNodesWithFixedPosition(diagramMetadata), layoutFactory);
+        return new FixedLayoutFactory(diagramMetadata.getFixedPositions(), diagramMetadata.getFixedTextPositions(), layoutFactory);
     }
 
     private static FixedLayoutFactory createFixedLayoutFactory(DiagramMetadata diagramMetadata) {
-        return new FixedLayoutFactory(getFixedPositions(diagramMetadata), getTextNodesWithFixedPosition(diagramMetadata));
+        return new FixedLayoutFactory(diagramMetadata.getFixedPositions(), diagramMetadata.getFixedTextPositions());
     }
 
     public static FixedLayoutFactory create(InputStream metadataIs, LayoutFactory layoutFactory) {

--- a/network-area-diagram/src/main/java/com/powsybl/nad/layout/FixedLayoutFactoryUtils.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/layout/FixedLayoutFactoryUtils.java
@@ -7,16 +7,15 @@
  */
 package com.powsybl.nad.layout;
 
+import com.powsybl.nad.model.Point;
+import com.powsybl.nad.svg.metadata.DiagramMetadata;
+
 import java.io.InputStream;
 import java.io.Reader;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-
-import com.powsybl.nad.layout.AbstractLayout.TextPosition;
-import com.powsybl.nad.model.Point;
-import com.powsybl.nad.svg.metadata.DiagramMetadata;
 
 /**
  * @author Massimo Ferraro {@literal <massimo.ferraro at soft.it>}

--- a/network-area-diagram/src/main/java/com/powsybl/nad/layout/LayoutFactoryUtils.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/layout/LayoutFactoryUtils.java
@@ -16,40 +16,40 @@ import java.nio.file.Path;
 /**
  * @author Massimo Ferraro {@literal <massimo.ferraro at soft.it>}
  */
-public final class FixedLayoutFactoryUtils {
+public final class LayoutFactoryUtils {
 
-    private FixedLayoutFactoryUtils() {
+    private LayoutFactoryUtils() {
     }
 
-    private static FixedLayoutFactory createFixedLayoutFactory(LayoutFactory layoutFactory, DiagramMetadata diagramMetadata) {
+    private static FixedLayoutFactory createLayoutFactory(LayoutFactory layoutFactory, DiagramMetadata diagramMetadata) {
         return new FixedLayoutFactory(diagramMetadata.getFixedPositions(), diagramMetadata.getFixedTextPositions(), layoutFactory);
     }
 
-    private static FixedLayoutFactory createFixedLayoutFactory(DiagramMetadata diagramMetadata) {
+    private static FixedLayoutFactory createLayoutFactory(DiagramMetadata diagramMetadata) {
         return new FixedLayoutFactory(diagramMetadata.getFixedPositions(), diagramMetadata.getFixedTextPositions());
     }
 
     public static FixedLayoutFactory create(InputStream metadataIs, LayoutFactory layoutFactory) {
-        return createFixedLayoutFactory(layoutFactory, DiagramMetadata.parseJson(metadataIs));
+        return createLayoutFactory(layoutFactory, DiagramMetadata.parseJson(metadataIs));
     }
 
     public static FixedLayoutFactory create(InputStream metadataIs) {
-        return createFixedLayoutFactory(DiagramMetadata.parseJson(metadataIs));
+        return createLayoutFactory(DiagramMetadata.parseJson(metadataIs));
     }
 
     public static FixedLayoutFactory create(Path metadataFile, LayoutFactory layoutFactory) {
-        return createFixedLayoutFactory(layoutFactory, DiagramMetadata.parseJson(metadataFile));
+        return createLayoutFactory(layoutFactory, DiagramMetadata.parseJson(metadataFile));
     }
 
     public static FixedLayoutFactory create(Path metadataFile) {
-        return createFixedLayoutFactory(DiagramMetadata.parseJson(metadataFile));
+        return createLayoutFactory(DiagramMetadata.parseJson(metadataFile));
     }
 
     public static FixedLayoutFactory create(Reader metadataReader, LayoutFactory layoutFactory) {
-        return createFixedLayoutFactory(layoutFactory, DiagramMetadata.parseJson(metadataReader));
+        return createLayoutFactory(layoutFactory, DiagramMetadata.parseJson(metadataReader));
     }
 
     public static FixedLayoutFactory create(Reader metadataReader) {
-        return createFixedLayoutFactory(DiagramMetadata.parseJson(metadataReader));
+        return createLayoutFactory(DiagramMetadata.parseJson(metadataReader));
     }
 }

--- a/network-area-diagram/src/main/java/com/powsybl/nad/layout/TextPosition.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/layout/TextPosition.java
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.nad.layout;
+
+import com.powsybl.nad.model.Point;
+
+/**
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
+ */
+public record TextPosition(Point topLeftPosition, Point edgeConnection) {
+}

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/DiagramMetadata.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/DiagramMetadata.java
@@ -7,15 +7,6 @@
  */
 package com.powsybl.nad.svg.metadata;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.Reader;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.*;
-import java.util.stream.Collectors;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -25,9 +16,20 @@ import com.powsybl.diagram.metadata.AbstractMetadata;
 import com.powsybl.nad.layout.LayoutParameters;
 import com.powsybl.nad.layout.TextPosition;
 import com.powsybl.nad.model.Graph;
-import com.powsybl.nad.model.Node;
 import com.powsybl.nad.model.Point;
 import com.powsybl.nad.svg.SvgParameters;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * @author Thomas Adam {@literal <tadam at silicom.fr>}
@@ -177,14 +179,11 @@ public class DiagramMetadata extends AbstractMetadata {
 
     @JsonIgnore
     public Map<String, Point> getFixedPositions() {
-        return nodesMetadata.stream().collect(
-                Collectors.toMap(NodeMetadata::getEquipmentId, nm -> new Point(nm.getX(), nm.getY())));
+        return nodesMetadata.stream().collect(Collectors.toMap(NodeMetadata::getEquipmentId, NodeMetadata::getPosition));
     }
 
     @JsonIgnore
     public Map<String, TextPosition> getFixedTextPositions() {
-        return textNodesMetadata.stream().collect(
-                Collectors.toMap(TextNodeMetadata::getEquipmentId, tnm ->
-                        new TextPosition(new Point(tnm.getShiftX(), tnm.getShiftY()), new Point(tnm.getConnectionShiftX(), tnm.getConnectionShiftY()))));
+        return textNodesMetadata.stream().collect(Collectors.toMap(TextNodeMetadata::getEquipmentId, TextNodeMetadata::getTextPosition));
     }
 }

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/DiagramMetadata.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/DiagramMetadata.java
@@ -144,6 +144,7 @@ public class DiagramMetadata extends AbstractMetadata {
     }
 
     public static DiagramMetadata parseJson(Path file) {
+        Objects.requireNonNull(file);
         try (Reader reader = Files.newBufferedReader(file)) {
             return parseJson(reader);
         } catch (IOException e) {

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/DiagramMetadata.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/DiagramMetadata.java
@@ -13,17 +13,18 @@ import java.io.Reader;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.powsybl.commons.json.JsonUtil;
 import com.powsybl.diagram.metadata.AbstractMetadata;
 import com.powsybl.nad.layout.LayoutParameters;
+import com.powsybl.nad.layout.TextPosition;
 import com.powsybl.nad.model.Graph;
+import com.powsybl.nad.model.Point;
 import com.powsybl.nad.svg.SvgParameters;
 
 /**
@@ -170,5 +171,21 @@ public class DiagramMetadata extends AbstractMetadata {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    @JsonIgnore
+    public Map<String, Point> getFixedPositions() {
+        Map<String, Point> fixedPositions = new HashMap<>();
+        nodesMetadata.forEach(node -> fixedPositions.put(node.getEquipmentId(), new Point(node.getX(), node.getY())));
+        return fixedPositions;
+    }
+
+    @JsonIgnore
+    public Map<String, TextPosition> getFixedTextPositions() {
+        Map<String, TextPosition> fixedTextPosition = new HashMap<>();
+        textNodesMetadata.forEach(textNode -> fixedTextPosition.put(textNode.getEquipmentId(),
+                        new TextPosition(new Point(textNode.getShiftX(), textNode.getShiftY()),
+                                new Point(textNode.getConnectionShiftX(), textNode.getConnectionShiftY()))));
+        return fixedTextPosition;
     }
 }

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/DiagramMetadata.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/DiagramMetadata.java
@@ -14,6 +14,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -24,6 +25,7 @@ import com.powsybl.diagram.metadata.AbstractMetadata;
 import com.powsybl.nad.layout.LayoutParameters;
 import com.powsybl.nad.layout.TextPosition;
 import com.powsybl.nad.model.Graph;
+import com.powsybl.nad.model.Node;
 import com.powsybl.nad.model.Point;
 import com.powsybl.nad.svg.SvgParameters;
 
@@ -175,17 +177,14 @@ public class DiagramMetadata extends AbstractMetadata {
 
     @JsonIgnore
     public Map<String, Point> getFixedPositions() {
-        Map<String, Point> fixedPositions = new HashMap<>();
-        nodesMetadata.forEach(node -> fixedPositions.put(node.getEquipmentId(), new Point(node.getX(), node.getY())));
-        return fixedPositions;
+        return nodesMetadata.stream().collect(
+                Collectors.toMap(NodeMetadata::getEquipmentId, nm -> new Point(nm.getX(), nm.getY())));
     }
 
     @JsonIgnore
     public Map<String, TextPosition> getFixedTextPositions() {
-        Map<String, TextPosition> fixedTextPosition = new HashMap<>();
-        textNodesMetadata.forEach(textNode -> fixedTextPosition.put(textNode.getEquipmentId(),
-                        new TextPosition(new Point(textNode.getShiftX(), textNode.getShiftY()),
-                                new Point(textNode.getConnectionShiftX(), textNode.getConnectionShiftY()))));
-        return fixedTextPosition;
+        return textNodesMetadata.stream().collect(
+                Collectors.toMap(TextNodeMetadata::getEquipmentId, tnm ->
+                        new TextPosition(new Point(tnm.getShiftX(), tnm.getShiftY()), new Point(tnm.getConnectionShiftX(), tnm.getConnectionShiftY()))));
     }
 }

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/NodeMetadata.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/NodeMetadata.java
@@ -7,8 +7,10 @@
  */
 package com.powsybl.nad.svg.metadata;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.powsybl.nad.model.Point;
 
 /**
  * @author Luma Zamarreño {@literal <zamarrenolm at aia.es>}
@@ -34,5 +36,10 @@ public class NodeMetadata extends AbstractMetadataItem {
 
     public double getY() {
         return y;
+    }
+
+    @JsonIgnore
+    public Point getPosition() {
+        return new Point(x, y);
     }
 }

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/TextNodeMetadata.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/TextNodeMetadata.java
@@ -7,8 +7,11 @@
  */
 package com.powsybl.nad.svg.metadata;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.powsybl.nad.layout.TextPosition;
+import com.powsybl.nad.model.Point;
 
 /**
  * @author Massimo Ferraro {@literal <massimo.ferraro at soft.it>}
@@ -60,5 +63,10 @@ public class TextNodeMetadata extends AbstractMetadataItem {
     @JsonProperty("connectionShiftY")
     public double getConnectionShiftY() {
         return connectionShiftY;
+    }
+
+    @JsonIgnore
+    public TextPosition getTextPosition() {
+        return new TextPosition(new Point(shiftX, shiftY), new Point(connectionShiftX, connectionShiftY));
     }
 }

--- a/network-area-diagram/src/test/java/com/powsybl/nad/layout/FixedLayoutTest.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/layout/FixedLayoutTest.java
@@ -11,10 +11,19 @@ import com.powsybl.ieeecdf.converter.IeeeCdfNetworkFactory;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.nad.build.iidm.NetworkGraphBuilder;
 import com.powsybl.nad.build.iidm.VoltageLevelFilter;
+import com.powsybl.nad.layout.AbstractLayout.TextPosition;
 import com.powsybl.nad.model.Graph;
 import com.powsybl.nad.model.Point;
+
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -97,5 +106,86 @@ class FixedLayoutTest {
         assertEquals(0, actual.get("VL6").getY());
         assertEquals(0, actual.get("VL8").getX());
         assertEquals(0, actual.get("VL8").getY());
+    }
+
+    @Test
+    void testMetadataUtils() throws URISyntaxException, IOException {
+        Network network = Networks.createTwoVoltageLevels();
+        Path metadataFile = Paths.get(getClass().getResource("/two-voltage-levels_metadata.json").toURI());
+
+        Layout layout = new FixedLayoutFactory(new HashMap<>()).create();
+        testEmptyLayout(layout, network);
+
+        layout = FixedLayoutFactoryUtils.create(metadataFile).create();
+        testMetadataLayout(layout, network);
+        layout = FixedLayoutFactoryUtils.create(metadataFile, BasicFixedLayout::new).create();
+        testMetadataLayout(layout, network);
+
+        try (InputStream metadataIS = Files.newInputStream(metadataFile)) {
+            layout = FixedLayoutFactoryUtils.create(metadataIS).create();
+            testMetadataLayout(layout, network);
+        }
+        try (InputStream metadataIS = Files.newInputStream(metadataFile)) {
+            layout = FixedLayoutFactoryUtils.create(metadataIS, BasicFixedLayout::new).create();
+            testMetadataLayout(layout, network);
+        }
+
+        try (Reader metadataReader = Files.newBufferedReader(metadataFile)) {
+            layout = FixedLayoutFactoryUtils.create(metadataReader).create();
+            testMetadataLayout(layout, network);
+        }
+        try (Reader metadataReader = Files.newBufferedReader(metadataFile)) {
+            layout = FixedLayoutFactoryUtils.create(metadataReader, BasicFixedLayout::new).create();
+            testMetadataLayout(layout, network);
+        }
+    }
+
+    void testEmptyLayout(Layout layout, Network network) {
+        Graph graph = new NetworkGraphBuilder(network, VoltageLevelFilter.NO_FILTER).buildGraph();
+        layout.run(graph, new LayoutParameters());
+        Map<String, Point> nodePositions = graph.getNodePositions();
+        checkNodePosition(nodePositions.get("dl1"), 0, 0);
+        checkNodePosition(nodePositions.get("vl1"), 0, 0);
+        checkNodePosition(nodePositions.get("vl2"), 0, 0);
+        Map<String, TextPosition> textNodesPositions = getTextNodesPositions(graph);
+        checkNodeShift(nodePositions.get("vl1"), textNodesPositions.get("vl1").topLeftPosition(), 100, -40);
+        checkNodeShift(nodePositions.get("vl1"), textNodesPositions.get("vl1").edgeConnection(), 100, -15);
+        checkNodeShift(nodePositions.get("vl2"), textNodesPositions.get("vl2").topLeftPosition(), 100, -40);
+        checkNodeShift(nodePositions.get("vl2"), textNodesPositions.get("vl2").edgeConnection(), 100, -15);
+    }
+
+    void testMetadataLayout(Layout layout, Network network) {
+        Graph graph = new NetworkGraphBuilder(network, VoltageLevelFilter.NO_FILTER).buildGraph();
+        layout.run(graph, new LayoutParameters());
+        Map<String, Point> nodePositions = graph.getNodePositions();
+        checkNodePosition(nodePositions.get("dl1"), -49.12, 317.14);
+        checkNodePosition(nodePositions.get("vl1"), -56.06, -318.7);
+        checkNodePosition(nodePositions.get("vl2"), -230.42, 1.18);
+        Map<String, TextPosition> textNodesPositions = getTextNodesPositions(graph);
+        checkNodeShift(nodePositions.get("vl1"), textNodesPositions.get("vl1").topLeftPosition(), 80, -30);
+        checkNodeShift(nodePositions.get("vl1"), textNodesPositions.get("vl1").edgeConnection(), 80, -5);
+        checkNodeShift(nodePositions.get("vl2"), textNodesPositions.get("vl2").topLeftPosition(), 80, -30);
+        checkNodeShift(nodePositions.get("vl2"), textNodesPositions.get("vl2").edgeConnection(), 80, -5);
+    }
+
+    Map<String, TextPosition> getTextNodesPositions(Graph graph) {
+        Map<String, TextPosition> textNodesPositions = new HashMap<>();
+        graph.getTextEdgesMap()
+             .values()
+             .forEach(nodePair -> textNodesPositions.put(nodePair.getFirst().getEquipmentId(),
+                                                         new TextPosition(nodePair.getSecond().getPosition(),
+                                                                          nodePair.getSecond().getEdgeConnection())));
+        return textNodesPositions;
+    }
+
+    void checkNodePosition(Point point, double x, double y) {
+        assertEquals(x, point.getX());
+        assertEquals(y, point.getY());
+    }
+
+    void checkNodeShift(Point point, Point shiftedPoint, double shiftX, double shiftY) {
+        Point expectedPoint = point.shift(shiftX, shiftY);
+        assertEquals(expectedPoint.getX(), shiftedPoint.getX());
+        assertEquals(expectedPoint.getY(), shiftedPoint.getY());
     }
 }

--- a/network-area-diagram/src/test/java/com/powsybl/nad/layout/FixedLayoutTest.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/layout/FixedLayoutTest.java
@@ -11,7 +11,6 @@ import com.powsybl.ieeecdf.converter.IeeeCdfNetworkFactory;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.nad.build.iidm.NetworkGraphBuilder;
 import com.powsybl.nad.build.iidm.VoltageLevelFilter;
-import com.powsybl.nad.layout.AbstractLayout.TextPosition;
 import com.powsybl.nad.model.Graph;
 import com.powsybl.nad.model.Point;
 

--- a/network-area-diagram/src/test/java/com/powsybl/nad/layout/FixedLayoutTest.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/layout/FixedLayoutTest.java
@@ -115,26 +115,26 @@ class FixedLayoutTest {
         Layout layout = new FixedLayoutFactory(new HashMap<>()).create();
         testEmptyLayout(layout, network);
 
-        layout = FixedLayoutFactoryUtils.create(metadataFile).create();
+        layout = LayoutFactoryUtils.create(metadataFile).create();
         testMetadataLayout(layout, network);
-        layout = FixedLayoutFactoryUtils.create(metadataFile, BasicFixedLayout::new).create();
+        layout = LayoutFactoryUtils.create(metadataFile, BasicFixedLayout::new).create();
         testMetadataLayout(layout, network);
 
         try (InputStream metadataIS = Files.newInputStream(metadataFile)) {
-            layout = FixedLayoutFactoryUtils.create(metadataIS).create();
+            layout = LayoutFactoryUtils.create(metadataIS).create();
             testMetadataLayout(layout, network);
         }
         try (InputStream metadataIS = Files.newInputStream(metadataFile)) {
-            layout = FixedLayoutFactoryUtils.create(metadataIS, BasicFixedLayout::new).create();
+            layout = LayoutFactoryUtils.create(metadataIS, BasicFixedLayout::new).create();
             testMetadataLayout(layout, network);
         }
 
         try (Reader metadataReader = Files.newBufferedReader(metadataFile)) {
-            layout = FixedLayoutFactoryUtils.create(metadataReader).create();
+            layout = LayoutFactoryUtils.create(metadataReader).create();
             testMetadataLayout(layout, network);
         }
         try (Reader metadataReader = Files.newBufferedReader(metadataFile)) {
-            layout = FixedLayoutFactoryUtils.create(metadataReader, BasicFixedLayout::new).create();
+            layout = LayoutFactoryUtils.create(metadataReader, BasicFixedLayout::new).create();
             testMetadataLayout(layout, network);
         }
     }

--- a/network-area-diagram/src/test/resources/two-voltage-levels_metadata.json
+++ b/network-area-diagram/src/test/resources/two-voltage-levels_metadata.json
@@ -1,0 +1,127 @@
+{
+  "layoutParameters" : {
+    "textNodesForceLayout" : false,
+    "springRepulsionFactorForceLayout" : 0.0,
+    "textNodeFixedShift" : {
+      "x" : 100.0,
+      "y" : -40.0
+    },
+    "maxSteps" : 1000,
+    "textNodeEdgeConnectionYShift" : 25.0
+  },
+  "svgParameters" : {
+    "diagramPadding" : {
+      "left" : 200.0,
+      "top" : 200.0,
+      "right" : 200.0,
+      "bottom" : 200.0
+    },
+    "insertNameDesc" : false,
+    "svgWidthAndHeightAdded" : false,
+    "cssLocation" : "INSERTED_IN_SVG",
+    "sizeConstraint" : "FIXED_SCALE",
+    "fixedWidth" : -1,
+    "fixedHeight" : -1,
+    "fixedScale" : 0.2,
+    "arrowShift" : 30.0,
+    "arrowLabelShift" : 19.0,
+    "converterStationWidth" : 70.0,
+    "voltageLevelCircleRadius" : 30.0,
+    "fictitiousVoltageLevelCircleRadius" : 15.0,
+    "transformerCircleRadius" : 20.0,
+    "nodeHollowWidth" : 15.0,
+    "edgesForkLength" : 80.0,
+    "edgesForkAperture" : 60.0,
+    "edgeStartShift" : 0.0,
+    "unknownBusNodeExtraRadius" : 10.0,
+    "loopDistance" : 120.0,
+    "loopEdgesAperture" : 60.0,
+    "loopControlDistance" : 40.0,
+    "edgeInfoAlongEdge" : true,
+    "edgeNameDisplayed" : false,
+    "interAnnulusSpace" : 5.0,
+    "svgPrefix" : "",
+    "idDisplayed" : false,
+    "substationDescriptionDisplayed" : false,
+    "arrowHeight" : 10.0,
+    "busLegend" : true,
+    "voltageLevelDetails" : false,
+    "languageTag" : "en",
+    "voltageValuePrecision" : 1,
+    "powerValuePrecision" : 0,
+    "angleValuePrecision" : 1,
+    "currentValuePrecision" : 0,
+    "edgeInfoDisplayed" : "ACTIVE_POWER",
+    "pstArrowHeadSize" : 8.0,
+    "undefinedValueSymbol" : ""
+  },
+  "busNodes" : [ {
+    "svgId" : "1",
+    "equipmentId" : "vl1_0",
+    "nbNeighbours" : 0,
+    "index" : 0,
+    "vlNode" : "0"
+  }, {
+    "svgId" : "3",
+    "equipmentId" : "vl2_0",
+    "nbNeighbours" : 0,
+    "index" : 0,
+    "vlNode" : "2"
+  }, {
+    "svgId" : "6",
+    "equipmentId" : "dl1",
+    "nbNeighbours" : 0,
+    "index" : 0,
+    "vlNode" : "5"
+  } ],
+  "nodes" : [ {
+    "svgId" : "0",
+    "equipmentId" : "vl1",
+    "x" : -56.06,
+    "y" : -318.7
+  }, {
+    "svgId" : "2",
+    "equipmentId" : "vl2",
+    "x" : -230.42,
+    "y" : 1.18
+  }, {
+    "svgId" : "5",
+    "equipmentId" : "dl1",
+    "x" : -49.12,
+    "y" : 317.14
+  } ],
+  "edges" : [ {
+    "svgId" : "4",
+    "equipmentId" : "l1",
+    "node1" : "0",
+    "node2" : "2",
+    "busNode1" : "1",
+    "busNode2" : "3",
+    "type" : "LineEdge"
+  }, {
+    "svgId" : "7",
+    "equipmentId" : "dl1",
+    "node1" : "2",
+    "node2" : "5",
+    "busNode1" : "3",
+    "busNode2" : "6",
+    "type" : "DanglingLineEdge"
+  } ],
+  "textNodes" : [ {
+    "svgId" : "0-textnode",
+    "equipmentId" : "vl1",
+    "vlNode" : "0",
+    "shiftX" : 80.0,
+    "shiftY" : -30.0,
+    "connectionShiftX" : 80.0,
+    "connectionShiftY" : -5.0
+  }, {
+    "svgId" : "2-textnode",
+    "equipmentId" : "vl2",
+    "vlNode" : "2",
+    "shiftX" : 80.0,
+    "shiftY" : -30.0,
+    "connectionShiftX" : 80.0,
+    "connectionShiftY" : -5.0
+  } ]
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
no


**What kind of change does this PR introduce?**
feature


**What is the current behavior?**
In network area diagram initial positions of nodes and text nodes for a layout can be set providing them in maps


**What is the new behavior (if this is a feature change)?**
Initial positions of nodes and text nodes for a layout can be set reading them from a JSON diagram metadata file


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No