### PR TITLE
Fix GraphMetadata serialization: attributes' order

### DIFF
--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/GraphMetadata.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/GraphMetadata.java
@@ -10,6 +10,7 @@ package com.powsybl.sld.svg;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.powsybl.commons.json.JsonUtil;
@@ -32,6 +33,11 @@ import java.util.*;
 public class GraphMetadata extends AbstractMetadata {
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    // On some systems, the export order is determined by the order of the 1st encountered JsonCreator's attributes
+    // and "unescapedId" is put in last place. But on other systems, the export order is determined by the getters' order
+    // and "unescapedId" is put in 1st place, which leads to comparison errors in the unit tests.
+    // To prevent this discrepancy, the order is manually fixed.
+    @JsonPropertyOrder(value = {"unescapedId", "id", "vid", "nextVId", "componentType", "open", "direction", "vlabel", "equipmentId", "labels"})
     public static class NodeMetadata {
 
         private final String unescapedId;

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/substDiag_with_hvdc_line_metadata.json
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/substDiag_with_hvdc_line_metadata.json
@@ -123,6 +123,7 @@
       "positionName" : "NW_LABEL"
     } ]
   }, {
+    "unescapedId" : "LCC_1",
     "id" : "idLCC_95_1",
     "vid" : "VoltageLevel1",
     "nextVId" : "VoltageLevel2",
@@ -134,8 +135,7 @@
     "labels" : [ {
       "id" : "LCC_1_S_LABEL",
       "positionName" : "S_LABEL"
-    } ],
-    "unescapedId" : "LCC_1"
+    } ]
   }, {
     "id" : "LABEL_VL_VoltageLevel1",
     "vid" : "VoltageLevel1",
@@ -164,6 +164,7 @@
     "vlabel" : false,
     "labels" : [ ]
   }, {
+    "unescapedId" : "VSC_1",
     "id" : "idVSC_95_1",
     "vid" : "VoltageLevel1",
     "nextVId" : "VoltageLevel2",
@@ -175,8 +176,7 @@
     "labels" : [ {
       "id" : "VSC_1_N_LABEL",
       "positionName" : "N_LABEL"
-    } ],
-    "unescapedId" : "VSC_1"
+    } ]
   }, {
     "id" : "idBUSCO_95_Bus1_95_VSC_95_1",
     "vid" : "VoltageLevel1",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
On some systems, the export order of `GraphMetadata` attributes is determined by the order of the 1st encountered `JsonCreator`'s attributes and `unescapedId` is put in last place.  
But on other systems, the export order is determined by the getters' order and `unescapedId` is put in 1st place, which leads to comparison errors in the unit tests.

**What is the new behavior (if this is a feature change)?**
To prevent this discrepancy, the order is manually fixed.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
This problem was spotted via the pypowsybl "Snapshot CI" action. The problem occurs for the following jobs:
- Build windows cp310 wheel
- Build windows cp312 wheel
