### PR TITLE
Enable download of documentation in pdf format

### DIFF
--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -11,3 +11,6 @@ sphinx:
 python:
   install:
     - requirements: docs/requirements.txt
+
+formats:
+  - pdf


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines

**What kind of change does this PR introduce?**
Documentation configuration update: allows to download readthedocs documentation in pdf format.
See https://github.com/powsybl/powsybl-core/pull/3253

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No