### PR TITLE
[WIP] Display power production and power consumption icons at each voltage level node

### DIFF
--- a/network-area-diagram/src/main/java/com/powsybl/nad/build/iidm/NetworkGraphBuilder.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/build/iidm/NetworkGraphBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * Copyright (c) 2021-2025, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -71,6 +71,8 @@ public class NetworkGraphBuilder implements GraphBuilder {
         graph.addNode(vlNode);
         if (visible) {
             graph.addTextNode(vlNode);
+            graph.addProductionNode(vlNode);
+            graph.addConsumptionNode(vlNode);
         }
         return vlNode;
     }

--- a/network-area-diagram/src/main/java/com/powsybl/nad/layout/BasicFixedLayout.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/layout/BasicFixedLayout.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * Copyright (c) 2022-2025, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -18,7 +18,7 @@ public class BasicFixedLayout extends AbstractLayout {
 
     @Override
     protected void nodesLayout(Graph graph, LayoutParameters layoutParameters) {
-        org.jgrapht.Graph<Node, Edge> jgraphtGraph = graph.getJgraphtGraph(layoutParameters.isTextNodesForceLayout());
+        org.jgrapht.Graph<Node, Edge> jgraphtGraph = graph.getJgraphtGraph(layoutParameters.isTextNodesForceLayout(), layoutParameters.isPowerNodesForceLayout());
 
         jgraphtGraph.vertexSet().forEach(node -> {
             Point p = getInitialNodePositions().get(node.getEquipmentId());
@@ -29,6 +29,13 @@ public class BasicFixedLayout extends AbstractLayout {
 
         if (!layoutParameters.isTextNodesForceLayout()) {
             graph.getTextEdgesMap().values().forEach(nodePair -> fixedTextNodeLayout(nodePair, layoutParameters));
+        }
+        if (!layoutParameters.isPowerNodesForceLayout()) {
+            graph.getProductionEdgesMap().values().forEach(nodePair -> fixedProductionNodeLayout(nodePair, layoutParameters));
+            graph.getConsumptionEdgesMap().values().forEach(nodePair -> fixedConsumptionNodeLayout(nodePair, layoutParameters));
+        } else {
+            graph.getProductionEdgesMap().values().forEach(nodePair -> adjustProductionNodeForceLayout(nodePair, layoutParameters));
+            graph.getConsumptionEdgesMap().values().forEach(nodePair -> adjustConsumptionNodeForceLayout(nodePair, layoutParameters));
         }
     }
 }

--- a/network-area-diagram/src/main/java/com/powsybl/nad/layout/LayoutParameters.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/layout/LayoutParameters.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * Copyright (c) 2021-2025, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -17,6 +17,10 @@ public class LayoutParameters {
     private Point textNodeFixedShift = new Point(100, -40);
     private int maxSteps = 1000;
     private double textNodeEdgeConnectionYShift = 25;
+    private Point productionNodeFixedShift = new Point(-100, -50);
+    private Point consumptionNodeFixedShift = new Point(-100, +50);
+    private boolean powerNodesForceLayout = false;
+    private double powerNodeRadius = 15;
 
     public LayoutParameters() {
     }
@@ -56,6 +60,15 @@ public class LayoutParameters {
         return this;
     }
 
+    public Point getProductionNodeFixedShift() {
+        return productionNodeFixedShift;
+    }
+
+    public LayoutParameters setProductiontNodeFixedShift(double productionNodeFixedShiftX, double productionNodeFixedShiftY) {
+        this.productionNodeFixedShift = new Point(productionNodeFixedShiftX, productionNodeFixedShiftY);
+        return this;
+    }
+
     public int getMaxSteps() {
         return maxSteps;
     }
@@ -73,4 +86,29 @@ public class LayoutParameters {
         this.textNodeEdgeConnectionYShift = textNodeEdgeConnectionYShift;
         return this;
     }
+
+    public double getPowerNodeRadius() {
+        return powerNodeRadius;
+    }
+
+    public void setPowerNodeRadius(double powerNodeRadius) {
+        this.powerNodeRadius = powerNodeRadius;
+    }
+
+    public Point getConsumptionNodeFixedShift() {
+        return consumptionNodeFixedShift;
+    }
+
+    public void setConsumptionNodeFixedShift(Point consumptionNodeFixedShift) {
+        this.consumptionNodeFixedShift = consumptionNodeFixedShift;
+    }
+
+    public boolean isPowerNodesForceLayout() {
+        return powerNodesForceLayout;
+    }
+
+    public void setPowerNodesForceLayout(boolean powerNodesForceLayout) {
+        this.powerNodesForceLayout = powerNodesForceLayout;
+    }
+
 }

--- a/network-area-diagram/src/main/java/com/powsybl/nad/model/ConsumptionEdge.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/model/ConsumptionEdge.java
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.nad.model;
+
+public class ConsumptionEdge extends PowerEdge {
+
+    public static final String CONSUMPTION_EDGE = "ConsumptionEdge";
+
+    public ConsumptionEdge(String diagramId) {
+        super(diagramId, null, null, CONSUMPTION_EDGE);
+    }
+
+}

--- a/network-area-diagram/src/main/java/com/powsybl/nad/model/ConsumptionNode.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/model/ConsumptionNode.java
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.nad.model;
+
+public class ConsumptionNode extends PowerNode {
+
+    public ConsumptionNode(String diagramId) {
+        super(diagramId);
+    }
+}

--- a/network-area-diagram/src/main/java/com/powsybl/nad/model/PowerEdge.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/model/PowerEdge.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.nad.model;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class PowerEdge extends AbstractEdge {
+
+    private Point[] points;
+
+    public PowerEdge(String diagramId, String equipmentId, String nae, String type) {
+        super(diagramId, null, null, type);
+    }
+
+    public void setPoints(Point... points) {
+        this.points = points;
+    }
+
+    public List<Point> getPoints() {
+        return Arrays.asList(points);
+    }
+}

--- a/network-area-diagram/src/main/java/com/powsybl/nad/model/PowerNode.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/model/PowerNode.java
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.nad.model;
+
+public class PowerNode extends TextNode {
+
+    public PowerNode(String diagramId) {
+        super(diagramId);
+    }
+}

--- a/network-area-diagram/src/main/java/com/powsybl/nad/model/ProductionEdge.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/model/ProductionEdge.java
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.nad.model;
+
+public class ProductionEdge extends PowerEdge {
+
+    public static final String PRODUCTION_EDGE = "ProductionEdge";
+
+    public ProductionEdge(String diagramId) {
+        super(diagramId, null, null, PRODUCTION_EDGE);
+    }
+
+}

--- a/network-area-diagram/src/main/java/com/powsybl/nad/model/ProductionNode.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/model/ProductionNode.java
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.nad.model;
+
+public class ProductionNode extends PowerNode {
+
+    public ProductionNode(String diagramId) {
+        super(diagramId);
+    }
+}

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/DefaultEdgeRendering.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/DefaultEdgeRendering.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * Copyright (c) 2022-2025, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -25,9 +25,19 @@ public class DefaultEdgeRendering implements EdgeRendering {
         graph.getLoopBranchEdgesMap().forEach((node, edges) -> loopEdgesLayout(graph, node, edges, svgParameters));
         graph.getThreeWtNodesStream().forEach(threeWtNode -> computeThreeWtEdgeCoordinates(graph, threeWtNode, svgParameters));
         graph.getTextEdgesMap().forEach((edge, nodes) -> computeTextEdgeLayoutCoordinates(nodes.getFirst(), nodes.getSecond(), edge));
+        graph.getProductionEdgesMap().forEach((edge, nodes) -> computeProductionEdgeLayoutCoordinates(nodes.getFirst(), nodes.getSecond(), edge));
+        graph.getConsumptionEdgesMap().forEach((edge, nodes) -> computeConsumptionEdgeLayoutCoordinates(nodes.getFirst(), nodes.getSecond(), edge));
     }
 
     private void computeTextEdgeLayoutCoordinates(Node node1, TextNode node2, TextEdge edge) {
+        edge.setPoints(node1.getPosition(), node2.getEdgeConnection());
+    }
+
+    private void computeProductionEdgeLayoutCoordinates(Node node1, ProductionNode node2, ProductionEdge edge) {
+        edge.setPoints(node1.getPosition(), node2.getEdgeConnection());
+    }
+
+    private void computeConsumptionEdgeLayoutCoordinates(Node node1, ConsumptionNode node2, ConsumptionEdge edge) {
         edge.setPoints(node1.getPosition(), node2.getEdgeConnection());
     }
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/LabelProvider.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/LabelProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * Copyright (c) 2021-2025, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -30,4 +30,8 @@ public interface LabelProvider {
     String getBusDescription(BusNode busNode);
 
     List<String> getVoltageLevelDetails(VoltageLevelNode vlNode);
+
+    List<String> getVoltageProductionDetails(VoltageLevelNode vlNode);
+
+    List<String> getVoltageConsumptionDetails(VoltageLevelNode vlNode);
 }

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/StyleProvider.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/StyleProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * Copyright (c) 2021-2025, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -27,6 +27,7 @@ public interface StyleProvider {
     String DANGLING_LINE_EDGE_CLASS = CLASSES_PREFIX + "dangling-line-edge";
     String TIE_LINE_EDGE_CLASS = CLASSES_PREFIX + "tie-line-edge";
     String TEXT_EDGES_CLASS = CLASSES_PREFIX + "text-edges";
+    String POWER_EDGES_CLASS = CLASSES_PREFIX + "power-edges";
     String EDGE_INFOS_CLASS = CLASSES_PREFIX + "edge-infos";
     String EDGE_LABEL_CLASS = CLASSES_PREFIX + "edge-label";
     String ARROW_IN_CLASS = CLASSES_PREFIX + "arrow-in";
@@ -40,6 +41,8 @@ public interface StyleProvider {
     String WINDING_CLASS = CLASSES_PREFIX + "winding";
     String BUSNODE_CLASS = CLASSES_PREFIX + "busnode";
     String LABEL_BOX_CLASS = CLASSES_PREFIX + "label-box";
+    String POWER_LABEL_CLASS = CLASSES_PREFIX + "power-label";
+    String POWER_ICON_CLASS = CLASSES_PREFIX + "power-icon";
     String LEGEND_SQUARE_CLASS = CLASSES_PREFIX + "legend-square";
     String PST_ARROW_CLASS = CLASSES_PREFIX + "pst-arrow";
     String STRETCHABLE_CLASS = CLASSES_PREFIX + "stretchable";

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/SvgParameters.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/SvgParameters.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * Copyright (c) 2021-2025, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -55,7 +55,7 @@ public class SvgParameters {
     private EdgeInfoEnum edgeInfoDisplayed = EdgeInfoEnum.ACTIVE_POWER;
     private double pstArrowHeadSize = 8;
     private String undefinedValueSymbol = "";
-
+    private boolean voltageLevelPowerDetails = false;
 
     public enum CssLocation {
         INSERTED_IN_SVG, EXTERNAL_IMPORTED, EXTERNAL_NO_IMPORT
@@ -108,6 +108,7 @@ public class SvgParameters {
         this.edgeInfoDisplayed = other.edgeInfoDisplayed;
         this.pstArrowHeadSize = other.pstArrowHeadSize;
         this.undefinedValueSymbol = other.undefinedValueSymbol;
+        this.voltageLevelPowerDetails = other.voltageLevelPowerDetails;
     }
 
     public Padding getDiagramPadding() {
@@ -491,4 +492,14 @@ public class SvgParameters {
         this.undefinedValueSymbol = undefinedValueSymbol;
         return this;
     }
+
+    public boolean isVoltageLevelPowerDetails() {
+        return voltageLevelPowerDetails;
+    }
+
+    public SvgParameters setVoltageLevelPowerDetails(boolean voltageLevelPowerDetails) {
+        this.voltageLevelPowerDetails = voltageLevelPowerDetails;
+        return this;
+    }
+
 }

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/iidm/DefaultLabelProvider.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/iidm/DefaultLabelProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * Copyright (c) 2021-2025, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -114,6 +114,41 @@ public class DefaultLabelProvider implements LabelProvider {
 
         if (!activeConsumption.isEmpty() || !reactiveConsumption.isEmpty()) {
             voltageLevelDetails.add(String.format("⌂ %s / %s", activeConsumption, reactiveConsumption));
+        }
+
+        return voltageLevelDetails;
+    }
+
+    @Override
+    public List<String> getVoltageProductionDetails(VoltageLevelNode vlNode) {
+        List<String> voltageLevelDetails = new ArrayList<>();
+        VoltageLevel voltageLevel = network.getVoltageLevel(vlNode.getEquipmentId());
+
+        double activeProductionValue = voltageLevel.getGeneratorStream().mapToDouble(generator -> -generator.getTerminal().getP()).filter(p -> !Double.isNaN(p)).sum();
+        String activeProduction = activeProductionValue == 0 ? "" : valueFormatter.formatPower(activeProductionValue, "MW");
+
+        double reactiveProductionValue = voltageLevel.getGeneratorStream().mapToDouble(generator -> -generator.getTerminal().getQ()).filter(q -> !Double.isNaN(q)).sum();
+        String reactiveProduction = reactiveProductionValue == 0 ? "" : valueFormatter.formatPower(reactiveProductionValue, "MVAR");
+
+        if (!activeProduction.isEmpty() || !reactiveProduction.isEmpty()) {
+            voltageLevelDetails.add(String.format("%s / %s", activeProduction, reactiveProduction));
+        }
+        return voltageLevelDetails;
+    }
+
+    @Override
+    public List<String> getVoltageConsumptionDetails(VoltageLevelNode vlNode) {
+        List<String> voltageLevelDetails = new ArrayList<>();
+        VoltageLevel voltageLevel = network.getVoltageLevel(vlNode.getEquipmentId());
+
+        double activeConsumptionValue = voltageLevel.getLoadStream().mapToDouble(load -> load.getTerminal().getP()).filter(p -> !Double.isNaN(p)).sum();
+        String activeConsumption = activeConsumptionValue == 0 ? "" : valueFormatter.formatPower(activeConsumptionValue, "MW");
+
+        double reactiveConsumptionValue = voltageLevel.getLoadStream().mapToDouble(load -> load.getTerminal().getQ()).filter(q -> !Double.isNaN(q)).sum();
+        String reactiveConsumption = reactiveConsumptionValue == 0 ? "" : valueFormatter.formatPower(reactiveConsumptionValue, "MVAR");
+
+        if (!activeConsumption.isEmpty() || !reactiveConsumption.isEmpty()) {
+            voltageLevelDetails.add(String.format("%s / %s", activeConsumption, reactiveConsumption));
         }
 
         return voltageLevelDetails;

--- a/network-area-diagram/src/main/resources/nominalStyle.css
+++ b/network-area-diagram/src/main/resources/nominalStyle.css
@@ -16,6 +16,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}

--- a/network-area-diagram/src/main/resources/topologicalStyle.css
+++ b/network-area-diagram/src/main/resources/topologicalStyle.css
@@ -16,6 +16,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-legend-square {width: 20px; height: 20px; background: var(--nad-vl-color, black);}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-disconnected {--nad-vl-color: #808080}

--- a/network-area-diagram/src/test/java/com/powsybl/nad/svg/PowerNodeTest.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/svg/PowerNodeTest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.nad.svg;
+
+import com.powsybl.diagram.test.Networks;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.VoltageLevel;
+import com.powsybl.nad.AbstractTest;
+import com.powsybl.nad.layout.LayoutParameters;
+import com.powsybl.nad.model.VoltageLevelNode;
+import com.powsybl.nad.svg.iidm.DefaultLabelProvider;
+import com.powsybl.nad.svg.iidm.TopologicalStyleProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PowerNodeTest extends AbstractTest {
+
+    private LabelProvider labelProvider;
+
+    @BeforeEach
+    void setup() {
+        setLayoutParameters(new LayoutParameters());
+        setSvgParameters(new SvgParameters()
+                .setSvgWidthAndHeightAdded(true)
+                .setFixedWidth(800));
+    }
+
+    @Override
+    protected StyleProvider getStyleProvider(Network network) {
+        return new TopologicalStyleProvider(network);
+    }
+
+    @Override
+    protected LabelProvider getLabelProvider(Network network) {
+        if (labelProvider != null) {
+            return labelProvider;
+        }
+        return new DefaultLabelProvider(network, getSvgParameters()) {
+            @Override
+            public List<String> getVoltageLevelDetails(VoltageLevelNode vlNode) {
+                VoltageLevel vl = network.getVoltageLevel(vlNode.getEquipmentId());
+                return List.of(
+                        vl.getLoadCount() + " loads",
+                        vl.getGeneratorCount() + " generators",
+                        vl.getBatteryCount() + " batteries",
+                        vl.getDanglingLineCount() + " dangling lines");
+            }
+        };
+    }
+
+    @Test
+    void testProductionConsumption() {
+        Network network = Networks.createThreeVoltageLevelsFiveBusesWithValuesAtTerminals();
+
+        getSvgParameters().setVoltageLevelPowerDetails(true).setBusLegend(false);
+        labelProvider = new DefaultLabelProvider(network, getSvgParameters());
+        assertEquals(toString("/production-consumption-power-nodes.svg"), generateSvgString(network, "/production-consumption-power-nodes.svg"));
+    }
+
+    @Test
+    void testProductionConsumptionWithNaN() {
+        Network network = Networks.createThreeVoltageLevelsFiveBuses();
+
+        getSvgParameters().setVoltageLevelPowerDetails(true).setBusLegend(false);
+        labelProvider = new DefaultLabelProvider(network, getSvgParameters());
+        assertEquals(toString("/production_consumption_power_node_nan.svg"), generateSvgString(network, "/production_consumption_power_node_nan.svg"));
+    }
+
+    @Test
+    void testProductionConsumptionForceLayout() {
+        Network network = Networks.createThreeVoltageLevelsFiveBusesWithValuesAtTerminals();
+        getLayoutParameters().setPowerNodesForceLayout(true);
+        getSvgParameters().setVoltageLevelPowerDetails(true).setBusLegend(false);
+        labelProvider = new DefaultLabelProvider(network, getSvgParameters());
+        assertEquals(toString("/production-consumption-power-nodes-force-layout.svg"), generateSvgString(network, "production-consumption-power-nodes-force-layout.svg"));
+    }
+
+}

--- a/network-area-diagram/src/test/resources/3wt.svg
+++ b/network-area-diagram/src/test/resources/3wt.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}

--- a/network-area-diagram/src/test/resources/3wt_disconnected.svg
+++ b/network-area-diagram/src/test/resources/3wt_disconnected.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}

--- a/network-area-diagram/src/test/resources/3wt_disconnected_topological.svg
+++ b/network-area-diagram/src/test/resources/3wt_disconnected_topological.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-legend-square {width: 20px; height: 20px; background: var(--nad-vl-color, black);}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-disconnected {--nad-vl-color: #808080}

--- a/network-area-diagram/src/test/resources/3wt_metadata.json
+++ b/network-area-diagram/src/test/resources/3wt_metadata.json
@@ -7,7 +7,17 @@
       "y" : -40.0
     },
     "maxSteps" : 1000,
-    "textNodeEdgeConnectionYShift" : 25.0
+    "textNodeEdgeConnectionYShift" : 25.0,
+    "productionNodeFixedShift" : {
+      "x" : -100.0,
+      "y" : -50.0
+    },
+    "consumptionNodeFixedShift" : {
+      "x" : -100.0,
+      "y" : 50.0
+    },
+    "powerNodesForceLayout" : false,
+    "powerNodeRadius" : 15.0
   },
   "svgParameters" : {
     "diagramPadding" : {
@@ -53,7 +63,8 @@
     "currentValuePrecision" : 0,
     "edgeInfoDisplayed" : "ACTIVE_POWER",
     "pstArrowHeadSize" : 8.0,
-    "undefinedValueSymbol" : ""
+    "undefinedValueSymbol" : "",
+    "voltageLevelPowerDetails" : false
   },
   "busNodes" : [ {
     "svgId" : "1",

--- a/network-area-diagram/src/test/resources/3wt_partial.svg
+++ b/network-area-diagram/src/test/resources/3wt_partial.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}

--- a/network-area-diagram/src/test/resources/IEEE_118_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_118_bus.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-legend-square {width: 20px; height: 20px; background: var(--nad-vl-color, black);}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-disconnected {--nad-vl-color: #808080}

--- a/network-area-diagram/src/test/resources/IEEE_118_bus_partial.svg
+++ b/network-area-diagram/src/test/resources/IEEE_118_bus_partial.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-legend-square {width: 20px; height: 20px; background: var(--nad-vl-color, black);}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-disconnected {--nad-vl-color: #808080}

--- a/network-area-diagram/src/test/resources/IEEE_118_bus_partial_non_connected.svg
+++ b/network-area-diagram/src/test/resources/IEEE_118_bus_partial_non_connected.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-legend-square {width: 20px; height: 20px; background: var(--nad-vl-color, black);}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-disconnected {--nad-vl-color: #808080}

--- a/network-area-diagram/src/test/resources/IEEE_14_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_disconnection.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_disconnection.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_fictitious.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_fictitious.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_fictitious_metadata.json
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_fictitious_metadata.json
@@ -7,7 +7,17 @@
       "y" : -40.0
     },
     "maxSteps" : 1000,
-    "textNodeEdgeConnectionYShift" : 25.0
+    "textNodeEdgeConnectionYShift" : 25.0,
+    "productionNodeFixedShift" : {
+      "x" : -100.0,
+      "y" : -50.0
+    },
+    "consumptionNodeFixedShift" : {
+      "x" : -100.0,
+      "y" : 50.0
+    },
+    "powerNodesForceLayout" : false,
+    "powerNodeRadius" : 15.0
   },
   "svgParameters" : {
     "diagramPadding" : {
@@ -53,7 +63,8 @@
     "currentValuePrecision" : 0,
     "edgeInfoDisplayed" : "ACTIVE_POWER",
     "pstArrowHeadSize" : 8.0,
-    "undefinedValueSymbol" : ""
+    "undefinedValueSymbol" : "",
+    "voltageLevelPowerDetails" : false
   },
   "busNodes" : [ {
     "svgId" : "1",

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_text_nodes.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_text_nodes.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter1.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter1.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-legend-square {width: 20px; height: 20px; background: var(--nad-vl-color, black);}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-disconnected {--nad-vl-color: #808080}

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter2.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter2.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-legend-square {width: 20px; height: 20px; background: var(--nad-vl-color, black);}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-disconnected {--nad-vl-color: #808080}

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter2_metadata.json
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter2_metadata.json
@@ -7,7 +7,17 @@
       "y" : -40.0
     },
     "maxSteps" : 1000,
-    "textNodeEdgeConnectionYShift" : 25.0
+    "textNodeEdgeConnectionYShift" : 25.0,
+    "productionNodeFixedShift" : {
+      "x" : -100.0,
+      "y" : -50.0
+    },
+    "consumptionNodeFixedShift" : {
+      "x" : -100.0,
+      "y" : 50.0
+    },
+    "powerNodesForceLayout" : false,
+    "powerNodeRadius" : 15.0
   },
   "svgParameters" : {
     "diagramPadding" : {
@@ -53,7 +63,8 @@
     "currentValuePrecision" : 0,
     "edgeInfoDisplayed" : "ACTIVE_POWER",
     "pstArrowHeadSize" : 8.0,
-    "undefinedValueSymbol" : ""
+    "undefinedValueSymbol" : "",
+    "voltageLevelPowerDetails" : false
   },
   "busNodes" : [ {
     "svgId" : "1",

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter3.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter3.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-legend-square {width: 20px; height: 20px; background: var(--nad-vl-color, black);}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-disconnected {--nad-vl-color: #808080}

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter4.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter4.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-legend-square {width: 20px; height: 20px; background: var(--nad-vl-color, black);}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-disconnected {--nad-vl-color: #808080}

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter5.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter5.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-legend-square {width: 20px; height: 20px; background: var(--nad-vl-color, black);}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-disconnected {--nad-vl-color: #808080}

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter5_metadata.json
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter5_metadata.json
@@ -7,7 +7,17 @@
       "y" : -40.0
     },
     "maxSteps" : 1000,
-    "textNodeEdgeConnectionYShift" : 25.0
+    "textNodeEdgeConnectionYShift" : 25.0,
+    "productionNodeFixedShift" : {
+      "x" : -100.0,
+      "y" : -50.0
+    },
+    "consumptionNodeFixedShift" : {
+      "x" : -100.0,
+      "y" : 50.0
+    },
+    "powerNodesForceLayout" : false,
+    "powerNodeRadius" : 15.0
   },
   "svgParameters" : {
     "diagramPadding" : {
@@ -53,7 +63,8 @@
     "currentValuePrecision" : 0,
     "edgeInfoDisplayed" : "ACTIVE_POWER",
     "pstArrowHeadSize" : 8.0,
-    "undefinedValueSymbol" : ""
+    "undefinedValueSymbol" : "",
+    "voltageLevelPowerDetails" : false
   },
   "busNodes" : [ {
     "svgId" : "1",

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_nofilter.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_nofilter.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-legend-square {width: 20px; height: 20px; background: var(--nad-vl-color, black);}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-disconnected {--nad-vl-color: #808080}

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_nofilter_metadata.json
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_nofilter_metadata.json
@@ -7,7 +7,17 @@
       "y" : -40.0
     },
     "maxSteps" : 1000,
-    "textNodeEdgeConnectionYShift" : 25.0
+    "textNodeEdgeConnectionYShift" : 25.0,
+    "productionNodeFixedShift" : {
+      "x" : -100.0,
+      "y" : -50.0
+    },
+    "consumptionNodeFixedShift" : {
+      "x" : -100.0,
+      "y" : 50.0
+    },
+    "powerNodesForceLayout" : false,
+    "powerNodeRadius" : 15.0
   },
   "svgParameters" : {
     "diagramPadding" : {
@@ -53,7 +63,8 @@
     "currentValuePrecision" : 0,
     "edgeInfoDisplayed" : "ACTIVE_POWER",
     "pstArrowHeadSize" : 8.0,
-    "undefinedValueSymbol" : ""
+    "undefinedValueSymbol" : "",
+    "voltageLevelPowerDetails" : false
   },
   "busNodes" : [ {
     "svgId" : "1",

--- a/network-area-diagram/src/test/resources/IEEE_14_id_prefixed.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_id_prefixed.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}

--- a/network-area-diagram/src/test/resources/IEEE_24_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_24_bus.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}

--- a/network-area-diagram/src/test/resources/IEEE_30_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_30_bus.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}

--- a/network-area-diagram/src/test/resources/IEEE_57_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_57_bus.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-legend-square {width: 20px; height: 20px; background: var(--nad-vl-color, black);}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-disconnected {--nad-vl-color: #808080}

--- a/network-area-diagram/src/test/resources/current_limits.svg
+++ b/network-area-diagram/src/test/resources/current_limits.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}

--- a/network-area-diagram/src/test/resources/dangling_line_connected.svg
+++ b/network-area-diagram/src/test/resources/dangling_line_connected.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}

--- a/network-area-diagram/src/test/resources/dangling_line_disconnected.svg
+++ b/network-area-diagram/src/test/resources/dangling_line_disconnected.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}

--- a/network-area-diagram/src/test/resources/detailed_text_node.svg
+++ b/network-area-diagram/src/test/resources/detailed_text_node.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-legend-square {width: 20px; height: 20px; background: var(--nad-vl-color, black);}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-disconnected {--nad-vl-color: #808080}

--- a/network-area-diagram/src/test/resources/detailed_text_node_no_legend.svg
+++ b/network-area-diagram/src/test/resources/detailed_text_node_no_legend.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-legend-square {width: 20px; height: 20px; background: var(--nad-vl-color, black);}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-disconnected {--nad-vl-color: #808080}

--- a/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.0.svg
+++ b/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.0.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}

--- a/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.2.svg
+++ b/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.2.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}

--- a/network-area-diagram/src/test/resources/edge_info_current.svg
+++ b/network-area-diagram/src/test/resources/edge_info_current.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}

--- a/network-area-diagram/src/test/resources/edge_info_double_labels.svg
+++ b/network-area-diagram/src/test/resources/edge_info_double_labels.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}

--- a/network-area-diagram/src/test/resources/edge_info_missing_label.svg
+++ b/network-area-diagram/src/test/resources/edge_info_missing_label.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}

--- a/network-area-diagram/src/test/resources/edge_info_perpendicular_label.svg
+++ b/network-area-diagram/src/test/resources/edge_info_perpendicular_label.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}

--- a/network-area-diagram/src/test/resources/edge_info_reactive_power.svg
+++ b/network-area-diagram/src/test/resources/edge_info_reactive_power.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}

--- a/network-area-diagram/src/test/resources/edge_info_shift.svg
+++ b/network-area-diagram/src/test/resources/edge_info_shift.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}

--- a/network-area-diagram/src/test/resources/edge_without_id.svg
+++ b/network-area-diagram/src/test/resources/edge_without_id.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}

--- a/network-area-diagram/src/test/resources/hvdc-vl-depth-1.svg
+++ b/network-area-diagram/src/test/resources/hvdc-vl-depth-1.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}

--- a/network-area-diagram/src/test/resources/hvdc.svg
+++ b/network-area-diagram/src/test/resources/hvdc.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}

--- a/network-area-diagram/src/test/resources/hvdc_metadata.json
+++ b/network-area-diagram/src/test/resources/hvdc_metadata.json
@@ -7,7 +7,17 @@
       "y" : -40.0
     },
     "maxSteps" : 1000,
-    "textNodeEdgeConnectionYShift" : 25.0
+    "textNodeEdgeConnectionYShift" : 25.0,
+    "productionNodeFixedShift" : {
+      "x" : -100.0,
+      "y" : -50.0
+    },
+    "consumptionNodeFixedShift" : {
+      "x" : -100.0,
+      "y" : 50.0
+    },
+    "powerNodesForceLayout" : false,
+    "powerNodeRadius" : 15.0
   },
   "svgParameters" : {
     "diagramPadding" : {
@@ -53,7 +63,8 @@
     "currentValuePrecision" : 0,
     "edgeInfoDisplayed" : "ACTIVE_POWER",
     "pstArrowHeadSize" : 8.0,
-    "undefinedValueSymbol" : ""
+    "undefinedValueSymbol" : "",
+    "voltageLevelPowerDetails" : false
   },
   "busNodes" : [ {
     "svgId" : "1",

--- a/network-area-diagram/src/test/resources/parallel_transformers.svg
+++ b/network-area-diagram/src/test/resources/parallel_transformers.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}

--- a/network-area-diagram/src/test/resources/production-consumption-power-nodes-force-layout.svg
+++ b/network-area-diagram/src/test/resources/production-consumption-power-nodes-force-layout.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="800.00" height="845.03" viewBox="-465.87 -553.80 876.23 925.55" xmlns="http://www.w3.org/2000/svg">
+<svg width="800.00" height="1180.87" viewBox="-532.54 -781.15 1089.80 1608.63" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
@@ -113,171 +113,181 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 }
 ]]></style>
     <g class="nad-vl-nodes">
-        <g transform="translate(-80.30,-211.15)" id="0">
+        <g transform="translate(230.58,170.39)" id="0">
             <circle r="27.50" id="1" class="nad-vl300to500-0 nad-busnode"/>
-            <path d="M-57.312,4.651 A57.500,57.500 345.053 1 1 -54.173,19.276 L-29.374,13.907 A32.500,32.500 -333.556 1 0 -32.494,-0.629 Z " id="2" class="nad-vl300to500-1 nad-busnode"/>
+            <path d="M-22.546,-52.895 A57.500,57.500 345.053 1 1 -35.426,-45.291 L-22.487,-23.465 A32.500,32.500 -333.556 1 0 -9.685,-31.024 Z " id="2" class="nad-vl300to500-1 nad-busnode"/>
         </g>
-        <g transform="translate(-265.87,-43.40)" id="3">
+        <g transform="translate(-224.31,-86.36)" id="3">
             <circle r="27.50" id="4" class="nad-vl300to500-0 nad-busnode"/>
         </g>
-        <g transform="translate(-19.83,171.75)" id="5">
+        <g transform="translate(257.26,-149.11)" id="5">
             <circle r="27.50" id="6" class="nad-vl180to300-0 nad-busnode"/>
-            <path d="M-1.506,-57.480 A57.500,57.500 345.053 1 1 -16.281,-55.147 L-12.278,-30.092 A32.500,32.500 -333.556 1 0 2.407,-32.411 Z " id="7" class="nad-vl180to300-1 nad-busnode"/>
+            <path d="M-12.196,56.192 A57.500,57.500 345.053 1 1 2.710,57.436 L4.776,32.147 A32.500,32.500 -333.556 1 0 -10.040,30.910 Z " id="7" class="nad-vl180to300-1 nad-busnode"/>
         </g>
-        <g transform="translate(210.36,-353.80)" id="12" class="nad-boundary-node">
-            <path d="M15.016,23.038 A27.500,27.500 180.000 0 1 -15.016,-23.038" id="13" class="nad-vl300to500-0 nad-busnode"/>
+        <g transform="translate(-332.54,-538.01)" id="12" class="nad-boundary-node">
+            <path d="M26.743,-6.409 A27.500,27.500 180.000 0 1 -26.743,6.409" id="13" class="nad-vl300to500-0 nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="8">
             <g id="8.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-107.19,-205.38 -158.52,-194.37 -199.91,-156.95"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-180.78,-174.25)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="216.60,146.71 189.91,101.50 22.80,7.18"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(163.78,86.75)">
                     <g class="nad-active">
-                        <g transform="rotate(-132.11)">
+                        <g transform="rotate(-60.56)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-42.11)" x="-19.00" style="text-anchor:end"></text>
+                        <text transform="rotate(-330.56)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
             <g id="8.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-257.43,-69.57 -241.30,-119.53 -199.91,-156.95"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-219.05,-139.65)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-196.81,-86.63 -144.31,-87.14 22.80,7.18"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-118.18,-72.39)">
                     <g class="nad-active">
-                        <g transform="rotate(47.89)">
+                        <g transform="rotate(119.44)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-42.11)" x="19.00"></text>
+                        <text transform="rotate(29.44)" x="19.00"></text>
                     </g>
                 </g>
             </g>
         </g>
         <g id="9">
             <g id="9.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-97.96,-156.43 -104.87,-135.02 -146.26,-97.60"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-127.13,-114.90)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="173.08,170.95 150.59,171.17 -16.52,76.85"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(124.46,156.42)">
                     <g class="nad-active">
-                        <g transform="rotate(-132.11)">
+                        <g transform="rotate(-60.56)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-42.11)" x="-19.00" style="text-anchor:end"></text>
+                        <text transform="rotate(-330.56)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
             <g id="9.2" class="nad-disconnected nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-238.99,-49.17 -187.65,-60.19 -146.26,-97.60"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-165.40,-80.31)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-210.32,-62.68 -183.63,-17.47 -16.52,76.85"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-157.51,-2.72)">
                     <g class="nad-active">
-                        <g transform="rotate(47.89)">
+                        <g transform="rotate(119.44)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-42.11)" x="19.00"></text>
+                        <text transform="rotate(29.44)" x="19.00"></text>
                     </g>
                 </g>
             </g>
         </g>
         <g id="10">
             <g id="10.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-71.33,-154.36 -52.41,-34.52"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-66.26,-122.26)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="235.37,113.09 242.67,25.59"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(238.07,80.70)">
                     <g class="nad-active">
-                        <g transform="rotate(171.03)">
+                        <g transform="rotate(4.77)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(81.03)" x="19.00"></text>
+                        <text transform="rotate(-85.23)" x="19.00"></text>
                     </g>
                 </g>
             </g>
             <g id="10.2" class="nad-vl180to300-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-24.12,144.59 -43.05,24.75"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-33.87,82.85)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="254.97,-121.71 247.66,-34.21"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(249.77,-59.43)">
                     <g class="nad-active">
-                        <g transform="rotate(-8.97)">
+                        <g transform="rotate(-175.23)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-278.97)" x="-19.00" style="text-anchor:end"></text>
+                        <text transform="rotate(-85.23)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
             <g class="nad-glued-center">
-                <circle class="nad-vl300to500-line nad-winding" cx="-49.29" cy="-14.76" r="20.00"/>
-                <circle class="nad-vl180to300-line nad-winding" cx="-46.17" cy="4.99" r="20.00"/>
+                <circle class="nad-vl300to500-line nad-winding" cx="244.33" cy="5.66" r="20.00"/>
+                <circle class="nad-vl180to300-line nad-winding" cx="246.00" cy="-14.28" r="20.00"/>
             </g>
         </g>
         <g id="11">
             <g id="11.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-245.17,-25.30 -176.73,34.55"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-220.71,-3.90)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-197.04,-89.91 -28.15,-111.92"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-164.81,-94.11)">
                     <g class="nad-active">
-                        <g transform="rotate(131.17)">
+                        <g transform="rotate(82.58)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(41.17)" x="19.00"></text>
+                        <text transform="rotate(-7.42)" x="19.00"></text>
                     </g>
                 </g>
             </g>
             <g id="11.2" class="nad-vl180to300-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-63.12,133.90 -131.56,74.05"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-87.58,112.51)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="200.24,-141.68 31.35,-119.67"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(168.01,-137.48)">
                     <g class="nad-active">
-                        <g transform="rotate(-48.83)">
+                        <g transform="rotate(-97.42)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-318.83)" x="-19.00" style="text-anchor:end"></text>
+                        <text transform="rotate(-7.42)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
             <g class="nad-glued-center">
-                <circle class="nad-vl300to500-line nad-winding" cx="-161.67" cy="47.72" r="20.00"/>
-                <circle class="nad-vl180to300-line nad-winding" cx="-146.62" cy="60.88" r="20.00"/>
+                <circle class="nad-vl300to500-line nad-winding" cx="-8.32" cy="-114.51" r="20.00"/>
+                <circle class="nad-vl180to300-line nad-winding" cx="11.52" cy="-117.09" r="20.00"/>
             </g>
         </g>
         <g id="14" class="nad-dangling-line-edge">
             <g id="14.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-242.83,-58.42 -27.76,-198.60"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-215.61,-76.16)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-230.71,-113.10 -278.42,-312.18"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-238.29,-144.71)">
                     <g class="nad-active">
-                        <g transform="rotate(56.90)">
+                        <g transform="rotate(-13.48)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-33.10)" x="19.00"></text>
+                        <text transform="rotate(-283.48)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
             <g id="14.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="187.32,-338.78 -27.76,-198.60"/>
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-326.13,-511.27 -278.42,-312.18"/>
             </g>
         </g>
     </g>
     <g class="nad-text-edges">
-        <polyline id="0-textedge" points="-20.97,-220.05 19.70,-226.15"/>
-        <polyline id="3-textedge" points="-236.20,-47.85 -165.87,-58.40"/>
-        <polyline id="5-textedge" points="39.50,162.85 80.17,156.75"/>
+        <polyline id="0-textedge" points="289.92,161.49 330.58,155.39"/>
+        <polyline id="3-textedge" points="-194.64,-90.81 -124.31,-101.36"/>
+        <polyline id="5-textedge" points="316.59,-158.01 357.26,-164.11"/>
     </g>
     <g class="nad-text-nodes">
-        <foreignObject id="0-textnode" y="-251.15" x="19.70" height="1" width="1">
-            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
-                <div>Voltage level 1</div>
+        <text id="0-textnode" y="155.39" x="330.58">Voltage level 1</text>
+        <text id="3-textnode" y="-101.36" x="-124.31">Voltage level 2</text>
+        <text id="5-textnode" y="-164.11" x="357.26">vl3</text>
+    </g>
+    <g class="nad-power-edges">
+        <polyline id="0-prodedge" points="228.72,230.36 216.83,612.49"/>
+    </g>
+    <g class="nad-text-nodes">
+        <circle class="nad-power-icon" cx="216.36" cy="627.48" r="15.00"/>
+        <foreignObject id="0-prodnode" y="612.48" x="-23.64" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-power-label">
+                <div>100 MW / 10 MVAR</div>
             </div>
         </foreignObject>
-        <foreignObject id="3-textnode" y="-83.40" x="-165.87" height="1" width="1">
-            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
-                <div>Voltage level 2</div>
-            </div>
-        </foreignObject>
-        <foreignObject id="5-textnode" y="131.75" x="80.17" height="1" width="1">
-            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
-                <div>vl3</div>
+    </g>
+    <g class="nad-power-edges">
+        <polyline id="5-consumptionedge" points="246.18,-208.08 178.89,-566.41"/>
+    </g>
+    <g class="nad-text-nodes">
+        <circle class="nad-power-icon" cx="176.12" cy="-581.15" r="15.00"/>
+        <foreignObject id="5-consumptionnode" y="-596.15" x="-33.88" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-power-label">
+                <div>99 MW / 9 MVAR</div>
             </div>
         </foreignObject>
     </g>

--- a/network-area-diagram/src/test/resources/production-consumption-power-nodes.svg
+++ b/network-area-diagram/src/test/resources/production-consumption-power-nodes.svg
@@ -5,8 +5,8 @@
 .nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 3; stroke-dasharray: 6,7}
 .nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
-.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
-.nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightgrey)}
+.nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 40}
 .nad-branch-edges .nad-tie-line-edge .nad-edge-path {stroke-width: 7}
 .nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
@@ -22,14 +22,79 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-power-edges {stroke: black; stroke-width: 2;}
 .nad-power-label {width: max-content;}
 .nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
+.nad-legend-square {width: 20px; height: 20px; background: var(--nad-vl-color, black);}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
-.nad-vl0to30 {--nad-vl-color: #AFB42B}
-.nad-vl30to50 {--nad-vl-color: #EF9A9A}
-.nad-vl50to70 {--nad-vl-color: #9C27B0}
-.nad-vl70to120 {--nad-vl-color: #E65100}
-.nad-vl120to180 {--nad-vl-color: #00ACC1}
-.nad-vl180to300 {--nad-vl-color: #2E7D32}
-.nad-vl300to500 {--nad-vl-color: #D32F2F}
+.nad-disconnected {--nad-vl-color: #808080}
+.nad-vl0to30-line {--nad-vl-color: #afb42b}
+.nad-vl0to30-0 {--nad-vl-color: #827717}
+.nad-vl0to30-1 {--nad-vl-color: #d4e157}
+.nad-vl0to30-2 {--nad-vl-color: #e6ee9c}
+.nad-vl0to30-3 {--nad-vl-color: #c0ca33}
+.nad-vl0to30-4 {--nad-vl-color: #f0fc83}
+.nad-vl0to30-5 {--nad-vl-color: #9e9d24}
+.nad-vl0to30-6 {--nad-vl-color: #cddc39}
+.nad-vl0to30-7 {--nad-vl-color: #dce775}
+.nad-vl0to30-8 {--nad-vl-color: #ddfc88}
+.nad-vl30to50-line {--nad-vl-color: #ef9a9a}
+.nad-vl30to50-0 {--nad-vl-color: #c2185b}
+.nad-vl30to50-1 {--nad-vl-color: #f06292}
+.nad-vl30to50-2 {--nad-vl-color: #d81b60}
+.nad-vl30to50-3 {--nad-vl-color: #ec407a}
+.nad-vl30to50-4 {--nad-vl-color: #880e4f}
+.nad-vl30to50-5 {--nad-vl-color: #ad1457}
+.nad-vl30to50-6 {--nad-vl-color: #e91e63}
+.nad-vl30to50-7 {--nad-vl-color: #f48fb1}
+.nad-vl30to50-8 {--nad-vl-color: #f8bbd0}
+.nad-vl50to70-line {--nad-vl-color: #9c27b0}
+.nad-vl50to70-0 {--nad-vl-color: #7b1fa2}
+.nad-vl50to70-1 {--nad-vl-color: #ba68c8}
+.nad-vl50to70-2 {--nad-vl-color: #512da8}
+.nad-vl50to70-3 {--nad-vl-color: #ab47bc}
+.nad-vl50to70-4 {--nad-vl-color: #e1bee7}
+.nad-vl50to70-5 {--nad-vl-color: #6a1b9a}
+.nad-vl50to70-6 {--nad-vl-color: #4a148c}
+.nad-vl50to70-7 {--nad-vl-color: #ce93d8}
+.nad-vl50to70-8 {--nad-vl-color: #9575cd}
+.nad-vl70to120-line {--nad-vl-color: #e65100}
+.nad-vl70to120-0 {--nad-vl-color: #fb8c00}
+.nad-vl70to120-1 {--nad-vl-color: #ffb74d}
+.nad-vl70to120-2 {--nad-vl-color: #f57c00}
+.nad-vl70to120-3 {--nad-vl-color: #ffa726}
+.nad-vl70to120-4 {--nad-vl-color: #ffe0b2}
+.nad-vl70to120-5 {--nad-vl-color: #ef6c00}
+.nad-vl70to120-6 {--nad-vl-color: #ff9800}
+.nad-vl70to120-7 {--nad-vl-color: #ffcc80}
+.nad-vl70to120-8 {--nad-vl-color: #fff3e0}
+.nad-vl120to180-line {--nad-vl-color: #00ACC1}
+.nad-vl120to180-0 {--nad-vl-color: #4fc3f7}
+.nad-vl120to180-1 {--nad-vl-color: #01579b}
+.nad-vl120to180-2 {--nad-vl-color: #b3e5fc}
+.nad-vl120to180-3 {--nad-vl-color: #039be5}
+.nad-vl120to180-4 {--nad-vl-color: #81d4fa}
+.nad-vl120to180-5 {--nad-vl-color: #0288d1}
+.nad-vl120to180-6 {--nad-vl-color: #29b6f6}
+.nad-vl120to180-7 {--nad-vl-color: #0277bd}
+.nad-vl120to180-8 {--nad-vl-color: #03a9f4}
+.nad-vl180to300-line {--nad-vl-color: #2e7d32}
+.nad-vl180to300-0 {--nad-vl-color: #81c784}
+.nad-vl180to300-1 {--nad-vl-color: #558b2f}
+.nad-vl180to300-2 {--nad-vl-color: #c8e6c9}
+.nad-vl180to300-3 {--nad-vl-color: #43a047}
+.nad-vl180to300-4 {--nad-vl-color: #a5d6a7}
+.nad-vl180to300-5 {--nad-vl-color: #388e3c}
+.nad-vl180to300-6 {--nad-vl-color: #66bb6a}
+.nad-vl180to300-7 {--nad-vl-color: #1b5e20}
+.nad-vl180to300-8 {--nad-vl-color: #4caf50}
+.nad-vl300to500-line {--nad-vl-color: #d32f2f}
+.nad-vl300to500-0 {--nad-vl-color: #ef5350}
+.nad-vl300to500-1 {--nad-vl-color: #ef9a9a}
+.nad-vl300to500-2 {--nad-vl-color: #b71c1c}
+.nad-vl300to500-3 {--nad-vl-color: #e57373}
+.nad-vl300to500-4 {--nad-vl-color: #e53935}
+.nad-vl300to500-5 {--nad-vl-color: #ff8a80}
+.nad-vl300to500-6 {--nad-vl-color: #f44336}
+.nad-vl300to500-7 {--nad-vl-color: #ffcdd2}
+.nad-vl300to500-8 {--nad-vl-color: #c62828}
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
@@ -48,24 +113,24 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 }
 ]]></style>
     <g class="nad-vl-nodes">
-        <g transform="translate(-80.30,-211.15)" id="0" class="nad-vl300to500">
-            <circle r="27.50" id="1" class="nad-busnode"/>
-            <path d="M-57.312,4.651 A57.500,57.500 345.053 1 1 -54.173,19.276 L-29.374,13.907 A32.500,32.500 -333.556 1 0 -32.494,-0.629 Z " id="2" class="nad-busnode"/>
+        <g transform="translate(-80.30,-211.15)" id="0">
+            <circle r="27.50" id="1" class="nad-vl300to500-0 nad-busnode"/>
+            <path d="M-57.312,4.651 A57.500,57.500 345.053 1 1 -54.173,19.276 L-29.374,13.907 A32.500,32.500 -333.556 1 0 -32.494,-0.629 Z " id="2" class="nad-vl300to500-1 nad-busnode"/>
         </g>
-        <g transform="translate(-265.87,-43.40)" id="3" class="nad-vl300to500">
-            <circle r="27.50" id="4" class="nad-busnode"/>
+        <g transform="translate(-265.87,-43.40)" id="3">
+            <circle r="27.50" id="4" class="nad-vl300to500-0 nad-busnode"/>
         </g>
-        <g transform="translate(-19.83,171.75)" id="5" class="nad-vl180to300">
-            <circle r="27.50" id="6" class="nad-busnode"/>
-            <path d="M-1.506,-57.480 A57.500,57.500 345.053 1 1 -16.281,-55.147 L-12.278,-30.092 A32.500,32.500 -333.556 1 0 2.407,-32.411 Z " id="7" class="nad-busnode"/>
+        <g transform="translate(-19.83,171.75)" id="5">
+            <circle r="27.50" id="6" class="nad-vl180to300-0 nad-busnode"/>
+            <path d="M-1.506,-57.480 A57.500,57.500 345.053 1 1 -16.281,-55.147 L-12.278,-30.092 A32.500,32.500 -333.556 1 0 2.407,-32.411 Z " id="7" class="nad-vl180to300-1 nad-busnode"/>
         </g>
-        <g transform="translate(210.36,-353.80)" id="12" class="nad-boundary-node nad-vl300to500">
-            <path d="M15.016,23.038 A27.500,27.500 180.000 0 1 -15.016,-23.038" id="13" class="nad-busnode"/>
+        <g transform="translate(210.36,-353.80)" id="12" class="nad-boundary-node">
+            <path d="M15.016,23.038 A27.500,27.500 180.000 0 1 -15.016,-23.038" id="13" class="nad-vl300to500-0 nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="8">
-            <g id="8.1" class="nad-vl300to500">
+            <g id="8.1" class="nad-vl300to500-line">
                 <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-107.19,-205.38 -158.52,-194.37 -199.91,-156.95"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-180.78,-174.25)">
                     <g class="nad-active">
@@ -77,7 +142,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g id="8.2" class="nad-vl300to500">
+            <g id="8.2" class="nad-vl300to500-line">
                 <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-257.43,-69.57 -241.30,-119.53 -199.91,-156.95"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-219.05,-139.65)">
                     <g class="nad-active">
@@ -89,14 +154,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
-                <g class="nad-edge-label" transform="translate(-199.91,-156.95)">
-                    <text transform="rotate(-42.11)" x="0.00" style="text-anchor:middle">l1</text>
-                </g>
-            </g>
         </g>
         <g id="9">
-            <g id="9.1" class="nad-vl300to500">
+            <g id="9.1" class="nad-vl300to500-line">
                 <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-97.96,-156.43 -104.87,-135.02 -146.26,-97.60"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-127.13,-114.90)">
                     <g class="nad-active">
@@ -108,7 +168,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g id="9.2" class="nad-disconnected nad-vl300to500">
+            <g id="9.2" class="nad-disconnected nad-vl300to500-line">
                 <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-238.99,-49.17 -187.65,-60.19 -146.26,-97.60"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-165.40,-80.31)">
                     <g class="nad-active">
@@ -120,14 +180,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
-                <g class="nad-edge-label" transform="translate(-146.26,-97.60)">
-                    <text transform="rotate(-42.11)" x="0.00" style="text-anchor:middle">l2</text>
-                </g>
-            </g>
         </g>
         <g id="10">
-            <g id="10.1" class="nad-vl300to500">
+            <g id="10.1" class="nad-vl300to500-line">
                 <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-71.33,-154.36 -52.41,-34.52"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-66.26,-122.26)">
                     <g class="nad-active">
@@ -139,7 +194,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g id="10.2" class="nad-vl180to300">
+            <g id="10.2" class="nad-vl180to300-line">
                 <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-24.12,144.59 -43.05,24.75"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-33.87,82.85)">
                     <g class="nad-active">
@@ -152,15 +207,12 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g class="nad-glued-center">
-                <circle class="nad-vl300to500 nad-winding" cx="-49.29" cy="-14.76" r="20.00"/>
-                <circle class="nad-vl180to300 nad-winding" cx="-46.17" cy="4.99" r="20.00"/>
-                <g class="nad-edge-label" transform="translate(-47.73,-4.88)">
-                    <text transform="rotate(81.03)" x="0.00" style="text-anchor:middle">tr1</text>
-                </g>
+                <circle class="nad-vl300to500-line nad-winding" cx="-49.29" cy="-14.76" r="20.00"/>
+                <circle class="nad-vl180to300-line nad-winding" cx="-46.17" cy="4.99" r="20.00"/>
             </g>
         </g>
         <g id="11">
-            <g id="11.1" class="nad-vl300to500">
+            <g id="11.1" class="nad-vl300to500-line">
                 <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-245.17,-25.30 -176.73,34.55"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-220.71,-3.90)">
                     <g class="nad-active">
@@ -172,7 +224,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g id="11.2" class="nad-vl180to300">
+            <g id="11.2" class="nad-vl180to300-line">
                 <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-63.12,133.90 -131.56,74.05"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-87.58,112.51)">
                     <g class="nad-active">
@@ -185,15 +237,12 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g class="nad-glued-center">
-                <circle class="nad-vl300to500 nad-winding" cx="-161.67" cy="47.72" r="20.00"/>
-                <circle class="nad-vl180to300 nad-winding" cx="-146.62" cy="60.88" r="20.00"/>
-                <g class="nad-edge-label" transform="translate(-154.14,54.30)">
-                    <text transform="rotate(41.17)" x="0.00" style="text-anchor:middle">tr2</text>
-                </g>
+                <circle class="nad-vl300to500-line nad-winding" cx="-161.67" cy="47.72" r="20.00"/>
+                <circle class="nad-vl180to300-line nad-winding" cx="-146.62" cy="60.88" r="20.00"/>
             </g>
         </g>
         <g id="14" class="nad-dangling-line-edge">
-            <g id="14.1" class="nad-vl300to500">
+            <g id="14.1" class="nad-vl300to500-line">
                 <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-242.83,-58.42 -27.76,-198.60"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-215.61,-76.16)">
                     <g class="nad-active">
@@ -205,7 +254,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g id="14.2" class="nad-vl300to500">
+            <g id="14.2" class="nad-vl300to500-line">
                 <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="187.32,-338.78 -27.76,-198.60"/>
             </g>
         </g>
@@ -216,55 +265,29 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <polyline id="5-textedge" points="39.50,162.85 80.17,156.75"/>
     </g>
     <g class="nad-text-nodes">
-        <foreignObject id="0-textnode" y="-251.15" x="19.70" height="1" width="1">
-            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
-                <div>Voltage level 1</div>
-                <table>
-                    <tr>
-                        <td>
-                            <div class="nad-legend-square"/>
-                        </td>
-                        <td> kV / °</td>
-                    </tr>
-                    <tr>
-                        <td>
-                            <div class="nad-legend-square"/>
-                        </td>
-                        <td> kV / °</td>
-                    </tr>
-                </table>
+        <text id="0-textnode" y="-226.15" x="19.70">Voltage level 1</text>
+        <text id="3-textnode" y="-58.40" x="-165.87">Voltage level 2</text>
+        <text id="5-textnode" y="156.75" x="80.17">vl3</text>
+    </g>
+    <g class="nad-power-edges">
+        <polyline id="0-prodedge" points="-133.97,-237.99 -166.89,-254.45"/>
+    </g>
+    <g class="nad-text-nodes">
+        <circle class="nad-power-icon" cx="-180.30" cy="-261.15" r="15.00"/>
+        <foreignObject id="0-prodnode" y="-276.15" x="-420.30" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-power-label">
+                <div>100 MW / 10 MVAR</div>
             </div>
         </foreignObject>
-        <foreignObject id="3-textnode" y="-83.40" x="-165.87" height="1" width="1">
-            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
-                <div>Voltage level 2</div>
-                <table>
-                    <tr>
-                        <td>
-                            <div class="nad-legend-square"/>
-                        </td>
-                        <td> kV / °</td>
-                    </tr>
-                </table>
-            </div>
-        </foreignObject>
-        <foreignObject id="5-textnode" y="131.75" x="80.17" height="1" width="1">
-            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
-                <div>vl3</div>
-                <table>
-                    <tr>
-                        <td>
-                            <div class="nad-legend-square"/>
-                        </td>
-                        <td> kV / °</td>
-                    </tr>
-                    <tr>
-                        <td>
-                            <div class="nad-legend-square"/>
-                        </td>
-                        <td> kV / °</td>
-                    </tr>
-                </table>
+    </g>
+    <g class="nad-power-edges">
+        <polyline id="5-consumptionedge" points="-73.50,198.58 -106.42,215.04"/>
+    </g>
+    <g class="nad-text-nodes">
+        <circle class="nad-power-icon" cx="-119.83" cy="221.75" r="15.00"/>
+        <foreignObject id="5-consumptionnode" y="206.75" x="-329.83" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-power-label">
+                <div>99 MW / 9 MVAR</div>
             </div>
         </foreignObject>
     </g>

--- a/network-area-diagram/src/test/resources/production_consumption_power_node_nan.svg
+++ b/network-area-diagram/src/test/resources/production_consumption_power_node_nan.svg
@@ -5,8 +5,8 @@
 .nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 3; stroke-dasharray: 6,7}
 .nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
-.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
-.nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightgrey)}
+.nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 40}
 .nad-branch-edges .nad-tie-line-edge .nad-edge-path {stroke-width: 7}
 .nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
@@ -22,14 +22,79 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-power-edges {stroke: black; stroke-width: 2;}
 .nad-power-label {width: max-content;}
 .nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
+.nad-legend-square {width: 20px; height: 20px; background: var(--nad-vl-color, black);}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
-.nad-vl0to30 {--nad-vl-color: #AFB42B}
-.nad-vl30to50 {--nad-vl-color: #EF9A9A}
-.nad-vl50to70 {--nad-vl-color: #9C27B0}
-.nad-vl70to120 {--nad-vl-color: #E65100}
-.nad-vl120to180 {--nad-vl-color: #00ACC1}
-.nad-vl180to300 {--nad-vl-color: #2E7D32}
-.nad-vl300to500 {--nad-vl-color: #D32F2F}
+.nad-disconnected {--nad-vl-color: #808080}
+.nad-vl0to30-line {--nad-vl-color: #afb42b}
+.nad-vl0to30-0 {--nad-vl-color: #827717}
+.nad-vl0to30-1 {--nad-vl-color: #d4e157}
+.nad-vl0to30-2 {--nad-vl-color: #e6ee9c}
+.nad-vl0to30-3 {--nad-vl-color: #c0ca33}
+.nad-vl0to30-4 {--nad-vl-color: #f0fc83}
+.nad-vl0to30-5 {--nad-vl-color: #9e9d24}
+.nad-vl0to30-6 {--nad-vl-color: #cddc39}
+.nad-vl0to30-7 {--nad-vl-color: #dce775}
+.nad-vl0to30-8 {--nad-vl-color: #ddfc88}
+.nad-vl30to50-line {--nad-vl-color: #ef9a9a}
+.nad-vl30to50-0 {--nad-vl-color: #c2185b}
+.nad-vl30to50-1 {--nad-vl-color: #f06292}
+.nad-vl30to50-2 {--nad-vl-color: #d81b60}
+.nad-vl30to50-3 {--nad-vl-color: #ec407a}
+.nad-vl30to50-4 {--nad-vl-color: #880e4f}
+.nad-vl30to50-5 {--nad-vl-color: #ad1457}
+.nad-vl30to50-6 {--nad-vl-color: #e91e63}
+.nad-vl30to50-7 {--nad-vl-color: #f48fb1}
+.nad-vl30to50-8 {--nad-vl-color: #f8bbd0}
+.nad-vl50to70-line {--nad-vl-color: #9c27b0}
+.nad-vl50to70-0 {--nad-vl-color: #7b1fa2}
+.nad-vl50to70-1 {--nad-vl-color: #ba68c8}
+.nad-vl50to70-2 {--nad-vl-color: #512da8}
+.nad-vl50to70-3 {--nad-vl-color: #ab47bc}
+.nad-vl50to70-4 {--nad-vl-color: #e1bee7}
+.nad-vl50to70-5 {--nad-vl-color: #6a1b9a}
+.nad-vl50to70-6 {--nad-vl-color: #4a148c}
+.nad-vl50to70-7 {--nad-vl-color: #ce93d8}
+.nad-vl50to70-8 {--nad-vl-color: #9575cd}
+.nad-vl70to120-line {--nad-vl-color: #e65100}
+.nad-vl70to120-0 {--nad-vl-color: #fb8c00}
+.nad-vl70to120-1 {--nad-vl-color: #ffb74d}
+.nad-vl70to120-2 {--nad-vl-color: #f57c00}
+.nad-vl70to120-3 {--nad-vl-color: #ffa726}
+.nad-vl70to120-4 {--nad-vl-color: #ffe0b2}
+.nad-vl70to120-5 {--nad-vl-color: #ef6c00}
+.nad-vl70to120-6 {--nad-vl-color: #ff9800}
+.nad-vl70to120-7 {--nad-vl-color: #ffcc80}
+.nad-vl70to120-8 {--nad-vl-color: #fff3e0}
+.nad-vl120to180-line {--nad-vl-color: #00ACC1}
+.nad-vl120to180-0 {--nad-vl-color: #4fc3f7}
+.nad-vl120to180-1 {--nad-vl-color: #01579b}
+.nad-vl120to180-2 {--nad-vl-color: #b3e5fc}
+.nad-vl120to180-3 {--nad-vl-color: #039be5}
+.nad-vl120to180-4 {--nad-vl-color: #81d4fa}
+.nad-vl120to180-5 {--nad-vl-color: #0288d1}
+.nad-vl120to180-6 {--nad-vl-color: #29b6f6}
+.nad-vl120to180-7 {--nad-vl-color: #0277bd}
+.nad-vl120to180-8 {--nad-vl-color: #03a9f4}
+.nad-vl180to300-line {--nad-vl-color: #2e7d32}
+.nad-vl180to300-0 {--nad-vl-color: #81c784}
+.nad-vl180to300-1 {--nad-vl-color: #558b2f}
+.nad-vl180to300-2 {--nad-vl-color: #c8e6c9}
+.nad-vl180to300-3 {--nad-vl-color: #43a047}
+.nad-vl180to300-4 {--nad-vl-color: #a5d6a7}
+.nad-vl180to300-5 {--nad-vl-color: #388e3c}
+.nad-vl180to300-6 {--nad-vl-color: #66bb6a}
+.nad-vl180to300-7 {--nad-vl-color: #1b5e20}
+.nad-vl180to300-8 {--nad-vl-color: #4caf50}
+.nad-vl300to500-line {--nad-vl-color: #d32f2f}
+.nad-vl300to500-0 {--nad-vl-color: #ef5350}
+.nad-vl300to500-1 {--nad-vl-color: #ef9a9a}
+.nad-vl300to500-2 {--nad-vl-color: #b71c1c}
+.nad-vl300to500-3 {--nad-vl-color: #e57373}
+.nad-vl300to500-4 {--nad-vl-color: #e53935}
+.nad-vl300to500-5 {--nad-vl-color: #ff8a80}
+.nad-vl300to500-6 {--nad-vl-color: #f44336}
+.nad-vl300to500-7 {--nad-vl-color: #ffcdd2}
+.nad-vl300to500-8 {--nad-vl-color: #c62828}
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
@@ -48,24 +113,24 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 }
 ]]></style>
     <g class="nad-vl-nodes">
-        <g transform="translate(-80.30,-211.15)" id="0" class="nad-vl300to500">
-            <circle r="27.50" id="1" class="nad-busnode"/>
-            <path d="M-57.312,4.651 A57.500,57.500 345.053 1 1 -54.173,19.276 L-29.374,13.907 A32.500,32.500 -333.556 1 0 -32.494,-0.629 Z " id="2" class="nad-busnode"/>
+        <g transform="translate(-80.30,-211.15)" id="0">
+            <circle r="27.50" id="1" class="nad-vl300to500-0 nad-busnode"/>
+            <path d="M-57.312,4.651 A57.500,57.500 345.053 1 1 -54.173,19.276 L-29.374,13.907 A32.500,32.500 -333.556 1 0 -32.494,-0.629 Z " id="2" class="nad-vl300to500-1 nad-busnode"/>
         </g>
-        <g transform="translate(-265.87,-43.40)" id="3" class="nad-vl300to500">
-            <circle r="27.50" id="4" class="nad-busnode"/>
+        <g transform="translate(-265.87,-43.40)" id="3">
+            <circle r="27.50" id="4" class="nad-vl300to500-0 nad-busnode"/>
         </g>
-        <g transform="translate(-19.83,171.75)" id="5" class="nad-vl180to300">
-            <circle r="27.50" id="6" class="nad-busnode"/>
-            <path d="M-1.506,-57.480 A57.500,57.500 345.053 1 1 -16.281,-55.147 L-12.278,-30.092 A32.500,32.500 -333.556 1 0 2.407,-32.411 Z " id="7" class="nad-busnode"/>
+        <g transform="translate(-19.83,171.75)" id="5">
+            <circle r="27.50" id="6" class="nad-vl180to300-0 nad-busnode"/>
+            <path d="M-1.506,-57.480 A57.500,57.500 345.053 1 1 -16.281,-55.147 L-12.278,-30.092 A32.500,32.500 -333.556 1 0 2.407,-32.411 Z " id="7" class="nad-vl180to300-1 nad-busnode"/>
         </g>
-        <g transform="translate(210.36,-353.80)" id="12" class="nad-boundary-node nad-vl300to500">
-            <path d="M15.016,23.038 A27.500,27.500 180.000 0 1 -15.016,-23.038" id="13" class="nad-busnode"/>
+        <g transform="translate(210.36,-353.80)" id="12" class="nad-boundary-node">
+            <path d="M15.016,23.038 A27.500,27.500 180.000 0 1 -15.016,-23.038" id="13" class="nad-vl300to500-0 nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="8">
-            <g id="8.1" class="nad-vl300to500">
+            <g id="8.1" class="nad-vl300to500-line">
                 <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-107.19,-205.38 -158.52,-194.37 -199.91,-156.95"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-180.78,-174.25)">
                     <g class="nad-active">
@@ -77,7 +142,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g id="8.2" class="nad-vl300to500">
+            <g id="8.2" class="nad-vl300to500-line">
                 <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-257.43,-69.57 -241.30,-119.53 -199.91,-156.95"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-219.05,-139.65)">
                     <g class="nad-active">
@@ -89,14 +154,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
-                <g class="nad-edge-label" transform="translate(-199.91,-156.95)">
-                    <text transform="rotate(-42.11)" x="0.00" style="text-anchor:middle">l1</text>
-                </g>
-            </g>
         </g>
         <g id="9">
-            <g id="9.1" class="nad-vl300to500">
+            <g id="9.1" class="nad-vl300to500-line">
                 <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-97.96,-156.43 -104.87,-135.02 -146.26,-97.60"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-127.13,-114.90)">
                     <g class="nad-active">
@@ -108,7 +168,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g id="9.2" class="nad-disconnected nad-vl300to500">
+            <g id="9.2" class="nad-disconnected nad-vl300to500-line">
                 <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-238.99,-49.17 -187.65,-60.19 -146.26,-97.60"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-165.40,-80.31)">
                     <g class="nad-active">
@@ -120,14 +180,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
-                <g class="nad-edge-label" transform="translate(-146.26,-97.60)">
-                    <text transform="rotate(-42.11)" x="0.00" style="text-anchor:middle">l2</text>
-                </g>
-            </g>
         </g>
         <g id="10">
-            <g id="10.1" class="nad-vl300to500">
+            <g id="10.1" class="nad-vl300to500-line">
                 <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-71.33,-154.36 -52.41,-34.52"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-66.26,-122.26)">
                     <g class="nad-active">
@@ -139,7 +194,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g id="10.2" class="nad-vl180to300">
+            <g id="10.2" class="nad-vl180to300-line">
                 <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-24.12,144.59 -43.05,24.75"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-33.87,82.85)">
                     <g class="nad-active">
@@ -152,15 +207,12 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g class="nad-glued-center">
-                <circle class="nad-vl300to500 nad-winding" cx="-49.29" cy="-14.76" r="20.00"/>
-                <circle class="nad-vl180to300 nad-winding" cx="-46.17" cy="4.99" r="20.00"/>
-                <g class="nad-edge-label" transform="translate(-47.73,-4.88)">
-                    <text transform="rotate(81.03)" x="0.00" style="text-anchor:middle">tr1</text>
-                </g>
+                <circle class="nad-vl300to500-line nad-winding" cx="-49.29" cy="-14.76" r="20.00"/>
+                <circle class="nad-vl180to300-line nad-winding" cx="-46.17" cy="4.99" r="20.00"/>
             </g>
         </g>
         <g id="11">
-            <g id="11.1" class="nad-vl300to500">
+            <g id="11.1" class="nad-vl300to500-line">
                 <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-245.17,-25.30 -176.73,34.55"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-220.71,-3.90)">
                     <g class="nad-active">
@@ -172,7 +224,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g id="11.2" class="nad-vl180to300">
+            <g id="11.2" class="nad-vl180to300-line">
                 <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-63.12,133.90 -131.56,74.05"/>
                 <g class="nad-glued-2 nad-edge-infos" transform="translate(-87.58,112.51)">
                     <g class="nad-active">
@@ -185,15 +237,12 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g class="nad-glued-center">
-                <circle class="nad-vl300to500 nad-winding" cx="-161.67" cy="47.72" r="20.00"/>
-                <circle class="nad-vl180to300 nad-winding" cx="-146.62" cy="60.88" r="20.00"/>
-                <g class="nad-edge-label" transform="translate(-154.14,54.30)">
-                    <text transform="rotate(41.17)" x="0.00" style="text-anchor:middle">tr2</text>
-                </g>
+                <circle class="nad-vl300to500-line nad-winding" cx="-161.67" cy="47.72" r="20.00"/>
+                <circle class="nad-vl180to300-line nad-winding" cx="-146.62" cy="60.88" r="20.00"/>
             </g>
         </g>
         <g id="14" class="nad-dangling-line-edge">
-            <g id="14.1" class="nad-vl300to500">
+            <g id="14.1" class="nad-vl300to500-line">
                 <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-242.83,-58.42 -27.76,-198.60"/>
                 <g class="nad-glued-1 nad-edge-infos" transform="translate(-215.61,-76.16)">
                     <g class="nad-active">
@@ -205,7 +254,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g id="14.2" class="nad-vl300to500">
+            <g id="14.2" class="nad-vl300to500-line">
                 <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="187.32,-338.78 -27.76,-198.60"/>
             </g>
         </g>
@@ -216,56 +265,12 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <polyline id="5-textedge" points="39.50,162.85 80.17,156.75"/>
     </g>
     <g class="nad-text-nodes">
-        <foreignObject id="0-textnode" y="-251.15" x="19.70" height="1" width="1">
-            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
-                <div>Voltage level 1</div>
-                <table>
-                    <tr>
-                        <td>
-                            <div class="nad-legend-square"/>
-                        </td>
-                        <td> kV / °</td>
-                    </tr>
-                    <tr>
-                        <td>
-                            <div class="nad-legend-square"/>
-                        </td>
-                        <td> kV / °</td>
-                    </tr>
-                </table>
-            </div>
-        </foreignObject>
-        <foreignObject id="3-textnode" y="-83.40" x="-165.87" height="1" width="1">
-            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
-                <div>Voltage level 2</div>
-                <table>
-                    <tr>
-                        <td>
-                            <div class="nad-legend-square"/>
-                        </td>
-                        <td> kV / °</td>
-                    </tr>
-                </table>
-            </div>
-        </foreignObject>
-        <foreignObject id="5-textnode" y="131.75" x="80.17" height="1" width="1">
-            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
-                <div>vl3</div>
-                <table>
-                    <tr>
-                        <td>
-                            <div class="nad-legend-square"/>
-                        </td>
-                        <td> kV / °</td>
-                    </tr>
-                    <tr>
-                        <td>
-                            <div class="nad-legend-square"/>
-                        </td>
-                        <td> kV / °</td>
-                    </tr>
-                </table>
-            </div>
-        </foreignObject>
+        <text id="0-textnode" y="-226.15" x="19.70">Voltage level 1</text>
+        <text id="3-textnode" y="-58.40" x="-165.87">Voltage level 2</text>
+        <text id="5-textnode" y="156.75" x="80.17">vl3</text>
     </g>
+    <g class="nad-power-edges"></g>
+    <g class="nad-text-nodes"></g>
+    <g class="nad-power-edges"></g>
+    <g class="nad-text-nodes"></g>
 </svg>

--- a/network-area-diagram/src/test/resources/production_consumption_text_node.svg
+++ b/network-area-diagram/src/test/resources/production_consumption_text_node.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-legend-square {width: 20px; height: 20px; background: var(--nad-vl-color, black);}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-disconnected {--nad-vl-color: #808080}

--- a/network-area-diagram/src/test/resources/simple-eu-loop100.svg
+++ b/network-area-diagram/src/test/resources/simple-eu-loop100.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-legend-square {width: 20px; height: 20px; background: var(--nad-vl-color, black);}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-disconnected {--nad-vl-color: #808080}

--- a/network-area-diagram/src/test/resources/simple-eu-loop80.svg
+++ b/network-area-diagram/src/test/resources/simple-eu-loop80.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-legend-square {width: 20px; height: 20px; background: var(--nad-vl-color, black);}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-disconnected {--nad-vl-color: #808080}

--- a/network-area-diagram/src/test/resources/simple-eu.svg
+++ b/network-area-diagram/src/test/resources/simple-eu.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-legend-square {width: 20px; height: 20px; background: var(--nad-vl-color, black);}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-disconnected {--nad-vl-color: #808080}

--- a/network-area-diagram/src/test/resources/tie_line.svg
+++ b/network-area-diagram/src/test/resources/tie_line.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}

--- a/network-area-diagram/src/test/resources/tie_line_filtered.svg
+++ b/network-area-diagram/src/test/resources/tie_line_filtered.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}

--- a/network-area-diagram/src/test/resources/two-voltage-levels_metadata.json
+++ b/network-area-diagram/src/test/resources/two-voltage-levels_metadata.json
@@ -7,7 +7,17 @@
       "y" : -40.0
     },
     "maxSteps" : 1000,
-    "textNodeEdgeConnectionYShift" : 25.0
+    "textNodeEdgeConnectionYShift" : 25.0,
+    "productionNodeFixedShift" : {
+      "x" : -100.0,
+      "y" : -50.0
+    },
+    "consumptionNodeFixedShift" : {
+      "x" : -100.0,
+      "y" : 50.0
+    },
+    "powerNodesForceLayout" : false,
+    "powerNodeRadius" : 15.0
   },
   "svgParameters" : {
     "diagramPadding" : {
@@ -53,7 +63,8 @@
     "currentValuePrecision" : 0,
     "edgeInfoDisplayed" : "ACTIVE_POWER",
     "pstArrowHeadSize" : 8.0,
-    "undefinedValueSymbol" : ""
+    "undefinedValueSymbol" : "",
+    "voltageLevelPowerDetails" : false
   },
   "busNodes" : [ {
     "svgId" : "1",

--- a/network-area-diagram/src/test/resources/vl_description_id.svg
+++ b/network-area-diagram/src/test/resources/vl_description_id.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-legend-square {width: 20px; height: 20px; background: var(--nad-vl-color, black);}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-disconnected {--nad-vl-color: #808080}

--- a/network-area-diagram/src/test/resources/vl_description_substation.svg
+++ b/network-area-diagram/src/test/resources/vl_description_substation.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-legend-square {width: 20px; height: 20px; background: var(--nad-vl-color, black);}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-disconnected {--nad-vl-color: #808080}

--- a/network-area-diagram/src/test/resources/vl_description_substation_id.svg
+++ b/network-area-diagram/src/test/resources/vl_description_substation_id.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-legend-square {width: 20px; height: 20px; background: var(--nad-vl-color, black);}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-disconnected {--nad-vl-color: #808080}

--- a/network-area-diagram/src/test/resources/voltage_limits.svg
+++ b/network-area-diagram/src/test/resources/voltage_limits.svg
@@ -19,6 +19,9 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-power-edges {stroke: black; stroke-width: 2;}
+.nad-power-label {width: max-content;}
+.nad-power-icon {fill: none; stroke-width: 2; stroke: #000000;}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
Fixes #613 


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature

**What is the current behavior?**
<!-- You can also link to an open issue here -->

Production and consumption information are shown as text in Voltage Level details

**What is the new behavior (if this is a feature change)?**

Show production and consumption icons

