### PR TITLE
Remove unused glued and stretchable style classes

### DIFF
--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/StyleProvider.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/StyleProvider.java
@@ -42,9 +42,6 @@ public interface StyleProvider {
     String LABEL_BOX_CLASS = CLASSES_PREFIX + "label-box";
     String LEGEND_SQUARE_CLASS = CLASSES_PREFIX + "legend-square";
     String PST_ARROW_CLASS = CLASSES_PREFIX + "pst-arrow";
-    String STRETCHABLE_CLASS = CLASSES_PREFIX + "stretchable";
-    String GLUED_CLASS = CLASSES_PREFIX + "glued";
-    String GLUED_CENTER_CLASS = CLASSES_PREFIX + "glued-center";
 
     List<String> getCssFilenames();
 

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/SvgWriter.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/SvgWriter.java
@@ -182,7 +182,6 @@ public class SvgWriter {
         }
         if (!BranchEdge.LINE_EDGE.equals(edge.getType()) || svgParameters.isEdgeNameDisplayed()) {
             writer.writeStartElement(GROUP_ELEMENT_NAME);
-            writer.writeAttribute(CLASS_ATTRIBUTE, StyleProvider.GLUED_CENTER_CLASS);
             switch (edge.getType()) {
                 case BranchEdge.PST_EDGE:
                 case BranchEdge.TWO_WT_EDGE:
@@ -255,7 +254,7 @@ public class SvgWriter {
             Optional<EdgeInfo> edgeInfo = labelProvider.getEdgeInfo(graph, edge, side);
             if (!graph.isLoop(edge)) {
                 writer.writeEmptyElement(POLYLINE_ELEMENT_NAME);
-                writeStyleClasses(writer, StyleProvider.EDGE_PATH_CLASS, StyleProvider.STRETCHABLE_CLASS, StyleProvider.GLUED_CLASS + "-" + side.getNum());
+                writeStyleClasses(writer, StyleProvider.EDGE_PATH_CLASS);
                 writer.writeAttribute(POINTS_ATTRIBUTE, getPolylinePointsString(edge, side));
                 if (edgeInfo.isPresent()) {
                     drawBranchEdgeInfo(graph, writer, edge, side, edgeInfo.get());
@@ -301,7 +300,7 @@ public class SvgWriter {
         insertName(writer, edge::getName);
 
         writer.writeEmptyElement(POLYLINE_ELEMENT_NAME);
-        writeStyleClasses(writer, StyleProvider.EDGE_PATH_CLASS, StyleProvider.STRETCHABLE_CLASS);
+        writeStyleClasses(writer, StyleProvider.EDGE_PATH_CLASS);
         writer.writeAttribute(POINTS_ATTRIBUTE, getPolylinePointsString(edge));
 
         Optional<EdgeInfo> edgeInfo = labelProvider.getEdgeInfo(graph, edge);
@@ -351,15 +350,13 @@ public class SvgWriter {
     private void drawBranchEdgeInfo(Graph graph, XMLStreamWriter writer, BranchEdge edge, BranchEdge.Side side, EdgeInfo edgeInfo) throws XMLStreamException {
         VoltageLevelNode vlNode = graph.getVoltageLevelNode(edge, side);
         BusNode busNode = graph.getBusGraphNode(edge, side);
-        List<String> additionalStyles = List.of(StyleProvider.GLUED_CLASS + "-" + side.getNum());
-        drawEdgeInfo(writer, additionalStyles, edgeInfo, getArrowCenter(vlNode, busNode, edge.getPoints(side)), edge.getEdgeEndAngle(side));
+        drawEdgeInfo(writer, edgeInfo, getArrowCenter(vlNode, busNode, edge.getPoints(side)), edge.getEdgeEndAngle(side));
     }
 
     private void drawThreeWtEdgeInfo(Graph graph, XMLStreamWriter writer, ThreeWtEdge edge, EdgeInfo edgeInfo) throws XMLStreamException {
         VoltageLevelNode vlNode = graph.getVoltageLevelNode(edge);
         BusNode busNode = graph.getBusGraphNode(edge);
-        List<String> additionalStyles = List.of(StyleProvider.GLUED_CLASS + "-1");
-        drawEdgeInfo(writer, additionalStyles, edgeInfo, getArrowCenter(vlNode, busNode, edge.getPoints()), edge.getEdgeAngle());
+        drawEdgeInfo(writer, edgeInfo, getArrowCenter(vlNode, busNode, edge.getPoints()), edge.getEdgeAngle());
     }
 
     private void drawEdgeInfo(XMLStreamWriter writer, EdgeInfo edgeInfo, Point infoCenter, double edgeAngle) throws XMLStreamException {

--- a/network-area-diagram/src/test/resources/3wt.svg
+++ b/network-area-diagram/src/test/resources/3wt.svg
@@ -62,8 +62,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
     <g class="nad-3wt-edges">
         <g id="7" class="nad-vl0to30">
             <desc>3WT</desc>
-            <polyline class="nad-edge-path nad-stretchable" points="68.27,-487.11 -14.91,-159.64"/>
-            <g class="nad-glued-1 nad-edge-infos" transform="translate(60.27,-455.61)">
+            <polyline class="nad-edge-path" points="68.27,-487.11 -14.91,-159.64"/>
+            <g class="nad-edge-infos" transform="translate(60.27,-455.61)">
                 <g class="nad-active">
                     <g transform="rotate(-165.75)">
                         <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -75,8 +75,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="8" class="nad-vl120to180">
             <desc>3WT</desc>
-            <polyline class="nad-edge-path nad-stretchable" points="-346.98,35.28 -53.59,-119.94"/>
-            <g class="nad-glued-1 nad-edge-infos" transform="translate(-318.25,20.09)">
+            <polyline class="nad-edge-path" points="-346.98,35.28 -53.59,-119.94"/>
+            <g class="nad-edge-infos" transform="translate(-318.25,20.09)">
                 <g class="nad-active">
                     <g transform="rotate(62.12)">
                         <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -88,8 +88,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="9" class="nad-vl30to50">
             <desc>3WT</desc>
-            <polyline class="nad-edge-path nad-stretchable" points="165.92,181.19 0.13,-106.29"/>
-            <g class="nad-glued-1 nad-edge-infos" transform="translate(149.68,153.04)">
+            <polyline class="nad-edge-path" points="165.92,181.19 0.13,-106.29"/>
+            <g class="nad-edge-infos" transform="translate(149.68,153.04)">
                 <g class="nad-active">
                     <g transform="rotate(-29.97)">
                         <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/3wt_disconnected.svg
+++ b/network-area-diagram/src/test/resources/3wt_disconnected.svg
@@ -62,8 +62,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
     <g class="nad-3wt-edges">
         <g id="6" class="nad-vl0to30">
             <desc>3WT</desc>
-            <polyline class="nad-edge-path nad-stretchable" points="68.27,-487.11 -14.91,-159.64"/>
-            <g class="nad-glued-1 nad-edge-infos" transform="translate(60.27,-455.61)">
+            <polyline class="nad-edge-path" points="68.27,-487.11 -14.91,-159.64"/>
+            <g class="nad-edge-infos" transform="translate(60.27,-455.61)">
                 <g class="nad-active">
                     <g transform="rotate(-165.75)">
                         <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -75,8 +75,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="7" class="nad-vl120to180">
             <desc>3WT</desc>
-            <polyline class="nad-edge-path nad-stretchable" points="-346.98,35.28 -53.59,-119.94"/>
-            <g class="nad-glued-1 nad-edge-infos" transform="translate(-318.25,20.09)">
+            <polyline class="nad-edge-path" points="-346.98,35.28 -53.59,-119.94"/>
+            <g class="nad-edge-infos" transform="translate(-318.25,20.09)">
                 <g class="nad-active">
                     <g transform="rotate(62.12)">
                         <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -88,8 +88,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="8" class="nad-disconnected nad-vl30to50">
             <desc>3WT</desc>
-            <polyline class="nad-edge-path nad-stretchable" points="159.42,170.52 0.13,-106.29"/>
-            <g class="nad-glued-1 nad-edge-infos" transform="translate(143.21,142.35)">
+            <polyline class="nad-edge-path" points="159.42,170.52 0.13,-106.29"/>
+            <g class="nad-edge-infos" transform="translate(143.21,142.35)">
                 <g class="nad-active">
                     <g transform="rotate(-29.92)">
                         <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/3wt_disconnected_topological.svg
+++ b/network-area-diagram/src/test/resources/3wt_disconnected_topological.svg
@@ -127,8 +127,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
     <g class="nad-3wt-edges">
         <g id="6" class="nad-vl0to30-line">
             <desc>3WT</desc>
-            <polyline class="nad-edge-path nad-stretchable" points="68.27,-487.11 -14.91,-159.64"/>
-            <g class="nad-glued-1 nad-edge-infos" transform="translate(60.27,-455.61)">
+            <polyline class="nad-edge-path" points="68.27,-487.11 -14.91,-159.64"/>
+            <g class="nad-edge-infos" transform="translate(60.27,-455.61)">
                 <g class="nad-active">
                     <g transform="rotate(-165.75)">
                         <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -140,8 +140,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="7" class="nad-vl120to180-line">
             <desc>3WT</desc>
-            <polyline class="nad-edge-path nad-stretchable" points="-346.98,35.28 -53.59,-119.94"/>
-            <g class="nad-glued-1 nad-edge-infos" transform="translate(-318.25,20.09)">
+            <polyline class="nad-edge-path" points="-346.98,35.28 -53.59,-119.94"/>
+            <g class="nad-edge-infos" transform="translate(-318.25,20.09)">
                 <g class="nad-active">
                     <g transform="rotate(62.12)">
                         <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -153,8 +153,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="8" class="nad-disconnected nad-vl30to50-line">
             <desc>3WT</desc>
-            <polyline class="nad-edge-path nad-stretchable" points="159.42,170.52 0.13,-106.29"/>
-            <g class="nad-glued-1 nad-edge-infos" transform="translate(143.21,142.35)">
+            <polyline class="nad-edge-path" points="159.42,170.52 0.13,-106.29"/>
+            <g class="nad-edge-infos" transform="translate(143.21,142.35)">
                 <g class="nad-active">
                     <g transform="rotate(-29.92)">
                         <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/3wt_overridden_styles.svg
+++ b/network-area-diagram/src/test/resources/3wt_overridden_styles.svg
@@ -127,8 +127,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
     <g class="nad-3wt-edges">
         <g id="7" class="nad-vl0to30-line">
             <desc>3WT</desc>
-            <polyline class="nad-edge-path nad-stretchable" style="stroke: black; stroke-dasharray:12,12" points="68.27,-487.11 -14.91,-159.64"/>
-            <g class="nad-glued-1 nad-edge-infos" transform="translate(60.27,-455.61)">
+            <polyline class="nad-edge-path" style="stroke: black; stroke-dasharray:12,12" points="68.27,-487.11 -14.91,-159.64"/>
+            <g class="nad-edge-infos" transform="translate(60.27,-455.61)">
                 <g class="nad-active">
                     <g transform="rotate(-165.75)">
                         <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -140,8 +140,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="8" class="nad-vl120to180-line">
             <desc>3WT</desc>
-            <polyline class="nad-edge-path nad-stretchable" style="stroke: lightgray; stroke-dasharray:4,4;" points="-346.98,35.28 -53.59,-119.94"/>
-            <g class="nad-glued-1 nad-edge-infos" transform="translate(-318.25,20.09)">
+            <polyline class="nad-edge-path" style="stroke: lightgray; stroke-dasharray:4,4;" points="-346.98,35.28 -53.59,-119.94"/>
+            <g class="nad-edge-infos" transform="translate(-318.25,20.09)">
                 <g class="nad-active">
                     <g transform="rotate(62.12)">
                         <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -153,8 +153,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="9" class="nad-vl30to50-line">
             <desc>3WT</desc>
-            <polyline class="nad-edge-path nad-stretchable" style="stroke: gray; stroke-dasharray:8,8" points="165.92,181.19 0.13,-106.29"/>
-            <g class="nad-glued-1 nad-edge-infos" transform="translate(149.68,153.04)">
+            <polyline class="nad-edge-path" style="stroke: gray; stroke-dasharray:8,8" points="165.92,181.19 0.13,-106.29"/>
+            <g class="nad-edge-infos" transform="translate(149.68,153.04)">
                 <g class="nad-active">
                     <g transform="rotate(-29.97)">
                         <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/3wt_partial.svg
+++ b/network-area-diagram/src/test/resources/3wt_partial.svg
@@ -54,8 +54,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
     <g class="nad-3wt-edges">
         <g id="7" class="nad-vl0to30">
             <desc>3WT</desc>
-            <polyline class="nad-edge-path nad-stretchable" points="68.27,-487.11 -14.91,-159.64"/>
-            <g class="nad-glued-1 nad-edge-infos" transform="translate(60.27,-455.61)">
+            <polyline class="nad-edge-path" points="68.27,-487.11 -14.91,-159.64"/>
+            <g class="nad-edge-infos" transform="translate(60.27,-455.61)">
                 <g class="nad-active">
                     <g transform="rotate(-165.75)">
                         <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/IEEE_118_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_118_bus.svg
@@ -587,8 +587,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="236">
             <desc>L1-2-1</desc>
             <g id="236.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="983.43,-3019.85 844.98,-3001.25"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(951.22,-3015.53)">
+                <polyline class="nad-edge-path" points="983.43,-3019.85 844.98,-3001.25"/>
+                <g class="nad-edge-infos" transform="translate(951.22,-3015.53)">
                     <g class="nad-active">
                         <g transform="rotate(-97.65)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -599,8 +599,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="236.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="706.53,-2982.65 844.98,-3001.25"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(738.74,-2986.97)">
+                <polyline class="nad-edge-path" points="706.53,-2982.65 844.98,-3001.25"/>
+                <g class="nad-edge-infos" transform="translate(738.74,-2986.97)">
                     <g class="nad-active">
                         <g transform="rotate(82.35)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -614,8 +614,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="237">
             <desc>L1-3-1</desc>
             <g id="237.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="994.35,-3001.39 850.98,-2807.17"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(975.05,-2975.24)">
+                <polyline class="nad-edge-path" points="994.35,-3001.39 850.98,-2807.17"/>
+                <g class="nad-edge-infos" transform="translate(975.05,-2975.24)">
                     <g class="nad-active">
                         <g transform="rotate(-143.57)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -626,8 +626,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="237.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="707.60,-2612.94 850.98,-2807.17"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(726.90,-2639.09)">
+                <polyline class="nad-edge-path" points="707.60,-2612.94 850.98,-2807.17"/>
+                <g class="nad-edge-infos" transform="translate(726.90,-2639.09)">
                     <g class="nad-active">
                         <g transform="rotate(36.43)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -641,8 +641,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="238">
             <desc>L9-10-1</desc>
             <g id="238.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1800.34,-152.72 -2120.80,-62.11"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1831.62,-143.87)">
+                <polyline class="nad-edge-path" points="-1800.34,-152.72 -2120.80,-62.11"/>
+                <g class="nad-edge-infos" transform="translate(-1831.62,-143.87)">
                     <g class="nad-active">
                         <g transform="rotate(-105.79)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -653,8 +653,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="238.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2441.26,28.50 -2120.80,-62.11"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-2409.98,19.65)">
+                <polyline class="nad-edge-path" points="-2441.26,28.50 -2120.80,-62.11"/>
+                <g class="nad-edge-infos" transform="translate(-2409.98,19.65)">
                     <g class="nad-active">
                         <g transform="rotate(74.21)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -668,8 +668,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="239">
             <desc>L92-100-1</desc>
             <g id="239.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2301.23,45.68 2205.16,-319.95"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(2292.97,14.25)">
+                <polyline class="nad-edge-path" points="2301.23,45.68 2205.16,-319.95"/>
+                <g class="nad-edge-infos" transform="translate(2292.97,14.25)">
                     <g class="nad-active">
                         <g transform="rotate(-14.72)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -680,8 +680,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="239.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2109.08,-685.59 2205.16,-319.95"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(2117.34,-654.16)">
+                <polyline class="nad-edge-path" points="2109.08,-685.59 2205.16,-319.95"/>
+                <g class="nad-edge-infos" transform="translate(2117.34,-654.16)">
                     <g class="nad-active">
                         <g transform="rotate(165.28)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -695,8 +695,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="240">
             <desc>L94-100-1</desc>
             <g id="240.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1701.89,-353.02 1891.76,-523.42"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1726.07,-374.73)">
+                <polyline class="nad-edge-path" points="1701.89,-353.02 1891.76,-523.42"/>
+                <g class="nad-edge-infos" transform="translate(1726.07,-374.73)">
                     <g class="nad-active">
                         <g transform="rotate(48.09)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -707,8 +707,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="240.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2081.63,-693.82 1891.76,-523.42"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(2057.44,-672.11)">
+                <polyline class="nad-edge-path" points="2081.63,-693.82 1891.76,-523.42"/>
+                <g class="nad-edge-infos" transform="translate(2057.44,-672.11)">
                     <g class="nad-active">
                         <g transform="rotate(-131.91)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -722,8 +722,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="241">
             <desc>L98-100-1</desc>
             <g id="241.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1284.72,-891.81 1679.98,-804.95"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1316.46,-884.84)">
+                <polyline class="nad-edge-path" points="1284.72,-891.81 1679.98,-804.95"/>
+                <g class="nad-edge-infos" transform="translate(1316.46,-884.84)">
                     <g class="nad-active">
                         <g transform="rotate(102.39)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -734,8 +734,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="241.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2075.24,-718.09 1679.98,-804.95"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(2043.49,-725.07)">
+                <polyline class="nad-edge-path" points="2075.24,-718.09 1679.98,-804.95"/>
+                <g class="nad-edge-infos" transform="translate(2043.49,-725.07)">
                     <g class="nad-active">
                         <g transform="rotate(-77.61)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -749,8 +749,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="242">
             <desc>L99-100-1</desc>
             <g id="242.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1346.04,-1185.85 1712.41,-956.32"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1373.58,-1168.60)">
+                <polyline class="nad-edge-path" points="1346.04,-1185.85 1712.41,-956.32"/>
+                <g class="nad-edge-infos" transform="translate(1373.58,-1168.60)">
                     <g class="nad-active">
                         <g transform="rotate(122.07)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -761,8 +761,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="242.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2078.79,-726.79 1712.41,-956.32"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(2051.25,-744.04)">
+                <polyline class="nad-edge-path" points="2078.79,-726.79 1712.41,-956.32"/>
+                <g class="nad-edge-infos" transform="translate(2051.25,-744.04)">
                     <g class="nad-active">
                         <g transform="rotate(-57.93)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -776,8 +776,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="243">
             <desc>L100-101-1</desc>
             <g id="243.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2127.10,-700.74 2432.81,-560.82"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(2156.65,-687.22)">
+                <polyline class="nad-edge-path" points="2127.10,-700.74 2432.81,-560.82"/>
+                <g class="nad-edge-infos" transform="translate(2156.65,-687.22)">
                     <g class="nad-active">
                         <g transform="rotate(114.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -788,8 +788,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="243.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2738.51,-420.90 2432.81,-560.82"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(2708.96,-434.43)">
+                <polyline class="nad-edge-path" points="2738.51,-420.90 2432.81,-560.82"/>
+                <g class="nad-edge-infos" transform="translate(2708.96,-434.43)">
                     <g class="nad-active">
                         <g transform="rotate(-65.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -803,8 +803,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="244">
             <desc>L100-103-1</desc>
             <g id="244.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2129.49,-709.79 2250.02,-699.23"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(2161.87,-706.95)">
+                <polyline class="nad-edge-path" points="2129.49,-709.79 2250.02,-699.23"/>
+                <g class="nad-edge-infos" transform="translate(2161.87,-706.95)">
                     <g class="nad-active">
                         <g transform="rotate(95.01)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -815,8 +815,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="244.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2370.56,-688.68 2250.02,-699.23"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(2338.18,-691.51)">
+                <polyline class="nad-edge-path" points="2370.56,-688.68 2250.02,-699.23"/>
+                <g class="nad-edge-infos" transform="translate(2338.18,-691.51)">
                     <g class="nad-active">
                         <g transform="rotate(-84.99)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -830,8 +830,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="245">
             <desc>L100-104-1</desc>
             <g id="245.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2127.12,-723.59 2327.06,-814.68"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(2156.70,-737.06)">
+                <polyline class="nad-edge-path" points="2127.12,-723.59 2327.06,-814.68"/>
+                <g class="nad-edge-infos" transform="translate(2156.70,-737.06)">
                     <g class="nad-active">
                         <g transform="rotate(65.51)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -842,8 +842,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="245.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2527.00,-905.76 2327.06,-814.68"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(2497.43,-892.29)">
+                <polyline class="nad-edge-path" points="2527.00,-905.76 2327.06,-814.68"/>
+                <g class="nad-edge-infos" transform="translate(2497.43,-892.29)">
                     <g class="nad-active">
                         <g transform="rotate(-114.49)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -857,8 +857,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="246">
             <desc>L100-106-1</desc>
             <g id="246.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2122.44,-730.69 2398.53,-981.84"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(2146.48,-752.56)">
+                <polyline class="nad-edge-path" points="2122.44,-730.69 2398.53,-981.84"/>
+                <g class="nad-edge-infos" transform="translate(2146.48,-752.56)">
                     <g class="nad-active">
                         <g transform="rotate(47.71)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -869,8 +869,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="246.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2674.63,-1232.98 2398.53,-981.84"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(2650.59,-1211.11)">
+                <polyline class="nad-edge-path" points="2674.63,-1232.98 2398.53,-981.84"/>
+                <g class="nad-edge-infos" transform="translate(2650.59,-1211.11)">
                     <g class="nad-active">
                         <g transform="rotate(-132.29)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -884,8 +884,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="247">
             <desc>L101-102-1</desc>
             <g id="247.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2768.88,-382.49 2802.35,-214.27"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(2775.22,-350.61)">
+                <polyline class="nad-edge-path" points="2768.88,-382.49 2802.35,-214.27"/>
+                <g class="nad-edge-infos" transform="translate(2775.22,-350.61)">
                     <g class="nad-active">
                         <g transform="rotate(168.75)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -896,8 +896,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="247.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2835.81,-46.06 2802.35,-214.27"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(2829.47,-77.93)">
+                <polyline class="nad-edge-path" points="2835.81,-46.06 2802.35,-214.27"/>
+                <g class="nad-edge-infos" transform="translate(2829.47,-77.93)">
                     <g class="nad-active">
                         <g transform="rotate(-11.25)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -911,8 +911,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="248">
             <desc>L92-102-1</desc>
             <g id="248.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2335.32,67.64 2574.70,26.60"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(2367.35,62.14)">
+                <polyline class="nad-edge-path" points="2335.32,67.64 2574.70,26.60"/>
+                <g class="nad-edge-infos" transform="translate(2367.35,62.14)">
                     <g class="nad-active">
                         <g transform="rotate(80.27)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -923,8 +923,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="248.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2814.07,-14.44 2574.70,26.60"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(2782.04,-8.95)">
+                <polyline class="nad-edge-path" points="2814.07,-14.44 2574.70,26.60"/>
+                <g class="nad-edge-infos" transform="translate(2782.04,-8.95)">
                     <g class="nad-active">
                         <g transform="rotate(-99.73)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -938,8 +938,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="249">
             <desc>L103-104-1</desc>
             <g id="249.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2413.22,-709.15 2474.99,-801.72"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(2431.26,-736.19)">
+                <polyline class="nad-edge-path" points="2413.22,-709.15 2474.99,-801.72"/>
+                <g class="nad-edge-infos" transform="translate(2431.26,-736.19)">
                     <g class="nad-active">
                         <g transform="rotate(33.72)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -950,8 +950,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="249.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2536.76,-894.29 2474.99,-801.72"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(2518.72,-867.26)">
+                <polyline class="nad-edge-path" points="2536.76,-894.29 2474.99,-801.72"/>
+                <g class="nad-edge-infos" transform="translate(2518.72,-867.26)">
                     <g class="nad-active">
                         <g transform="rotate(-146.28)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -965,8 +965,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="250">
             <desc>L103-105-1</desc>
             <g id="250.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2398.67,-713.77 2405.28,-967.67"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(2399.51,-746.26)">
+                <polyline class="nad-edge-path" points="2398.67,-713.77 2405.28,-967.67"/>
+                <g class="nad-edge-infos" transform="translate(2399.51,-746.26)">
                     <g class="nad-active">
                         <g transform="rotate(1.49)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -977,8 +977,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="250.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2411.90,-1221.57 2405.28,-967.67"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(2411.05,-1189.08)">
+                <polyline class="nad-edge-path" points="2411.90,-1221.57 2405.28,-967.67"/>
+                <g class="nad-edge-infos" transform="translate(2411.05,-1189.08)">
                     <g class="nad-active">
                         <g transform="rotate(-178.51)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -992,8 +992,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="251">
             <desc>L103-110-1</desc>
             <g id="251.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2381.28,-664.41 2244.89,-485.53"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(2361.57,-638.56)">
+                <polyline class="nad-edge-path" points="2381.28,-664.41 2244.89,-485.53"/>
+                <g class="nad-edge-infos" transform="translate(2361.57,-638.56)">
                     <g class="nad-active">
                         <g transform="rotate(-142.68)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1004,8 +1004,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="251.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2108.51,-306.65 2244.89,-485.53"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(2128.21,-332.49)">
+                <polyline class="nad-edge-path" points="2108.51,-306.65 2244.89,-485.53"/>
+                <g class="nad-edge-infos" transform="translate(2128.21,-332.49)">
                     <g class="nad-active">
                         <g transform="rotate(37.32)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1019,8 +1019,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="252">
             <desc>L104-105-1</desc>
             <g id="252.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2541.38,-942.52 2482.32,-1083.11"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(2528.79,-972.48)">
+                <polyline class="nad-edge-path" points="2541.38,-942.52 2482.32,-1083.11"/>
+                <g class="nad-edge-infos" transform="translate(2528.79,-972.48)">
                     <g class="nad-active">
                         <g transform="rotate(-22.79)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1031,8 +1031,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="252.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2423.26,-1223.70 2482.32,-1083.11"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(2435.85,-1193.74)">
+                <polyline class="nad-edge-path" points="2423.26,-1223.70 2482.32,-1083.11"/>
+                <g class="nad-edge-infos" transform="translate(2435.85,-1193.74)">
                     <g class="nad-active">
                         <g transform="rotate(157.21)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1046,8 +1046,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="253">
             <desc>L105-106-1</desc>
             <g id="253.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2440.11,-1249.29 2553.79,-1250.27"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(2472.61,-1249.57)">
+                <polyline class="nad-edge-path" points="2440.11,-1249.29 2553.79,-1250.27"/>
+                <g class="nad-edge-infos" transform="translate(2472.61,-1249.57)">
                     <g class="nad-active">
                         <g transform="rotate(89.51)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1058,8 +1058,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="253.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2667.47,-1251.24 2553.79,-1250.27"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(2634.97,-1250.97)">
+                <polyline class="nad-edge-path" points="2667.47,-1251.24 2553.79,-1250.27"/>
+                <g class="nad-edge-infos" transform="translate(2634.97,-1250.97)">
                     <g class="nad-active">
                         <g transform="rotate(-90.49)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1073,8 +1073,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="254">
             <desc>L105-107-1</desc>
             <g id="254.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2428.50,-1271.51 2542.33,-1432.40"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(2447.27,-1298.04)">
+                <polyline class="nad-edge-path" points="2428.50,-1271.51 2542.33,-1432.40"/>
+                <g class="nad-edge-infos" transform="translate(2447.27,-1298.04)">
                     <g class="nad-active">
                         <g transform="rotate(35.28)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1085,8 +1085,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="254.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2656.17,-1593.29 2542.33,-1432.40"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(2637.39,-1566.76)">
+                <polyline class="nad-edge-path" points="2656.17,-1593.29 2542.33,-1432.40"/>
+                <g class="nad-edge-infos" transform="translate(2637.39,-1566.76)">
                     <g class="nad-active">
                         <g transform="rotate(-144.72)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1100,8 +1100,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="255">
             <desc>L105-108-1</desc>
             <g id="255.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2385.68,-1254.59 2217.19,-1289.22"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(2353.84,-1261.14)">
+                <polyline class="nad-edge-path" points="2385.68,-1254.59 2217.19,-1289.22"/>
+                <g class="nad-edge-infos" transform="translate(2353.84,-1261.14)">
                     <g class="nad-active">
                         <g transform="rotate(-78.39)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1112,8 +1112,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="255.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2048.71,-1323.85 2217.19,-1289.22"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(2080.55,-1317.30)">
+                <polyline class="nad-edge-path" points="2048.71,-1323.85 2217.19,-1289.22"/>
+                <g class="nad-edge-infos" transform="translate(2080.55,-1317.30)">
                     <g class="nad-active">
                         <g transform="rotate(101.61)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1127,8 +1127,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="256">
             <desc>L106-107-1</desc>
             <g id="256.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2693.25,-1278.93 2683.51,-1433.61"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(2691.20,-1311.36)">
+                <polyline class="nad-edge-path" points="2693.25,-1278.93 2683.51,-1433.61"/>
+                <g class="nad-edge-infos" transform="translate(2691.20,-1311.36)">
                     <g class="nad-active">
                         <g transform="rotate(-3.60)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1139,8 +1139,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="256.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2673.78,-1588.29 2683.51,-1433.61"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(2675.82,-1555.86)">
+                <polyline class="nad-edge-path" points="2673.78,-1588.29 2683.51,-1433.61"/>
+                <g class="nad-edge-infos" transform="translate(2675.82,-1555.86)">
                     <g class="nad-active">
                         <g transform="rotate(176.40)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1154,8 +1154,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="257">
             <desc>L108-109-1</desc>
             <g id="257.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2012.02,-1303.67 1940.49,-1115.20"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(2000.49,-1273.29)">
+                <polyline class="nad-edge-path" points="2012.02,-1303.67 1940.49,-1115.20"/>
+                <g class="nad-edge-infos" transform="translate(2000.49,-1273.29)">
                     <g class="nad-active">
                         <g transform="rotate(-159.22)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1166,8 +1166,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="257.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1868.96,-926.72 1940.49,-1115.20"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1880.49,-957.11)">
+                <polyline class="nad-edge-path" points="1868.96,-926.72 1940.49,-1115.20"/>
+                <g class="nad-edge-infos" transform="translate(1880.49,-957.11)">
                     <g class="nad-active">
                         <g transform="rotate(20.78)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1181,8 +1181,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="258">
             <desc>L109-110-1</desc>
             <g id="258.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1868.91,-875.28 1975.52,-592.89"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1880.39,-844.88)">
+                <polyline class="nad-edge-path" points="1868.91,-875.28 1975.52,-592.89"/>
+                <g class="nad-edge-infos" transform="translate(1880.39,-844.88)">
                     <g class="nad-active">
                         <g transform="rotate(159.32)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1193,8 +1193,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="258.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2082.12,-310.51 1975.52,-592.89"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(2070.65,-340.91)">
+                <polyline class="nad-edge-path" points="2082.12,-310.51 1975.52,-592.89"/>
+                <g class="nad-edge-infos" transform="translate(2070.65,-340.91)">
                     <g class="nad-active">
                         <g transform="rotate(-20.68)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1208,8 +1208,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="259">
             <desc>L4-11-1</desc>
             <g id="259.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="834.08,-2036.88 726.45,-1978.05"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(805.57,-2021.29)">
+                <polyline class="nad-edge-path" points="834.08,-2036.88 726.45,-1978.05"/>
+                <g class="nad-edge-infos" transform="translate(805.57,-2021.29)">
                     <g class="nad-active">
                         <g transform="rotate(-118.66)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1220,8 +1220,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="259.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="618.82,-1919.21 726.45,-1978.05"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(647.34,-1934.80)">
+                <polyline class="nad-edge-path" points="618.82,-1919.21 726.45,-1978.05"/>
+                <g class="nad-edge-infos" transform="translate(647.34,-1934.80)">
                     <g class="nad-active">
                         <g transform="rotate(61.34)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1235,8 +1235,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="260">
             <desc>L5-11-1</desc>
             <g id="260.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="251.60,-2024.45 410.15,-1969.72"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(282.32,-2013.85)">
+                <polyline class="nad-edge-path" points="251.60,-2024.45 410.15,-1969.72"/>
+                <g class="nad-edge-infos" transform="translate(282.32,-2013.85)">
                     <g class="nad-active">
                         <g transform="rotate(109.04)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1247,8 +1247,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="260.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="568.70,-1914.99 410.15,-1969.72"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(537.98,-1925.60)">
+                <polyline class="nad-edge-path" points="568.70,-1914.99 410.15,-1969.72"/>
+                <g class="nad-edge-infos" transform="translate(537.98,-1925.60)">
                     <g class="nad-active">
                         <g transform="rotate(-70.96)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1262,8 +1262,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="261">
             <desc>L11-12-1</desc>
             <g id="261.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="588.37,-1932.78 544.39,-2118.81"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(580.89,-1964.41)">
+                <polyline class="nad-edge-path" points="588.37,-1932.78 544.39,-2118.81"/>
+                <g class="nad-edge-infos" transform="translate(580.89,-1964.41)">
                     <g class="nad-active">
                         <g transform="rotate(-13.30)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1274,8 +1274,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="261.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="500.41,-2304.83 544.39,-2118.81"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(507.89,-2273.21)">
+                <polyline class="nad-edge-path" points="500.41,-2304.83 544.39,-2118.81"/>
+                <g class="nad-edge-infos" transform="translate(507.89,-2273.21)">
                     <g class="nad-active">
                         <g transform="rotate(166.70)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1289,8 +1289,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="262">
             <desc>L11-13-1</desc>
             <g id="262.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="591.16,-1878.75 559.86,-1637.06"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(586.99,-1846.52)">
+                <polyline class="nad-edge-path" points="591.16,-1878.75 559.86,-1637.06"/>
+                <g class="nad-edge-infos" transform="translate(586.99,-1846.52)">
                     <g class="nad-active">
                         <g transform="rotate(-172.62)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1301,8 +1301,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="262.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="528.56,-1395.38 559.86,-1637.06"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(532.73,-1427.61)">
+                <polyline class="nad-edge-path" points="528.56,-1395.38 559.86,-1637.06"/>
+                <g class="nad-edge-infos" transform="translate(532.73,-1427.61)">
                     <g class="nad-active">
                         <g transform="rotate(7.38)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1316,8 +1316,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="263">
             <desc>L110-111-1</desc>
             <g id="263.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2098.28,-258.04 2170.80,42.73"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(2105.90,-226.45)">
+                <polyline class="nad-edge-path" points="2098.28,-258.04 2170.80,42.73"/>
+                <g class="nad-edge-infos" transform="translate(2105.90,-226.45)">
                     <g class="nad-active">
                         <g transform="rotate(166.44)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1328,8 +1328,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="263.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2243.31,343.50 2170.80,42.73"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(2235.69,311.90)">
+                <polyline class="nad-edge-path" points="2243.31,343.50 2170.80,42.73"/>
+                <g class="nad-edge-infos" transform="translate(2235.69,311.90)">
                     <g class="nad-active">
                         <g transform="rotate(-13.56)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1343,8 +1343,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="264">
             <desc>L110-112-1</desc>
             <g id="264.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2071.36,-266.42 1880.40,-95.15"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(2047.17,-244.72)">
+                <polyline class="nad-edge-path" points="2071.36,-266.42 1880.40,-95.15"/>
+                <g class="nad-edge-infos" transform="translate(2047.17,-244.72)">
                     <g class="nad-active">
                         <g transform="rotate(-131.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1355,8 +1355,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="264.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1689.44,76.12 1880.40,-95.15"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1713.64,54.42)">
+                <polyline class="nad-edge-path" points="1689.44,76.12 1880.40,-95.15"/>
+                <g class="nad-edge-infos" transform="translate(1713.64,54.42)">
                     <g class="nad-active">
                         <g transform="rotate(48.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1370,8 +1370,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="265">
             <desc>L17-113-1</desc>
             <g id="265.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-431.21,-994.52 -523.36,-1124.56"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-450.00,-1021.04)">
+                <polyline class="nad-edge-path" points="-431.21,-994.52 -523.36,-1124.56"/>
+                <g class="nad-edge-infos" transform="translate(-450.00,-1021.04)">
                     <g class="nad-active">
                         <g transform="rotate(-35.32)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1382,8 +1382,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="265.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-615.50,-1254.59 -523.36,-1124.56"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-596.71,-1228.08)">
+                <polyline class="nad-edge-path" points="-615.50,-1254.59 -523.36,-1124.56"/>
+                <g class="nad-edge-infos" transform="translate(-596.71,-1228.08)">
                     <g class="nad-active">
                         <g transform="rotate(144.68)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1397,8 +1397,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="266">
             <desc>L32-113-1</desc>
             <g id="266.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1339.19,-1298.30 -999.04,-1288.08"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1306.71,-1297.32)">
+                <polyline class="nad-edge-path" points="-1339.19,-1298.30 -999.04,-1288.08"/>
+                <g class="nad-edge-infos" transform="translate(-1306.71,-1297.32)">
                     <g class="nad-active">
                         <g transform="rotate(91.72)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1409,8 +1409,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="266.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-658.89,-1277.86 -999.04,-1288.08"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-691.38,-1278.83)">
+                <polyline class="nad-edge-path" points="-658.89,-1277.86 -999.04,-1288.08"/>
+                <g class="nad-edge-infos" transform="translate(-691.38,-1278.83)">
                     <g class="nad-active">
                         <g transform="rotate(-88.28)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1424,8 +1424,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="267">
             <desc>L32-114-1</desc>
             <g id="267.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1384.91,-1319.71 -1519.80,-1471.99"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1406.46,-1344.04)">
+                <polyline class="nad-edge-path" points="-1384.91,-1319.71 -1519.80,-1471.99"/>
+                <g class="nad-edge-infos" transform="translate(-1406.46,-1344.04)">
                     <g class="nad-active">
                         <g transform="rotate(-41.53)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1436,8 +1436,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="267.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1654.68,-1624.27 -1519.80,-1471.99"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1633.13,-1599.94)">
+                <polyline class="nad-edge-path" points="-1654.68,-1624.27 -1519.80,-1471.99"/>
+                <g class="nad-edge-infos" transform="translate(-1633.13,-1599.94)">
                     <g class="nad-active">
                         <g transform="rotate(138.47)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1451,8 +1451,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="268">
             <desc>L114-115-1</desc>
             <g id="268.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1682.49,-1619.07 -1727.37,-1498.25"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1693.81,-1588.61)">
+                <polyline class="nad-edge-path" points="-1682.49,-1619.07 -1727.37,-1498.25"/>
+                <g class="nad-edge-infos" transform="translate(-1693.81,-1588.61)">
                     <g class="nad-active">
                         <g transform="rotate(-159.62)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1463,8 +1463,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="268.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1772.25,-1377.42 -1727.37,-1498.25"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1760.93,-1407.89)">
+                <polyline class="nad-edge-path" points="-1772.25,-1377.42 -1727.37,-1498.25"/>
+                <g class="nad-edge-infos" transform="translate(-1760.93,-1407.89)">
                     <g class="nad-active">
                         <g transform="rotate(20.38)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1478,8 +1478,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="269">
             <desc>L27-115-1</desc>
             <g id="269.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1382.61,-1072.90 -1570.94,-1204.40"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1409.26,-1091.50)">
+                <polyline class="nad-edge-path" points="-1382.61,-1072.90 -1570.94,-1204.40"/>
+                <g class="nad-edge-infos" transform="translate(-1409.26,-1091.50)">
                     <g class="nad-active">
                         <g transform="rotate(-55.08)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1490,8 +1490,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="269.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1759.28,-1335.90 -1570.94,-1204.40"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1732.63,-1317.29)">
+                <polyline class="nad-edge-path" points="-1759.28,-1335.90 -1570.94,-1204.40"/>
+                <g class="nad-edge-infos" transform="translate(-1732.63,-1317.29)">
                     <g class="nad-active">
                         <g transform="rotate(124.92)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1505,8 +1505,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="270">
             <desc>L68-116-1</desc>
             <g id="270.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-962.23,294.51 -1161.61,322.56"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-994.41,299.04)">
+                <polyline class="nad-edge-path" points="-962.23,294.51 -1161.61,322.56"/>
+                <g class="nad-edge-infos" transform="translate(-994.41,299.04)">
                     <g class="nad-active">
                         <g transform="rotate(-98.01)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1517,8 +1517,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="270.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1361.00,350.60 -1161.61,322.56"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1328.81,346.08)">
+                <polyline class="nad-edge-path" points="-1361.00,350.60 -1161.61,322.56"/>
+                <g class="nad-edge-infos" transform="translate(-1328.81,346.08)">
                     <g class="nad-active">
                         <g transform="rotate(81.99)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1532,8 +1532,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="271">
             <desc>L12-117-1</desc>
             <g id="271.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="520.77,-2338.21 815.13,-2411.17"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(552.32,-2346.03)">
+                <polyline class="nad-edge-path" points="520.77,-2338.21 815.13,-2411.17"/>
+                <g class="nad-edge-infos" transform="translate(552.32,-2346.03)">
                     <g class="nad-active">
                         <g transform="rotate(76.08)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1544,8 +1544,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="271.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1109.49,-2484.14 815.13,-2411.17"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1077.94,-2476.32)">
+                <polyline class="nad-edge-path" points="1109.49,-2484.14 815.13,-2411.17"/>
+                <g class="nad-edge-infos" transform="translate(1077.94,-2476.32)">
                     <g class="nad-active">
                         <g transform="rotate(-103.92)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1559,8 +1559,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="272">
             <desc>L75-118-1</desc>
             <g id="272.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1722.94,-973.24 -1851.57,-1322.86"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1734.16,-1003.74)">
+                <polyline class="nad-edge-path" points="-1722.94,-973.24 -1851.57,-1322.86"/>
+                <g class="nad-edge-infos" transform="translate(-1734.16,-1003.74)">
                     <g class="nad-active">
                         <g transform="rotate(-20.20)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1571,8 +1571,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="272.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1980.20,-1672.49 -1851.57,-1322.86"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1968.98,-1641.99)">
+                <polyline class="nad-edge-path" points="-1980.20,-1672.49 -1851.57,-1322.86"/>
+                <g class="nad-edge-infos" transform="translate(-1968.98,-1641.99)">
                     <g class="nad-active">
                         <g transform="rotate(159.80)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1586,8 +1586,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="273">
             <desc>L76-118-1</desc>
             <g id="273.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1460.64,-1839.91 -1711.88,-1772.66"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1492.03,-1831.51)">
+                <polyline class="nad-edge-path" points="-1460.64,-1839.91 -1711.88,-1772.66"/>
+                <g class="nad-edge-infos" transform="translate(-1492.03,-1831.51)">
                     <g class="nad-active">
                         <g transform="rotate(-104.99)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1598,8 +1598,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="273.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1963.13,-1705.41 -1711.88,-1772.66"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1931.74,-1713.81)">
+                <polyline class="nad-edge-path" points="-1963.13,-1705.41 -1711.88,-1772.66"/>
+                <g class="nad-edge-infos" transform="translate(-1931.74,-1713.81)">
                     <g class="nad-active">
                         <g transform="rotate(75.01)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1613,8 +1613,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="274">
             <desc>L2-12-1</desc>
             <g id="274.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="671.72,-2952.54 586.68,-2655.29"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(662.78,-2921.30)">
+                <polyline class="nad-edge-path" points="671.72,-2952.54 586.68,-2655.29"/>
+                <g class="nad-edge-infos" transform="translate(662.78,-2921.30)">
                     <g class="nad-active">
                         <g transform="rotate(-164.04)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1625,8 +1625,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="274.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="501.64,-2358.04 586.68,-2655.29"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(510.58,-2389.28)">
+                <polyline class="nad-edge-path" points="501.64,-2358.04 586.68,-2655.29"/>
+                <g class="nad-edge-infos" transform="translate(510.58,-2389.28)">
                     <g class="nad-active">
                         <g transform="rotate(15.96)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1640,8 +1640,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="275">
             <desc>L3-12-1</desc>
             <g id="275.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="674.62,-2568.93 592.68,-2461.21"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(654.94,-2543.07)">
+                <polyline class="nad-edge-path" points="674.62,-2568.93 592.68,-2461.21"/>
+                <g class="nad-edge-infos" transform="translate(654.94,-2543.07)">
                     <g class="nad-active">
                         <g transform="rotate(-142.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1652,8 +1652,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="275.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="510.73,-2353.48 592.68,-2461.21"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(530.41,-2379.35)">
+                <polyline class="nad-edge-path" points="510.73,-2353.48 592.68,-2461.21"/>
+                <g class="nad-edge-infos" transform="translate(530.41,-2379.35)">
                     <g class="nad-active">
                         <g transform="rotate(37.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1667,8 +1667,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="276">
             <desc>L7-12-1</desc>
             <g id="276.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="211.75,-2804.56 345.87,-2579.89"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(228.41,-2776.66)">
+                <polyline class="nad-edge-path" points="211.75,-2804.56 345.87,-2579.89"/>
+                <g class="nad-edge-infos" transform="translate(228.41,-2776.66)">
                     <g class="nad-active">
                         <g transform="rotate(149.17)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1679,8 +1679,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="276.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="479.99,-2355.21 345.87,-2579.89"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(463.33,-2383.12)">
+                <polyline class="nad-edge-path" points="479.99,-2355.21 345.87,-2579.89"/>
+                <g class="nad-edge-infos" transform="translate(463.33,-2383.12)">
                     <g class="nad-active">
                         <g transform="rotate(-30.83)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1694,8 +1694,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="277">
             <desc>L12-14-1</desc>
             <g id="277.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="485.71,-2305.40 366.31,-1931.55"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(475.83,-2274.44)">
+                <polyline class="nad-edge-path" points="485.71,-2305.40 366.31,-1931.55"/>
+                <g class="nad-edge-infos" transform="translate(475.83,-2274.44)">
                     <g class="nad-active">
                         <g transform="rotate(-162.29)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1706,8 +1706,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="277.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="246.91,-1557.70 366.31,-1931.55"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(256.80,-1588.65)">
+                <polyline class="nad-edge-path" points="246.91,-1557.70 366.31,-1931.55"/>
+                <g class="nad-edge-infos" transform="translate(256.80,-1588.65)">
                     <g class="nad-active">
                         <g transform="rotate(17.71)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1721,8 +1721,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="278">
             <desc>L12-16-1</desc>
             <g id="278.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="476.07,-2310.81 245.58,-2044.75"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(454.79,-2286.25)">
+                <polyline class="nad-edge-path" points="476.07,-2310.81 245.58,-2044.75"/>
+                <g class="nad-edge-infos" transform="translate(454.79,-2286.25)">
                     <g class="nad-active">
                         <g transform="rotate(-139.10)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1733,8 +1733,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="278.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="15.09,-1778.69 245.58,-2044.75"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(36.37,-1803.25)">
+                <polyline class="nad-edge-path" points="15.09,-1778.69 245.58,-2044.75"/>
+                <g class="nad-edge-infos" transform="translate(36.37,-1803.25)">
                     <g class="nad-active">
                         <g transform="rotate(40.90)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1748,8 +1748,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="279">
             <desc>L13-15-1</desc>
             <g id="279.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="507.42,-1346.98 252.68,-1041.29"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(486.62,-1322.01)">
+                <polyline class="nad-edge-path" points="507.42,-1346.98 252.68,-1041.29"/>
+                <g class="nad-edge-infos" transform="translate(486.62,-1322.01)">
                     <g class="nad-active">
                         <g transform="rotate(-140.19)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1760,8 +1760,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="279.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2.07,-735.59 252.68,-1041.29"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(18.74,-760.56)">
+                <polyline class="nad-edge-path" points="-2.07,-735.59 252.68,-1041.29"/>
+                <g class="nad-edge-infos" transform="translate(18.74,-760.56)">
                     <g class="nad-active">
                         <g transform="rotate(39.81)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1775,8 +1775,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="280">
             <desc>L14-15-1</desc>
             <g id="280.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="230.26,-1505.28 109.44,-1122.98"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(220.46,-1474.29)">
+                <polyline class="nad-edge-path" points="230.26,-1505.28 109.44,-1122.98"/>
+                <g class="nad-edge-infos" transform="translate(220.46,-1474.29)">
                     <g class="nad-active">
                         <g transform="rotate(-162.46)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1787,8 +1787,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="280.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-11.39,-740.69 109.44,-1122.98"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1.59,-771.68)">
+                <polyline class="nad-edge-path" points="-11.39,-740.69 109.44,-1122.98"/>
+                <g class="nad-edge-infos" transform="translate(-1.59,-771.68)">
                     <g class="nad-active">
                         <g transform="rotate(17.54)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1802,8 +1802,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="281">
             <desc>L15-17-1</desc>
             <g id="281.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-42.72,-729.47 -217.49,-843.28"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-69.96,-747.21)">
+                <polyline class="nad-edge-path" points="-42.72,-729.47 -217.49,-843.28"/>
+                <g class="nad-edge-infos" transform="translate(-69.96,-747.21)">
                     <g class="nad-active">
                         <g transform="rotate(-56.93)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1814,8 +1814,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="281.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-392.27,-957.08 -217.49,-843.28"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-365.03,-939.35)">
+                <polyline class="nad-edge-path" points="-392.27,-957.08 -217.49,-843.28"/>
+                <g class="nad-edge-infos" transform="translate(-365.03,-939.35)">
                     <g class="nad-active">
                         <g transform="rotate(123.07)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1829,8 +1829,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="282">
             <desc>L15-19-1</desc>
             <g id="282.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-33.47,-690.67 -309.36,-214.80"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-49.77,-662.56)">
+                <polyline class="nad-edge-path" points="-33.47,-690.67 -309.36,-214.80"/>
+                <g class="nad-edge-infos" transform="translate(-49.77,-662.56)">
                     <g class="nad-active">
                         <g transform="rotate(-149.90)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1841,8 +1841,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="282.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-585.26,261.07 -309.36,-214.80"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-568.96,232.95)">
+                <polyline class="nad-edge-path" points="-585.26,261.07 -309.36,-214.80"/>
+                <g class="nad-edge-infos" transform="translate(-568.96,232.95)">
                     <g class="nad-active">
                         <g transform="rotate(30.10)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1856,8 +1856,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="283">
             <desc>L15-33-1</desc>
             <g id="283.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-22.65,-687.13 -64.07,-305.87"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-26.16,-654.82)">
+                <polyline class="nad-edge-path" points="-22.65,-687.13 -64.07,-305.87"/>
+                <g class="nad-edge-infos" transform="translate(-26.16,-654.82)">
                     <g class="nad-active">
                         <g transform="rotate(-173.80)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1868,8 +1868,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="283.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-105.49,75.39 -64.07,-305.87"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-101.98,43.08)">
+                <polyline class="nad-edge-path" points="-105.49,75.39 -64.07,-305.87"/>
+                <g class="nad-edge-infos" transform="translate(-101.98,43.08)">
                     <g class="nad-active">
                         <g transform="rotate(6.20)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1883,8 +1883,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="284">
             <desc>L16-17-1</desc>
             <g id="284.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-15.69,-1733.55 -209.11,-1365.00"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-30.79,-1704.78)">
+                <polyline class="nad-edge-path" points="-15.69,-1733.55 -209.11,-1365.00"/>
+                <g class="nad-edge-infos" transform="translate(-30.79,-1704.78)">
                     <g class="nad-active">
                         <g transform="rotate(-152.31)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1895,8 +1895,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="284.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-402.53,-996.44 -209.11,-1365.00"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-387.43,-1025.21)">
+                <polyline class="nad-edge-path" points="-402.53,-996.44 -209.11,-1365.00"/>
+                <g class="nad-edge-infos" transform="translate(-387.43,-1025.21)">
                     <g class="nad-active">
                         <g transform="rotate(27.69)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1910,8 +1910,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="285">
             <desc>L17-18-1</desc>
             <g id="285.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-416.49,-944.61 -431.40,-596.09"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-417.88,-912.14)">
+                <polyline class="nad-edge-path" points="-416.49,-944.61 -431.40,-596.09"/>
+                <g class="nad-edge-infos" transform="translate(-417.88,-912.14)">
                     <g class="nad-active">
                         <g transform="rotate(-177.55)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1922,8 +1922,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="285.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-446.30,-247.56 -431.40,-596.09"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-444.92,-280.03)">
+                <polyline class="nad-edge-path" points="-446.30,-247.56 -431.40,-596.09"/>
+                <g class="nad-edge-infos" transform="translate(-444.92,-280.03)">
                     <g class="nad-active">
                         <g transform="rotate(2.45)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1937,8 +1937,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="286">
             <desc>L17-31-1</desc>
             <g id="286.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-436.15,-990.03 -721.92,-1236.18"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-460.77,-1011.24)">
+                <polyline class="nad-edge-path" points="-436.15,-990.03 -721.92,-1236.18"/>
+                <g class="nad-edge-infos" transform="translate(-460.77,-1011.24)">
                     <g class="nad-active">
                         <g transform="rotate(-49.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1949,8 +1949,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="286.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1007.70,-1482.33 -721.92,-1236.18"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-983.07,-1461.12)">
+                <polyline class="nad-edge-path" points="-1007.70,-1482.33 -721.92,-1236.18"/>
+                <g class="nad-edge-infos" transform="translate(-983.07,-1461.12)">
                     <g class="nad-active">
                         <g transform="rotate(130.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1964,8 +1964,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="287">
             <desc>T30-17-1</desc>
             <g id="287.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-817.20,-371.22 -640.58,-635.29"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-799.13,-398.23)">
+                <polyline class="nad-edge-path" points="-817.20,-371.22 -640.58,-635.29"/>
+                <g class="nad-edge-infos" transform="translate(-799.13,-398.23)">
                     <g class="nad-active">
                         <g transform="rotate(33.78)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1976,8 +1976,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="287.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-430.60,-949.23 -607.22,-685.16"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-448.67,-922.21)">
+                <polyline class="nad-edge-path" points="-430.60,-949.23 -607.22,-685.16"/>
+                <g class="nad-edge-infos" transform="translate(-448.67,-922.21)">
                     <g class="nad-active">
                         <g transform="rotate(-146.22)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1987,7 +1987,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500-line nad-winding" cx="-629.46" cy="-651.91" r="20.00"/>
                 <circle class="nad-vl120to180-line nad-winding" cx="-618.34" cy="-668.54" r="20.00"/>
             </g>
@@ -1995,8 +1995,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="288">
             <desc>L18-19-1</desc>
             <g id="288.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-455.39,-193.75 -523.27,32.39"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-464.73,-162.62)">
+                <polyline class="nad-edge-path" points="-455.39,-193.75 -523.27,32.39"/>
+                <g class="nad-edge-infos" transform="translate(-464.73,-162.62)">
                     <g class="nad-active">
                         <g transform="rotate(-163.29)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2007,8 +2007,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="288.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-591.15,258.52 -523.27,32.39"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-581.80,227.39)">
+                <polyline class="nad-edge-path" points="-591.15,258.52 -523.27,32.39"/>
+                <g class="nad-edge-infos" transform="translate(-581.80,227.39)">
                     <g class="nad-active">
                         <g transform="rotate(16.71)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2022,8 +2022,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="289">
             <desc>L19-20-1</desc>
             <g id="289.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-624.53,295.22 -1076.76,479.08"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-654.64,307.46)">
+                <polyline class="nad-edge-path" points="-624.53,295.22 -1076.76,479.08"/>
+                <g class="nad-edge-infos" transform="translate(-654.64,307.46)">
                     <g class="nad-active">
                         <g transform="rotate(-112.12)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2034,8 +2034,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="289.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1528.99,662.94 -1076.76,479.08"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1498.88,650.70)">
+                <polyline class="nad-edge-path" points="-1528.99,662.94 -1076.76,479.08"/>
+                <g class="nad-edge-infos" transform="translate(-1498.88,650.70)">
                     <g class="nad-active">
                         <g transform="rotate(67.88)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2049,8 +2049,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="290">
             <desc>L19-34-1</desc>
             <g id="290.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-596.22,312.21 -539.66,857.82"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-592.87,344.54)">
+                <polyline class="nad-edge-path" points="-596.22,312.21 -539.66,857.82"/>
+                <g class="nad-edge-infos" transform="translate(-592.87,344.54)">
                     <g class="nad-active">
                         <g transform="rotate(174.08)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2061,8 +2061,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="290.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-483.11,1403.43 -539.66,857.82"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-486.46,1371.11)">
+                <polyline class="nad-edge-path" points="-483.11,1403.43 -539.66,857.82"/>
+                <g class="nad-edge-infos" transform="translate(-486.46,1371.11)">
                     <g class="nad-active">
                         <g transform="rotate(-5.92)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2076,8 +2076,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="291">
             <desc>L20-21-1</desc>
             <g id="291.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1581.95,674.12 -1835.99,681.78"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1614.44,675.10)">
+                <polyline class="nad-edge-path" points="-1581.95,674.12 -1835.99,681.78"/>
+                <g class="nad-edge-infos" transform="translate(-1614.44,675.10)">
                     <g class="nad-active">
                         <g transform="rotate(-91.73)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2088,8 +2088,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="291.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2090.02,689.44 -1835.99,681.78"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-2057.53,688.46)">
+                <polyline class="nad-edge-path" points="-2090.02,689.44 -1835.99,681.78"/>
+                <g class="nad-edge-infos" transform="translate(-2057.53,688.46)">
                     <g class="nad-active">
                         <g transform="rotate(88.27)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2103,8 +2103,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="292">
             <desc>L21-22-1</desc>
             <g id="292.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2122.71,663.26 -2159.57,472.11"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-2128.87,631.35)">
+                <polyline class="nad-edge-path" points="-2122.71,663.26 -2159.57,472.11"/>
+                <g class="nad-edge-infos" transform="translate(-2128.87,631.35)">
                     <g class="nad-active">
                         <g transform="rotate(-10.91)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2115,8 +2115,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="292.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2196.42,280.97 -2159.57,472.11"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-2190.27,312.88)">
+                <polyline class="nad-edge-path" points="-2196.42,280.97 -2159.57,472.11"/>
+                <g class="nad-edge-infos" transform="translate(-2190.27,312.88)">
                     <g class="nad-active">
                         <g transform="rotate(169.09)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2130,8 +2130,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="293">
             <desc>L22-23-1</desc>
             <g id="293.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2194.92,227.29 -2111.65,-104.11"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-2187.00,195.77)">
+                <polyline class="nad-edge-path" points="-2194.92,227.29 -2111.65,-104.11"/>
+                <g class="nad-edge-infos" transform="translate(-2187.00,195.77)">
                     <g class="nad-active">
                         <g transform="rotate(14.10)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2142,8 +2142,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="293.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2028.38,-435.52 -2111.65,-104.11"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-2036.30,-404.00)">
+                <polyline class="nad-edge-path" points="-2028.38,-435.52 -2111.65,-104.11"/>
+                <g class="nad-edge-infos" transform="translate(-2036.30,-404.00)">
                     <g class="nad-active">
                         <g transform="rotate(-165.90)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2157,8 +2157,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="294">
             <desc>L23-24-1</desc>
             <g id="294.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2048.96,-465.67 -2287.33,-496.08"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-2081.20,-469.78)">
+                <polyline class="nad-edge-path" points="-2048.96,-465.67 -2287.33,-496.08"/>
+                <g class="nad-edge-infos" transform="translate(-2081.20,-469.78)">
                     <g class="nad-active">
                         <g transform="rotate(-82.73)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2169,8 +2169,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="294.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2525.71,-526.50 -2287.33,-496.08"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-2493.47,-522.39)">
+                <polyline class="nad-edge-path" points="-2525.71,-526.50 -2287.33,-496.08"/>
+                <g class="nad-edge-infos" transform="translate(-2493.47,-522.39)">
                     <g class="nad-active">
                         <g transform="rotate(97.27)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2184,8 +2184,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="295">
             <desc>L23-25-1</desc>
             <g id="295.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1995.60,-470.93 -1819.80,-529.85"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1964.79,-481.25)">
+                <polyline class="nad-edge-path" points="-1995.60,-470.93 -1819.80,-529.85"/>
+                <g class="nad-edge-infos" transform="translate(-1964.79,-481.25)">
                     <g class="nad-active">
                         <g transform="rotate(71.47)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2196,8 +2196,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="295.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1643.99,-588.77 -1819.80,-529.85"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1674.81,-578.44)">
+                <polyline class="nad-edge-path" points="-1643.99,-588.77 -1819.80,-529.85"/>
+                <g class="nad-edge-infos" transform="translate(-1674.81,-578.44)">
                     <g class="nad-active">
                         <g transform="rotate(-108.53)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2211,8 +2211,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="296">
             <desc>L23-32-1</desc>
             <g id="296.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2004.73,-483.84 -1694.18,-880.65"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1984.70,-509.44)">
+                <polyline class="nad-edge-path" points="-2004.73,-483.84 -1694.18,-880.65"/>
+                <g class="nad-edge-infos" transform="translate(-1984.70,-509.44)">
                     <g class="nad-active">
                         <g transform="rotate(38.05)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2223,8 +2223,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="296.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1383.63,-1277.47 -1694.18,-880.65"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1403.66,-1251.87)">
+                <polyline class="nad-edge-path" points="-1383.63,-1277.47 -1694.18,-880.65"/>
+                <g class="nad-edge-infos" transform="translate(-1403.66,-1251.87)">
                     <g class="nad-active">
                         <g transform="rotate(-141.95)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2238,8 +2238,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="297">
             <desc>L24-70-1</desc>
             <g id="297.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2528.79,-543.04 -2359.06,-634.60"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-2500.19,-558.47)">
+                <polyline class="nad-edge-path" points="-2528.79,-543.04 -2359.06,-634.60"/>
+                <g class="nad-edge-infos" transform="translate(-2500.19,-558.47)">
                     <g class="nad-active">
                         <g transform="rotate(61.65)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2250,8 +2250,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="297.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2189.33,-726.17 -2359.06,-634.60"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-2217.94,-710.74)">
+                <polyline class="nad-edge-path" points="-2189.33,-726.17 -2359.06,-634.60"/>
+                <g class="nad-edge-infos" transform="translate(-2217.94,-710.74)">
                     <g class="nad-active">
                         <g transform="rotate(-118.35)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2265,8 +2265,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="298">
             <desc>L24-72-1</desc>
             <g id="298.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2580.09,-534.67 -2778.54,-568.98"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-2612.11,-540.20)">
+                <polyline class="nad-edge-path" points="-2580.09,-534.67 -2778.54,-568.98"/>
+                <g class="nad-edge-infos" transform="translate(-2612.11,-540.20)">
                     <g class="nad-active">
                         <g transform="rotate(-80.19)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2277,8 +2277,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="298.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2976.99,-603.29 -2778.54,-568.98"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-2944.96,-597.76)">
+                <polyline class="nad-edge-path" points="-2976.99,-603.29 -2778.54,-568.98"/>
+                <g class="nad-edge-infos" transform="translate(-2944.96,-597.76)">
                     <g class="nad-active">
                         <g transform="rotate(99.81)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2292,8 +2292,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="299">
             <desc>L25-27-1</desc>
             <g id="299.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1604.46,-621.49 -1488.99,-827.33"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1588.56,-649.84)">
+                <polyline class="nad-edge-path" points="-1604.46,-621.49 -1488.99,-827.33"/>
+                <g class="nad-edge-infos" transform="translate(-1588.56,-649.84)">
                     <g class="nad-active">
                         <g transform="rotate(29.29)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2304,8 +2304,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="299.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1373.52,-1033.17 -1488.99,-827.33"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1389.42,-1004.83)">
+                <polyline class="nad-edge-path" points="-1373.52,-1033.17 -1488.99,-827.33"/>
+                <g class="nad-edge-infos" transform="translate(-1389.42,-1004.83)">
                     <g class="nad-active">
                         <g transform="rotate(-150.71)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2319,8 +2319,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="300">
             <desc>T26-25-1</desc>
             <g id="300.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1348.10,-386.48 -1448.55,-465.04"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1373.70,-406.50)">
+                <polyline class="nad-edge-path" points="-1348.10,-386.48 -1448.55,-465.04"/>
+                <g class="nad-edge-infos" transform="translate(-1373.70,-406.50)">
                     <g class="nad-active">
                         <g transform="rotate(-51.97)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2331,8 +2331,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="300.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1596.25,-580.57 -1495.81,-502.00"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1570.65,-560.54)">
+                <polyline class="nad-edge-path" points="-1596.25,-580.57 -1495.81,-502.00"/>
+                <g class="nad-edge-infos" transform="translate(-1570.65,-560.54)">
                     <g class="nad-active">
                         <g transform="rotate(128.03)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2342,7 +2342,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500-line nad-winding" cx="-1464.30" cy="-477.36" r="20.00"/>
                 <circle class="nad-vl120to180-line nad-winding" cx="-1480.06" cy="-489.68" r="20.00"/>
             </g>
@@ -2350,8 +2350,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="301">
             <desc>L26-30-1</desc>
             <g id="301.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1298.97,-368.36 -1079.47,-358.95"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1266.50,-366.97)">
+                <polyline class="nad-edge-path" points="-1298.97,-368.36 -1079.47,-358.95"/>
+                <g class="nad-edge-infos" transform="translate(-1266.50,-366.97)">
                     <g class="nad-active">
                         <g transform="rotate(92.45)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2362,8 +2362,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="301.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-859.96,-349.54 -1079.47,-358.95"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-892.43,-350.93)">
+                <polyline class="nad-edge-path" points="-859.96,-349.54 -1079.47,-358.95"/>
+                <g class="nad-edge-infos" transform="translate(-892.43,-350.93)">
                     <g class="nad-active">
                         <g transform="rotate(-87.55)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2377,8 +2377,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="302">
             <desc>L27-28-1</desc>
             <g id="302.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1339.37,-1075.26 -1081.34,-1301.03"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1314.91,-1096.66)">
+                <polyline class="nad-edge-path" points="-1339.37,-1075.26 -1081.34,-1301.03"/>
+                <g class="nad-edge-infos" transform="translate(-1314.91,-1096.66)">
                     <g class="nad-active">
                         <g transform="rotate(48.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2389,8 +2389,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="302.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-823.32,-1526.79 -1081.34,-1301.03"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-847.77,-1505.39)">
+                <polyline class="nad-edge-path" points="-823.32,-1526.79 -1081.34,-1301.03"/>
+                <g class="nad-edge-infos" transform="translate(-847.77,-1505.39)">
                     <g class="nad-active">
                         <g transform="rotate(-131.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2404,8 +2404,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="303">
             <desc>L27-32-1</desc>
             <g id="303.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1360.81,-1084.65 -1363.37,-1178.14"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1361.70,-1117.13)">
+                <polyline class="nad-edge-path" points="-1360.81,-1084.65 -1363.37,-1178.14"/>
+                <g class="nad-edge-infos" transform="translate(-1361.70,-1117.13)">
                     <g class="nad-active">
                         <g transform="rotate(-1.57)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2416,8 +2416,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="303.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1365.93,-1271.63 -1363.37,-1178.14"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1365.04,-1239.14)">
+                <polyline class="nad-edge-path" points="-1365.93,-1271.63 -1363.37,-1178.14"/>
+                <g class="nad-edge-infos" transform="translate(-1365.04,-1239.14)">
                     <g class="nad-active">
                         <g transform="rotate(178.43)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2431,8 +2431,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="304">
             <desc>L28-29-1</desc>
             <g id="304.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-793.77,-1570.93 -755.13,-1684.70"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-783.32,-1601.71)">
+                <polyline class="nad-edge-path" points="-793.77,-1570.93 -755.13,-1684.70"/>
+                <g class="nad-edge-infos" transform="translate(-783.32,-1601.71)">
                     <g class="nad-active">
                         <g transform="rotate(18.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2443,8 +2443,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="304.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-716.49,-1798.47 -755.13,-1684.70"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-726.94,-1767.69)">
+                <polyline class="nad-edge-path" points="-716.49,-1798.47 -755.13,-1684.70"/>
+                <g class="nad-edge-infos" transform="translate(-726.94,-1767.69)">
                     <g class="nad-active">
                         <g transform="rotate(-161.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2458,8 +2458,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="305">
             <desc>L29-31-1</desc>
             <g id="305.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-726.99,-1804.96 -868.09,-1662.39"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-749.85,-1781.86)">
+                <polyline class="nad-edge-path" points="-726.99,-1804.96 -868.09,-1662.39"/>
+                <g class="nad-edge-infos" transform="translate(-749.85,-1781.86)">
                     <g class="nad-active">
                         <g transform="rotate(-135.30)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2470,8 +2470,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="305.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1009.19,-1519.82 -868.09,-1662.39"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-986.33,-1542.92)">
+                <polyline class="nad-edge-path" points="-1009.19,-1519.82 -868.09,-1662.39"/>
+                <g class="nad-edge-infos" transform="translate(-986.33,-1542.92)">
                     <g class="nad-active">
                         <g transform="rotate(44.70)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2485,8 +2485,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="306">
             <desc>L3-5-1</desc>
             <g id="306.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="673.64,-2569.71 458.44,-2312.12"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(652.80,-2544.77)">
+                <polyline class="nad-edge-path" points="673.64,-2569.71 458.44,-2312.12"/>
+                <g class="nad-edge-infos" transform="translate(652.80,-2544.77)">
                     <g class="nad-active">
                         <g transform="rotate(-140.12)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2497,8 +2497,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="306.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="243.23,-2054.53 458.44,-2312.12"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(264.07,-2079.47)">
+                <polyline class="nad-edge-path" points="243.23,-2054.53 458.44,-2312.12"/>
+                <g class="nad-edge-infos" transform="translate(264.07,-2079.47)">
                     <g class="nad-active">
                         <g transform="rotate(39.88)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2512,8 +2512,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="307">
             <desc>L8-30-1</desc>
             <g id="307.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-822.34,-746.28 -827.06,-561.07"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-823.17,-713.79)">
+                <polyline class="nad-edge-path" points="-822.34,-746.28 -827.06,-561.07"/>
+                <g class="nad-edge-infos" transform="translate(-823.17,-713.79)">
                     <g class="nad-active">
                         <g transform="rotate(-178.54)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2524,8 +2524,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="307.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-831.79,-375.85 -827.06,-561.07"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-830.96,-408.34)">
+                <polyline class="nad-edge-path" points="-831.79,-375.85 -827.06,-561.07"/>
+                <g class="nad-edge-infos" transform="translate(-830.96,-408.34)">
                     <g class="nad-active">
                         <g transform="rotate(1.46)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2539,8 +2539,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="308">
             <desc>L30-38-1</desc>
             <g id="308.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-832.08,-320.86 -824.90,155.73"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-831.59,-288.37)">
+                <polyline class="nad-edge-path" points="-832.08,-320.86 -824.90,155.73"/>
+                <g class="nad-edge-infos" transform="translate(-831.59,-288.37)">
                     <g class="nad-active">
                         <g transform="rotate(179.14)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2551,8 +2551,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="308.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-817.73,632.31 -824.90,155.73"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-818.22,599.82)">
+                <polyline class="nad-edge-path" points="-817.73,632.31 -824.90,155.73"/>
+                <g class="nad-edge-infos" transform="translate(-818.22,599.82)">
                     <g class="nad-active">
                         <g transform="rotate(-0.86)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2566,8 +2566,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="309">
             <desc>L31-32-1</desc>
             <g id="309.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1052.17,-1486.22 -1197.61,-1399.70"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1080.10,-1469.60)">
+                <polyline class="nad-edge-path" points="-1052.17,-1486.22 -1197.61,-1399.70"/>
+                <g class="nad-edge-infos" transform="translate(-1080.10,-1469.60)">
                     <g class="nad-active">
                         <g transform="rotate(-120.75)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2578,8 +2578,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="309.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1343.04,-1313.18 -1197.61,-1399.70"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1315.11,-1329.80)">
+                <polyline class="nad-edge-path" points="-1343.04,-1313.18 -1197.61,-1399.70"/>
+                <g class="nad-edge-infos" transform="translate(-1315.11,-1329.80)">
                     <g class="nad-active">
                         <g transform="rotate(59.25)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2593,8 +2593,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="310">
             <desc>L33-37-1</desc>
             <g id="310.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-120.05,127.67 -308.18,532.30"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-133.75,157.14)">
+                <polyline class="nad-edge-path" points="-120.05,127.67 -308.18,532.30"/>
+                <g class="nad-edge-infos" transform="translate(-133.75,157.14)">
                     <g class="nad-active">
                         <g transform="rotate(-155.06)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2605,8 +2605,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="310.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-496.31,936.94 -308.18,532.30"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-482.61,907.47)">
+                <polyline class="nad-edge-path" points="-496.31,936.94 -308.18,532.30"/>
+                <g class="nad-edge-infos" transform="translate(-482.61,907.47)">
                     <g class="nad-active">
                         <g transform="rotate(24.94)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2620,8 +2620,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="311">
             <desc>L34-36-1</desc>
             <g id="311.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-501.39,1448.40 -855.24,1743.57"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-526.35,1469.22)">
+                <polyline class="nad-edge-path" points="-501.39,1448.40 -855.24,1743.57"/>
+                <g class="nad-edge-infos" transform="translate(-526.35,1469.22)">
                     <g class="nad-active">
                         <g transform="rotate(-129.83)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2632,8 +2632,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="311.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1209.09,2038.75 -855.24,1743.57"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1184.14,2017.93)">
+                <polyline class="nad-edge-path" points="-1209.09,2038.75 -855.24,1743.57"/>
+                <g class="nad-edge-infos" transform="translate(-1184.14,2017.93)">
                     <g class="nad-active">
                         <g transform="rotate(50.17)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2647,8 +2647,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="312">
             <desc>L34-37-1</desc>
             <g id="312.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-481.89,1403.33 -494.09,1196.33"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-483.80,1370.89)">
+                <polyline class="nad-edge-path" points="-481.89,1403.33 -494.09,1196.33"/>
+                <g class="nad-edge-infos" transform="translate(-483.80,1370.89)">
                     <g class="nad-active">
                         <g transform="rotate(-3.37)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2659,8 +2659,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="312.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-506.29,989.32 -494.09,1196.33"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-504.38,1021.77)">
+                <polyline class="nad-edge-path" points="-506.29,989.32 -494.09,1196.33"/>
+                <g class="nad-edge-infos" transform="translate(-504.38,1021.77)">
                     <g class="nad-active">
                         <g transform="rotate(176.63)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2674,8 +2674,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="313">
             <desc>L34-43-1</desc>
             <g id="313.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-453.97,1438.80 4.35,1578.49"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-422.88,1448.28)">
+                <polyline class="nad-edge-path" points="-453.97,1438.80 4.35,1578.49"/>
+                <g class="nad-edge-infos" transform="translate(-422.88,1448.28)">
                     <g class="nad-active">
                         <g transform="rotate(106.95)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2686,8 +2686,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="313.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="462.67,1718.18 4.35,1578.49"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(431.58,1708.70)">
+                <polyline class="nad-edge-path" points="462.67,1718.18 4.35,1578.49"/>
+                <g class="nad-edge-infos" transform="translate(431.58,1708.70)">
                     <g class="nad-active">
                         <g transform="rotate(-73.05)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2701,8 +2701,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="314">
             <desc>L35-36-1</desc>
             <g id="314.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1216.10,1782.28 -1222.45,1905.59"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1217.77,1814.73)">
+                <polyline class="nad-edge-path" points="-1216.10,1782.28 -1222.45,1905.59"/>
+                <g class="nad-edge-infos" transform="translate(-1217.77,1814.73)">
                     <g class="nad-active">
                         <g transform="rotate(-177.05)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2713,8 +2713,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="314.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1228.80,2028.90 -1222.45,1905.59"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1227.13,1996.44)">
+                <polyline class="nad-edge-path" points="-1228.80,2028.90 -1222.45,1905.59"/>
+                <g class="nad-edge-infos" transform="translate(-1227.13,1996.44)">
                     <g class="nad-active">
                         <g transform="rotate(2.95)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2728,8 +2728,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="315">
             <desc>L35-37-1</desc>
             <g id="315.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1196.39,1734.29 -861.30,1358.34"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1174.77,1710.02)">
+                <polyline class="nad-edge-path" points="-1196.39,1734.29 -861.30,1358.34"/>
+                <g class="nad-edge-infos" transform="translate(-1174.77,1710.02)">
                     <g class="nad-active">
                         <g transform="rotate(41.71)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2740,8 +2740,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="315.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-526.21,982.40 -861.30,1358.34"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-547.83,1006.66)">
+                <polyline class="nad-edge-path" points="-526.21,982.40 -861.30,1358.34"/>
+                <g class="nad-edge-infos" transform="translate(-547.83,1006.66)">
                     <g class="nad-active">
                         <g transform="rotate(-138.29)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2755,8 +2755,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="316">
             <desc>L37-39-1</desc>
             <g id="316.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-483.66,974.85 -269.20,1089.60"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-455.00,990.18)">
+                <polyline class="nad-edge-path" points="-483.66,974.85 -269.20,1089.60"/>
+                <g class="nad-edge-infos" transform="translate(-455.00,990.18)">
                     <g class="nad-active">
                         <g transform="rotate(118.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2767,8 +2767,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="316.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-54.74,1204.34 -269.20,1089.60"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-83.39,1189.01)">
+                <polyline class="nad-edge-path" points="-54.74,1204.34 -269.20,1089.60"/>
+                <g class="nad-edge-infos" transform="translate(-83.39,1189.01)">
                     <g class="nad-active">
                         <g transform="rotate(-61.85)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2782,8 +2782,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="317">
             <desc>L37-40-1</desc>
             <g id="317.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-480.65,958.24 -244.85,926.81"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-448.43,953.95)">
+                <polyline class="nad-edge-path" points="-480.65,958.24 -244.85,926.81"/>
+                <g class="nad-edge-infos" transform="translate(-448.43,953.95)">
                     <g class="nad-active">
                         <g transform="rotate(82.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2794,8 +2794,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="317.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-9.05,895.38 -244.85,926.81"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-41.27,899.67)">
+                <polyline class="nad-edge-path" points="-9.05,895.38 -244.85,926.81"/>
+                <g class="nad-edge-infos" transform="translate(-41.27,899.67)">
                     <g class="nad-active">
                         <g transform="rotate(-97.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2809,8 +2809,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="318">
             <desc>T38-37-1</desc>
             <g id="318.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-797.64,679.02 -684.08,789.89"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-774.38,701.72)">
+                <polyline class="nad-edge-path" points="-797.64,679.02 -684.08,789.89"/>
+                <g class="nad-edge-infos" transform="translate(-774.38,701.72)">
                     <g class="nad-active">
                         <g transform="rotate(134.31)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2821,8 +2821,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="318.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-527.59,942.66 -641.15,831.80"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-550.84,919.96)">
+                <polyline class="nad-edge-path" points="-527.59,942.66 -641.15,831.80"/>
+                <g class="nad-edge-infos" transform="translate(-550.84,919.96)">
                     <g class="nad-active">
                         <g transform="rotate(-45.69)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2832,7 +2832,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500-line nad-winding" cx="-669.77" cy="803.86" r="20.00"/>
                 <circle class="nad-vl120to180-line nad-winding" cx="-655.46" cy="817.83" r="20.00"/>
             </g>
@@ -2840,8 +2840,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="319">
             <desc>L38-65-1</desc>
             <g id="319.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-811.92,686.78 -757.74,957.38"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-805.54,718.64)">
+                <polyline class="nad-edge-path" points="-811.92,686.78 -757.74,957.38"/>
+                <g class="nad-edge-infos" transform="translate(-805.54,718.64)">
                     <g class="nad-active">
                         <g transform="rotate(168.68)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2852,8 +2852,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="319.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-703.56,1227.97 -757.74,957.38"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-709.94,1196.11)">
+                <polyline class="nad-edge-path" points="-703.56,1227.97 -757.74,957.38"/>
+                <g class="nad-edge-infos" transform="translate(-709.94,1196.11)">
                     <g class="nad-active">
                         <g transform="rotate(-11.32)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2867,8 +2867,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="320">
             <desc>L39-40-1</desc>
             <g id="320.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-26.42,1190.12 -6.14,1054.53"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-21.61,1157.98)">
+                <polyline class="nad-edge-path" points="-26.42,1190.12 -6.14,1054.53"/>
+                <g class="nad-edge-infos" transform="translate(-21.61,1157.98)">
                     <g class="nad-active">
                         <g transform="rotate(8.51)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2879,8 +2879,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="320.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="14.14,918.94 -6.14,1054.53"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(9.33,951.09)">
+                <polyline class="nad-edge-path" points="14.14,918.94 -6.14,1054.53"/>
+                <g class="nad-edge-infos" transform="translate(9.33,951.09)">
                     <g class="nad-active">
                         <g transform="rotate(-171.49)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2894,8 +2894,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="321">
             <desc>L4-5-1</desc>
             <g id="321.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="830.72,-2049.35 541.91,-2041.75"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(798.24,-2048.50)">
+                <polyline class="nad-edge-path" points="830.72,-2049.35 541.91,-2041.75"/>
+                <g class="nad-edge-infos" transform="translate(798.24,-2048.50)">
                     <g class="nad-active">
                         <g transform="rotate(-91.51)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2906,8 +2906,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="321.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="253.09,-2034.15 541.91,-2041.75"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(285.58,-2035.01)">
+                <polyline class="nad-edge-path" points="253.09,-2034.15 541.91,-2041.75"/>
+                <g class="nad-edge-infos" transform="translate(285.58,-2035.01)">
                     <g class="nad-active">
                         <g transform="rotate(88.49)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2921,8 +2921,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="322">
             <desc>L40-41-1</desc>
             <g id="322.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="39.35,874.16 214.38,728.57"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(64.33,853.38)">
+                <polyline class="nad-edge-path" points="39.35,874.16 214.38,728.57"/>
+                <g class="nad-edge-infos" transform="translate(64.33,853.38)">
                     <g class="nad-active">
                         <g transform="rotate(50.25)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2933,8 +2933,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="322.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="389.42,582.99 214.38,728.57"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(364.43,603.77)">
+                <polyline class="nad-edge-path" points="389.42,582.99 214.38,728.57"/>
+                <g class="nad-edge-infos" transform="translate(364.43,603.77)">
                     <g class="nad-active">
                         <g transform="rotate(-129.75)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2948,8 +2948,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="323">
             <desc>L40-42-1</desc>
             <g id="323.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="28.45,866.23 65.09,774.97"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(40.56,836.07)">
+                <polyline class="nad-edge-path" points="28.45,866.23 65.09,774.97"/>
+                <g class="nad-edge-infos" transform="translate(40.56,836.07)">
                     <g class="nad-active">
                         <g transform="rotate(21.87)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2960,8 +2960,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="323.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="101.73,683.71 65.09,774.97"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(89.62,713.87)">
+                <polyline class="nad-edge-path" points="101.73,683.71 65.09,774.97"/>
+                <g class="nad-edge-infos" transform="translate(89.62,713.87)">
                     <g class="nad-active">
                         <g transform="rotate(-158.13)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2975,8 +2975,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="324">
             <desc>L41-42-1</desc>
             <g id="324.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="384.30,573.56 261.27,611.79"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(353.26,583.21)">
+                <polyline class="nad-edge-path" points="384.30,573.56 261.27,611.79"/>
+                <g class="nad-edge-infos" transform="translate(353.26,583.21)">
                     <g class="nad-active">
                         <g transform="rotate(-107.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2987,8 +2987,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="324.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="138.24,650.03 261.27,611.79"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(169.27,640.38)">
+                <polyline class="nad-edge-path" points="138.24,650.03 261.27,611.79"/>
+                <g class="nad-edge-infos" transform="translate(169.27,640.38)">
                     <g class="nad-active">
                         <g transform="rotate(72.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3002,8 +3002,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="325">
             <desc>L42-49-1</desc>
             <g id="325.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="86.51,668.57 37.90,688.40 -119.26,890.96"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(19.51,712.11)">
+                <polyline class="nad-edge-path" points="86.51,668.57 37.90,688.40 -119.26,890.96"/>
+                <g class="nad-edge-infos" transform="translate(19.51,712.11)">
                     <g class="nad-active">
                         <g transform="rotate(-142.19)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3014,8 +3014,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="325.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-283.55,1145.53 -276.42,1093.52 -119.26,890.96"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-258.03,1069.81)">
+                <polyline class="nad-edge-path" points="-283.55,1145.53 -276.42,1093.52 -119.26,890.96"/>
+                <g class="nad-edge-infos" transform="translate(-258.03,1069.81)">
                     <g class="nad-active">
                         <g transform="rotate(37.81)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3029,8 +3029,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="326">
             <desc>L42-49-2</desc>
             <g id="326.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="108.24,685.43 101.11,737.44 -56.05,940.00"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(82.72,761.15)">
+                <polyline class="nad-edge-path" points="108.24,685.43 101.11,737.44 -56.05,940.00"/>
+                <g class="nad-edge-infos" transform="translate(82.72,761.15)">
                     <g class="nad-active">
                         <g transform="rotate(-142.19)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3041,8 +3041,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="326.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-261.82,1162.39 -213.21,1142.56 -56.05,940.00"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-194.82,1118.85)">
+                <polyline class="nad-edge-path" points="-261.82,1162.39 -213.21,1142.56 -56.05,940.00"/>
+                <g class="nad-edge-infos" transform="translate(-194.82,1118.85)">
                     <g class="nad-active">
                         <g transform="rotate(37.81)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3056,8 +3056,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="327">
             <desc>L43-44-1</desc>
             <g id="327.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="516.15,1721.97 739.01,1687.33"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(548.26,1716.98)">
+                <polyline class="nad-edge-path" points="516.15,1721.97 739.01,1687.33"/>
+                <g class="nad-edge-infos" transform="translate(548.26,1716.98)">
                     <g class="nad-active">
                         <g transform="rotate(81.16)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3068,8 +3068,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="327.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="961.87,1652.69 739.01,1687.33"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(929.75,1657.68)">
+                <polyline class="nad-edge-path" points="961.87,1652.69 739.01,1687.33"/>
+                <g class="nad-edge-infos" transform="translate(929.75,1657.68)">
                     <g class="nad-active">
                         <g transform="rotate(-98.84)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3083,8 +3083,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="328">
             <desc>L44-45-1</desc>
             <g id="328.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="969.29,1629.33 821.49,1486.17"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(945.94,1606.72)">
+                <polyline class="nad-edge-path" points="969.29,1629.33 821.49,1486.17"/>
+                <g class="nad-edge-infos" transform="translate(945.94,1606.72)">
                     <g class="nad-active">
                         <g transform="rotate(-45.91)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3095,8 +3095,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="328.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="673.69,1343.01 821.49,1486.17"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(697.03,1365.62)">
+                <polyline class="nad-edge-path" points="673.69,1343.01 821.49,1486.17"/>
+                <g class="nad-edge-infos" transform="translate(697.03,1365.62)">
                     <g class="nad-active">
                         <g transform="rotate(134.09)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3110,8 +3110,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="329">
             <desc>L45-46-1</desc>
             <g id="329.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="641.61,1299.29 563.38,1143.29"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(627.04,1270.24)">
+                <polyline class="nad-edge-path" points="641.61,1299.29 563.38,1143.29"/>
+                <g class="nad-edge-infos" transform="translate(627.04,1270.24)">
                     <g class="nad-active">
                         <g transform="rotate(-26.63)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3122,8 +3122,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="329.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="485.14,987.28 563.38,1143.29"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(499.71,1016.33)">
+                <polyline class="nad-edge-path" points="485.14,987.28 563.38,1143.29"/>
+                <g class="nad-edge-infos" transform="translate(499.71,1016.33)">
                     <g class="nad-active">
                         <g transform="rotate(153.37)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3137,8 +3137,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="330">
             <desc>L45-49-1</desc>
             <g id="330.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="626.78,1319.51 183.33,1248.32"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(594.70,1314.36)">
+                <polyline class="nad-edge-path" points="626.78,1319.51 183.33,1248.32"/>
+                <g class="nad-edge-infos" transform="translate(594.70,1314.36)">
                     <g class="nad-active">
                         <g transform="rotate(-80.88)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3149,8 +3149,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="330.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-260.13,1177.13 183.33,1248.32"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-228.04,1182.29)">
+                <polyline class="nad-edge-path" points="-260.13,1177.13 183.33,1248.32"/>
+                <g class="nad-edge-infos" transform="translate(-228.04,1182.29)">
                     <g class="nad-active">
                         <g transform="rotate(99.12)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3164,8 +3164,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="331">
             <desc>L46-47-1</desc>
             <g id="331.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="448.20,950.44 89.00,771.51"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(419.11,935.95)">
+                <polyline class="nad-edge-path" points="448.20,950.44 89.00,771.51"/>
+                <g class="nad-edge-infos" transform="translate(419.11,935.95)">
                     <g class="nad-active">
                         <g transform="rotate(-63.52)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3176,8 +3176,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="331.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-270.19,592.59 89.00,771.51"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-241.10,607.08)">
+                <polyline class="nad-edge-path" points="-270.19,592.59 89.00,771.51"/>
+                <g class="nad-edge-infos" transform="translate(-241.10,607.08)">
                     <g class="nad-active">
                         <g transform="rotate(116.48)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3191,8 +3191,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="332">
             <desc>L46-48-1</desc>
             <g id="332.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="459.05,986.51 388.86,1107.96"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(442.79,1014.65)">
+                <polyline class="nad-edge-path" points="459.05,986.51 388.86,1107.96"/>
+                <g class="nad-edge-infos" transform="translate(442.79,1014.65)">
                     <g class="nad-active">
                         <g transform="rotate(-149.97)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3203,8 +3203,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="332.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="318.67,1229.40 388.86,1107.96"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(334.93,1201.27)">
+                <polyline class="nad-edge-path" points="318.67,1229.40 388.86,1107.96"/>
+                <g class="nad-edge-infos" transform="translate(334.93,1201.27)">
                     <g class="nad-active">
                         <g transform="rotate(30.03)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3218,8 +3218,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="333">
             <desc>L47-49-1</desc>
             <g id="333.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-294.46,607.83 -291.05,876.55"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-294.05,640.33)">
+                <polyline class="nad-edge-path" points="-294.46,607.83 -291.05,876.55"/>
+                <g class="nad-edge-infos" transform="translate(-294.05,640.33)">
                     <g class="nad-active">
                         <g transform="rotate(179.27)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3230,8 +3230,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="333.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-287.63,1145.28 -291.05,876.55"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-288.05,1112.78)">
+                <polyline class="nad-edge-path" points="-287.63,1145.28 -291.05,876.55"/>
+                <g class="nad-edge-infos" transform="translate(-288.05,1112.78)">
                     <g class="nad-active">
                         <g transform="rotate(-0.73)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3245,8 +3245,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="334">
             <desc>L47-69-1</desc>
             <g id="334.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-315.60,562.34 -684.59,243.04"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-340.18,541.07)">
+                <polyline class="nad-edge-path" points="-315.60,562.34 -684.59,243.04"/>
+                <g class="nad-edge-infos" transform="translate(-340.18,541.07)">
                     <g class="nad-active">
                         <g transform="rotate(-49.13)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3257,8 +3257,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="334.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1053.58,-76.25 -684.59,243.04"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1029.01,-54.98)">
+                <polyline class="nad-edge-path" points="-1053.58,-76.25 -684.59,243.04"/>
+                <g class="nad-edge-infos" transform="translate(-1029.01,-54.98)">
                     <g class="nad-active">
                         <g transform="rotate(130.87)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3272,8 +3272,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="335">
             <desc>L48-49-1</desc>
             <g id="335.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="277.66,1249.51 8.81,1212.99"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(245.45,1245.14)">
+                <polyline class="nad-edge-path" points="277.66,1249.51 8.81,1212.99"/>
+                <g class="nad-edge-infos" transform="translate(245.45,1245.14)">
                     <g class="nad-active">
                         <g transform="rotate(-82.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3284,8 +3284,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="335.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-260.04,1176.48 8.81,1212.99"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-227.83,1180.85)">
+                <polyline class="nad-edge-path" points="-260.04,1176.48 8.81,1212.99"/>
+                <g class="nad-edge-infos" transform="translate(-227.83,1180.85)">
                     <g class="nad-active">
                         <g transform="rotate(97.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3299,8 +3299,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="336">
             <desc>L49-50-1</desc>
             <g id="336.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-277.70,1198.55 -197.03,1415.46"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-266.37,1229.01)">
+                <polyline class="nad-edge-path" points="-277.70,1198.55 -197.03,1415.46"/>
+                <g class="nad-edge-infos" transform="translate(-266.37,1229.01)">
                     <g class="nad-active">
                         <g transform="rotate(159.60)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3311,8 +3311,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="336.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-116.35,1632.36 -197.03,1415.46"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-127.68,1601.90)">
+                <polyline class="nad-edge-path" points="-116.35,1632.36 -197.03,1415.46"/>
+                <g class="nad-edge-infos" transform="translate(-127.68,1601.90)">
                     <g class="nad-active">
                         <g transform="rotate(-20.40)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3326,8 +3326,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="337">
             <desc>L49-51-1</desc>
             <g id="337.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-314.66,1175.43 -734.12,1216.17"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-347.00,1178.57)">
+                <polyline class="nad-edge-path" points="-314.66,1175.43 -734.12,1216.17"/>
+                <g class="nad-edge-infos" transform="translate(-347.00,1178.57)">
                     <g class="nad-active">
                         <g transform="rotate(-95.55)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3338,8 +3338,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="337.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1153.58,1256.90 -734.12,1216.17"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1121.23,1253.76)">
+                <polyline class="nad-edge-path" points="-1153.58,1256.90 -734.12,1216.17"/>
+                <g class="nad-edge-infos" transform="translate(-1121.23,1253.76)">
                     <g class="nad-active">
                         <g transform="rotate(84.45)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3353,8 +3353,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="338">
             <desc>L49-54-1</desc>
             <g id="338.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-312.39,1184.00 -360.31,1205.44 -628.56,1575.98"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-377.91,1229.74)">
+                <polyline class="nad-edge-path" points="-312.39,1184.00 -360.31,1205.44 -628.56,1575.98"/>
+                <g class="nad-edge-infos" transform="translate(-377.91,1229.74)">
                     <g class="nad-active">
                         <g transform="rotate(-144.10)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3365,8 +3365,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="338.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-902.21,1998.74 -896.81,1946.51 -628.56,1575.98"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-879.22,1922.21)">
+                <polyline class="nad-edge-path" points="-902.21,1998.74 -896.81,1946.51 -628.56,1575.98"/>
+                <g class="nad-edge-infos" transform="translate(-879.22,1922.21)">
                     <g class="nad-active">
                         <g transform="rotate(35.90)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3380,8 +3380,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="339">
             <desc>L49-54-2</desc>
             <g id="339.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-290.11,1200.13 -295.51,1252.35 -563.76,1622.89"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-313.10,1276.65)">
+                <polyline class="nad-edge-path" points="-290.11,1200.13 -295.51,1252.35 -563.76,1622.89"/>
+                <g class="nad-edge-infos" transform="translate(-313.10,1276.65)">
                     <g class="nad-active">
                         <g transform="rotate(-144.10)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3392,8 +3392,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="339.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-879.94,2014.86 -832.01,1993.43 -563.76,1622.89"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-814.42,1969.13)">
+                <polyline class="nad-edge-path" points="-879.94,2014.86 -832.01,1993.43 -563.76,1622.89"/>
+                <g class="nad-edge-infos" transform="translate(-814.42,1969.13)">
                     <g class="nad-active">
                         <g transform="rotate(35.90)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3407,8 +3407,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="340">
             <desc>L49-66-1</desc>
             <g id="340.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-288.80,1200.23 -291.70,1252.65 -131.88,1568.54"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-278.16,1279.42)">
+                <polyline class="nad-edge-path" points="-288.80,1200.23 -291.70,1252.65 -131.88,1568.54"/>
+                <g class="nad-edge-infos" transform="translate(-278.16,1279.42)">
                     <g class="nad-active">
                         <g transform="rotate(153.16)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3419,8 +3419,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="340.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="71.89,1913.15 27.94,1884.43 -131.88,1568.54"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(14.40,1857.66)">
+                <polyline class="nad-edge-path" points="71.89,1913.15 27.94,1884.43 -131.88,1568.54"/>
+                <g class="nad-edge-infos" transform="translate(14.40,1857.66)">
                     <g class="nad-active">
                         <g transform="rotate(-26.84)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3434,8 +3434,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="341">
             <desc>L49-66-2</desc>
             <g id="341.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-264.26,1187.82 -220.32,1216.54 -60.49,1532.43"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-206.77,1243.31)">
+                <polyline class="nad-edge-path" points="-264.26,1187.82 -220.32,1216.54 -60.49,1532.43"/>
+                <g class="nad-edge-infos" transform="translate(-206.77,1243.31)">
                     <g class="nad-active">
                         <g transform="rotate(153.16)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3446,8 +3446,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="341.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="96.43,1900.73 99.33,1848.31 -60.49,1532.43"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(85.78,1821.54)">
+                <polyline class="nad-edge-path" points="96.43,1900.73 99.33,1848.31 -60.49,1532.43"/>
+                <g class="nad-edge-infos" transform="translate(85.78,1821.54)">
                     <g class="nad-active">
                         <g transform="rotate(-26.84)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3461,8 +3461,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="342">
             <desc>L49-69-1</desc>
             <g id="342.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-301.80,1149.42 -680.83,539.26"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-318.95,1121.81)">
+                <polyline class="nad-edge-path" points="-301.80,1149.42 -680.83,539.26"/>
+                <g class="nad-edge-infos" transform="translate(-318.95,1121.81)">
                     <g class="nad-active">
                         <g transform="rotate(-31.85)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3473,8 +3473,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="342.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1059.87,-70.89 -680.83,539.26"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1042.72,-43.28)">
+                <polyline class="nad-edge-path" points="-1059.87,-70.89 -680.83,539.26"/>
+                <g class="nad-edge-infos" transform="translate(-1042.72,-43.28)">
                     <g class="nad-active">
                         <g transform="rotate(148.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3488,8 +3488,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="343">
             <desc>L5-6-1</desc>
             <g id="343.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="214.47,-2058.58 109.32,-2296.19"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(201.32,-2088.30)">
+                <polyline class="nad-edge-path" points="214.47,-2058.58 109.32,-2296.19"/>
+                <g class="nad-edge-infos" transform="translate(201.32,-2088.30)">
                     <g class="nad-active">
                         <g transform="rotate(-23.87)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3500,8 +3500,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="343.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="4.16,-2533.80 109.32,-2296.19"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(17.31,-2504.08)">
+                <polyline class="nad-edge-path" points="4.16,-2533.80 109.32,-2296.19"/>
+                <g class="nad-edge-infos" transform="translate(17.31,-2504.08)">
                     <g class="nad-active">
                         <g transform="rotate(156.13)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3515,8 +3515,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="344">
             <desc>T8-5-1</desc>
             <g id="344.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-804.06,-794.92 -317.20,-1380.53"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-783.28,-819.91)">
+                <polyline class="nad-edge-path" points="-804.06,-794.92 -317.20,-1380.53"/>
+                <g class="nad-edge-infos" transform="translate(-783.28,-819.91)">
                     <g class="nad-active">
                         <g transform="rotate(39.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3527,8 +3527,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="344.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="208.02,-2012.28 -278.84,-1426.67"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(187.24,-1987.29)">
+                <polyline class="nad-edge-path" points="208.02,-2012.28 -278.84,-1426.67"/>
+                <g class="nad-edge-infos" transform="translate(187.24,-1987.29)">
                     <g class="nad-active">
                         <g transform="rotate(-140.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3538,7 +3538,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500-line nad-winding" cx="-304.41" cy="-1395.91" r="20.00"/>
                 <circle class="nad-vl120to180-line nad-winding" cx="-291.63" cy="-1411.29" r="20.00"/>
             </g>
@@ -3546,8 +3546,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="345">
             <desc>L50-57-1</desc>
             <g id="345.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-114.70,1684.47 -167.83,1860.95"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-124.07,1715.59)">
+                <polyline class="nad-edge-path" points="-114.70,1684.47 -167.83,1860.95"/>
+                <g class="nad-edge-infos" transform="translate(-124.07,1715.59)">
                     <g class="nad-active">
                         <g transform="rotate(-163.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3558,8 +3558,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="345.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-220.97,2037.43 -167.83,1860.95"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-211.60,2006.31)">
+                <polyline class="nad-edge-path" points="-220.97,2037.43 -167.83,1860.95"/>
+                <g class="nad-edge-infos" transform="translate(-211.60,2006.31)">
                     <g class="nad-active">
                         <g transform="rotate(16.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3573,8 +3573,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="346">
             <desc>L51-52-1</desc>
             <g id="346.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1206.85,1268.80 -1454.55,1357.16"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1237.46,1279.72)">
+                <polyline class="nad-edge-path" points="-1206.85,1268.80 -1454.55,1357.16"/>
+                <g class="nad-edge-infos" transform="translate(-1237.46,1279.72)">
                     <g class="nad-active">
                         <g transform="rotate(-109.63)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3585,8 +3585,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="346.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1702.24,1445.52 -1454.55,1357.16"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1671.63,1434.60)">
+                <polyline class="nad-edge-path" points="-1702.24,1445.52 -1454.55,1357.16"/>
+                <g class="nad-edge-infos" transform="translate(-1671.63,1434.60)">
                     <g class="nad-active">
                         <g transform="rotate(70.37)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3600,8 +3600,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="347">
             <desc>L51-58-1</desc>
             <g id="347.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1173.95,1286.15 -1138.86,1419.30"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1165.66,1317.57)">
+                <polyline class="nad-edge-path" points="-1173.95,1286.15 -1138.86,1419.30"/>
+                <g class="nad-edge-infos" transform="translate(-1165.66,1317.57)">
                     <g class="nad-active">
                         <g transform="rotate(165.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3612,8 +3612,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="347.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1103.77,1552.45 -1138.86,1419.30"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1112.06,1521.02)">
+                <polyline class="nad-edge-path" points="-1103.77,1552.45 -1138.86,1419.30"/>
+                <g class="nad-edge-infos" transform="translate(-1112.06,1521.02)">
                     <g class="nad-active">
                         <g transform="rotate(-14.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3627,8 +3627,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="348">
             <desc>L52-53-1</desc>
             <g id="348.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1724.06,1481.96 -1697.04,1662.10"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1719.24,1514.10)">
+                <polyline class="nad-edge-path" points="-1724.06,1481.96 -1697.04,1662.10"/>
+                <g class="nad-edge-infos" transform="translate(-1719.24,1514.10)">
                     <g class="nad-active">
                         <g transform="rotate(171.47)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3639,8 +3639,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="348.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1670.02,1842.24 -1697.04,1662.10"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1674.84,1810.10)">
+                <polyline class="nad-edge-path" points="-1670.02,1842.24 -1697.04,1662.10"/>
+                <g class="nad-edge-infos" transform="translate(-1674.84,1810.10)">
                     <g class="nad-active">
                         <g transform="rotate(-8.53)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3654,8 +3654,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="349">
             <desc>L53-54-1</desc>
             <g id="349.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1639.01,1874.98 -1285.49,1947.76"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1607.18,1881.53)">
+                <polyline class="nad-edge-path" points="-1639.01,1874.98 -1285.49,1947.76"/>
+                <g class="nad-edge-infos" transform="translate(-1607.18,1881.53)">
                     <g class="nad-active">
                         <g transform="rotate(101.63)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3666,8 +3666,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="349.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-931.98,2020.54 -1285.49,1947.76"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-963.81,2013.99)">
+                <polyline class="nad-edge-path" points="-931.98,2020.54 -1285.49,1947.76"/>
+                <g class="nad-edge-infos" transform="translate(-963.81,2013.99)">
                     <g class="nad-active">
                         <g transform="rotate(-78.37)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3681,8 +3681,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="350">
             <desc>L54-55-1</desc>
             <g id="350.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-910.80,2052.98 -962.79,2295.66"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-917.61,2084.76)">
+                <polyline class="nad-edge-path" points="-910.80,2052.98 -962.79,2295.66"/>
+                <g class="nad-edge-infos" transform="translate(-917.61,2084.76)">
                     <g class="nad-active">
                         <g transform="rotate(-167.91)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3693,8 +3693,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="350.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1014.77,2538.33 -962.79,2295.66"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1007.97,2506.56)">
+                <polyline class="nad-edge-path" points="-1014.77,2538.33 -962.79,2295.66"/>
+                <g class="nad-edge-infos" transform="translate(-1007.97,2506.56)">
                     <g class="nad-active">
                         <g transform="rotate(12.09)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3708,8 +3708,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="351">
             <desc>L54-56-1</desc>
             <g id="351.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-895.70,2051.96 -860.13,2150.50"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-884.67,2082.52)">
+                <polyline class="nad-edge-path" points="-895.70,2051.96 -860.13,2150.50"/>
+                <g class="nad-edge-infos" transform="translate(-884.67,2082.52)">
                     <g class="nad-active">
                         <g transform="rotate(160.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3720,8 +3720,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="351.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-824.55,2249.04 -860.13,2150.50"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-835.59,2218.47)">
+                <polyline class="nad-edge-path" points="-824.55,2249.04 -860.13,2150.50"/>
+                <g class="nad-edge-infos" transform="translate(-835.59,2218.47)">
                     <g class="nad-active">
                         <g transform="rotate(-19.85)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3735,8 +3735,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="352">
             <desc>L54-59-1</desc>
             <g id="352.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-894.38,2051.44 -771.70,2343.00"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-881.77,2081.39)">
+                <polyline class="nad-edge-path" points="-894.38,2051.44 -771.70,2343.00"/>
+                <g class="nad-edge-infos" transform="translate(-881.77,2081.39)">
                     <g class="nad-active">
                         <g transform="rotate(157.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3747,8 +3747,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="352.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-649.02,2634.56 -771.70,2343.00"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-661.62,2604.61)">
+                <polyline class="nad-edge-path" points="-649.02,2634.56 -771.70,2343.00"/>
+                <g class="nad-edge-infos" transform="translate(-661.62,2604.61)">
                     <g class="nad-active">
                         <g transform="rotate(-22.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3762,8 +3762,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="353">
             <desc>L55-56-1</desc>
             <g id="353.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1004.66,2542.77 -917.87,2420.06"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-985.89,2516.24)">
+                <polyline class="nad-edge-path" points="-1004.66,2542.77 -917.87,2420.06"/>
+                <g class="nad-edge-infos" transform="translate(-985.89,2516.24)">
                     <g class="nad-active">
                         <g transform="rotate(35.27)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3774,8 +3774,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="353.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-831.09,2297.36 -917.87,2420.06"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-849.86,2323.89)">
+                <polyline class="nad-edge-path" points="-831.09,2297.36 -917.87,2420.06"/>
+                <g class="nad-edge-infos" transform="translate(-849.86,2323.89)">
                     <g class="nad-active">
                         <g transform="rotate(-144.73)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3789,8 +3789,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="354">
             <desc>L55-59-1</desc>
             <g id="354.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-993.84,2571.84 -829.44,2612.57"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-962.29,2579.65)">
+                <polyline class="nad-edge-path" points="-993.84,2571.84 -829.44,2612.57"/>
+                <g class="nad-edge-infos" transform="translate(-962.29,2579.65)">
                     <g class="nad-active">
                         <g transform="rotate(103.92)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3801,8 +3801,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="354.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-665.04,2653.30 -829.44,2612.57"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-696.59,2645.48)">
+                <polyline class="nad-edge-path" points="-665.04,2653.30 -829.44,2612.57"/>
+                <g class="nad-edge-infos" transform="translate(-696.59,2645.48)">
                     <g class="nad-active">
                         <g transform="rotate(-76.08)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3816,8 +3816,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="355">
             <desc>L56-57-1</desc>
             <g id="355.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-789.34,2265.59 -522.05,2169.33"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-758.76,2254.58)">
+                <polyline class="nad-edge-path" points="-789.34,2265.59 -522.05,2169.33"/>
+                <g class="nad-edge-infos" transform="translate(-758.76,2254.58)">
                     <g class="nad-active">
                         <g transform="rotate(70.20)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3828,8 +3828,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="355.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-254.77,2073.08 -522.05,2169.33"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-285.34,2084.09)">
+                <polyline class="nad-edge-path" points="-254.77,2073.08 -522.05,2169.33"/>
+                <g class="nad-edge-infos" transform="translate(-285.34,2084.09)">
                     <g class="nad-active">
                         <g transform="rotate(-109.80)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3843,8 +3843,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="356">
             <desc>L56-58-1</desc>
             <g id="356.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-825.53,2249.41 -955.99,1926.97"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-837.72,2219.28)">
+                <polyline class="nad-edge-path" points="-825.53,2249.41 -955.99,1926.97"/>
+                <g class="nad-edge-infos" transform="translate(-837.72,2219.28)">
                     <g class="nad-active">
                         <g transform="rotate(-22.03)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3855,8 +3855,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="356.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1086.45,1604.53 -955.99,1926.97"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1074.26,1634.66)">
+                <polyline class="nad-edge-path" points="-1086.45,1604.53 -955.99,1926.97"/>
+                <g class="nad-edge-infos" transform="translate(-1074.26,1634.66)">
                     <g class="nad-active">
                         <g transform="rotate(157.97)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3870,8 +3870,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="357">
             <desc>L56-59-1</desc>
             <g id="357.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-817.77,2302.29 -822.64,2354.56 -763.13,2484.11"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-810.12,2381.82)">
+                <polyline class="nad-edge-path" points="-817.77,2302.29 -822.64,2354.56 -763.13,2484.11"/>
+                <g class="nad-edge-infos" transform="translate(-810.12,2381.82)">
                     <g class="nad-active">
                         <g transform="rotate(155.33)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3882,8 +3882,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="357.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-660.79,2644.01 -703.62,2613.65 -763.13,2484.11"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-716.14,2586.39)">
+                <polyline class="nad-edge-path" points="-660.79,2644.01 -703.62,2613.65 -763.13,2484.11"/>
+                <g class="nad-edge-infos" transform="translate(-716.14,2586.39)">
                     <g class="nad-active">
                         <g transform="rotate(-24.67)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3897,8 +3897,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="358">
             <desc>L56-59-2</desc>
             <g id="358.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-792.78,2290.81 -749.94,2321.16 -690.43,2450.71"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-737.42,2348.42)">
+                <polyline class="nad-edge-path" points="-792.78,2290.81 -749.94,2321.16 -690.43,2450.71"/>
+                <g class="nad-edge-infos" transform="translate(-737.42,2348.42)">
                     <g class="nad-active">
                         <g transform="rotate(155.33)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3909,8 +3909,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="358.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-635.80,2632.53 -630.92,2580.26 -690.43,2450.71"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-643.45,2553.00)">
+                <polyline class="nad-edge-path" points="-635.80,2632.53 -630.92,2580.26 -690.43,2450.71"/>
+                <g class="nad-edge-infos" transform="translate(-643.45,2553.00)">
                     <g class="nad-active">
                         <g transform="rotate(-24.67)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3924,8 +3924,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="359">
             <desc>L59-60-1</desc>
             <g id="359.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-613.79,2672.28 -371.88,2794.15"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-584.76,2686.91)">
+                <polyline class="nad-edge-path" points="-613.79,2672.28 -371.88,2794.15"/>
+                <g class="nad-edge-infos" transform="translate(-584.76,2686.91)">
                     <g class="nad-active">
                         <g transform="rotate(116.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3936,8 +3936,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="359.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-129.96,2916.01 -371.88,2794.15"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-158.99,2901.39)">
+                <polyline class="nad-edge-path" points="-129.96,2916.01 -371.88,2794.15"/>
+                <g class="nad-edge-infos" transform="translate(-158.99,2901.39)">
                     <g class="nad-active">
                         <g transform="rotate(-63.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3951,8 +3951,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="360">
             <desc>L59-61-1</desc>
             <g id="360.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-610.93,2657.80 -399.95,2641.53"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-578.53,2655.30)">
+                <polyline class="nad-edge-path" points="-610.93,2657.80 -399.95,2641.53"/>
+                <g class="nad-edge-infos" transform="translate(-578.53,2655.30)">
                     <g class="nad-active">
                         <g transform="rotate(85.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3963,8 +3963,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="360.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-188.96,2625.26 -399.95,2641.53"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-221.36,2627.76)">
+                <polyline class="nad-edge-path" points="-188.96,2625.26 -399.95,2641.53"/>
+                <g class="nad-edge-infos" transform="translate(-221.36,2627.76)">
                     <g class="nad-active">
                         <g transform="rotate(-94.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3978,8 +3978,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="361">
             <desc>T63-59-1</desc>
             <g id="361.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-456.16,2503.86 -514.03,2553.42"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-480.84,2525.00)">
+                <polyline class="nad-edge-path" points="-456.16,2503.86 -514.03,2553.42"/>
+                <g class="nad-edge-infos" transform="translate(-480.84,2525.00)">
                     <g class="nad-active">
                         <g transform="rotate(-130.58)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -3990,8 +3990,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="361.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-617.46,2642.02 -559.60,2592.46"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-592.78,2620.88)">
+                <polyline class="nad-edge-path" points="-617.46,2642.02 -559.60,2592.46"/>
+                <g class="nad-edge-infos" transform="translate(-592.78,2620.88)">
                     <g class="nad-active">
                         <g transform="rotate(49.42)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4001,7 +4001,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500-line nad-winding" cx="-529.22" cy="2566.44" r="20.00"/>
                 <circle class="nad-vl120to180-line nad-winding" cx="-544.41" cy="2579.45" r="20.00"/>
             </g>
@@ -4009,8 +4009,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="362">
             <desc>L6-7-1</desc>
             <g id="362.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="9.67,-2580.84 95.34,-2693.56"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(29.34,-2606.71)">
+                <polyline class="nad-edge-path" points="9.67,-2580.84 95.34,-2693.56"/>
+                <g class="nad-edge-infos" transform="translate(29.34,-2606.71)">
                     <g class="nad-active">
                         <g transform="rotate(37.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4021,8 +4021,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="362.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="181.01,-2806.28 95.34,-2693.56"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(161.35,-2780.41)">
+                <polyline class="nad-edge-path" points="181.01,-2806.28 95.34,-2693.56"/>
+                <g class="nad-edge-infos" transform="translate(161.35,-2780.41)">
                     <g class="nad-active">
                         <g transform="rotate(-142.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4036,8 +4036,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="363">
             <desc>L60-61-1</desc>
             <g id="363.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-110.38,2901.34 -133.47,2775.76"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-116.25,2869.37)">
+                <polyline class="nad-edge-path" points="-110.38,2901.34 -133.47,2775.76"/>
+                <g class="nad-edge-infos" transform="translate(-116.25,2869.37)">
                     <g class="nad-active">
                         <g transform="rotate(-10.42)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4048,8 +4048,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="363.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-156.57,2650.19 -133.47,2775.76"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-150.69,2682.15)">
+                <polyline class="nad-edge-path" points="-156.57,2650.19 -133.47,2775.76"/>
+                <g class="nad-edge-infos" transform="translate(-150.69,2682.15)">
                     <g class="nad-active">
                         <g transform="rotate(169.58)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4063,8 +4063,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="364">
             <desc>L60-62-1</desc>
             <g id="364.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-87.63,2907.40 55.14,2738.78"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-66.63,2882.59)">
+                <polyline class="nad-edge-path" points="-87.63,2907.40 55.14,2738.78"/>
+                <g class="nad-edge-infos" transform="translate(-66.63,2882.59)">
                     <g class="nad-active">
                         <g transform="rotate(40.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4075,8 +4075,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="364.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="197.92,2570.17 55.14,2738.78"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(176.92,2594.97)">
+                <polyline class="nad-edge-path" points="197.92,2570.17 55.14,2738.78"/>
+                <g class="nad-edge-infos" transform="translate(176.92,2594.97)">
                     <g class="nad-active">
                         <g transform="rotate(-139.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4090,8 +4090,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="365">
             <desc>L61-62-1</desc>
             <g id="365.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-134.55,2617.85 27.07,2586.16"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-102.66,2611.60)">
+                <polyline class="nad-edge-path" points="-134.55,2617.85 27.07,2586.16"/>
+                <g class="nad-edge-infos" transform="translate(-102.66,2611.60)">
                     <g class="nad-active">
                         <g transform="rotate(78.91)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4102,8 +4102,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="365.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="188.70,2554.47 27.07,2586.16"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(156.81,2560.73)">
+                <polyline class="nad-edge-path" points="188.70,2554.47 27.07,2586.16"/>
+                <g class="nad-edge-infos" transform="translate(156.81,2560.73)">
                     <g class="nad-active">
                         <g transform="rotate(-101.09)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4117,8 +4117,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="366">
             <desc>T64-61-1</desc>
             <g id="366.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-478.13,2115.68 -342.99,2332.29"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-460.92,2143.25)">
+                <polyline class="nad-edge-path" points="-478.13,2115.68 -342.99,2332.29"/>
+                <g class="nad-edge-infos" transform="translate(-460.92,2143.25)">
                     <g class="nad-active">
                         <g transform="rotate(148.04)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4129,8 +4129,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="366.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-176.10,2599.81 -311.23,2383.20"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-193.30,2572.24)">
+                <polyline class="nad-edge-path" points="-176.10,2599.81 -311.23,2383.20"/>
+                <g class="nad-edge-infos" transform="translate(-193.30,2572.24)">
                     <g class="nad-active">
                         <g transform="rotate(-31.96)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4140,7 +4140,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500-line nad-winding" cx="-332.40" cy="2349.26" r="20.00"/>
                 <circle class="nad-vl120to180-line nad-winding" cx="-321.82" cy="2366.23" r="20.00"/>
             </g>
@@ -4148,8 +4148,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="367">
             <desc>L62-66-1</desc>
             <g id="367.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="210.44,2522.19 155.30,2238.69"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(204.23,2490.29)">
+                <polyline class="nad-edge-path" points="210.44,2522.19 155.30,2238.69"/>
+                <g class="nad-edge-infos" transform="translate(204.23,2490.29)">
                     <g class="nad-active">
                         <g transform="rotate(-11.01)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4160,8 +4160,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="367.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="100.16,1955.19 155.30,2238.69"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(106.37,1987.09)">
+                <polyline class="nad-edge-path" points="100.16,1955.19 155.30,2238.69"/>
+                <g class="nad-edge-infos" transform="translate(106.37,1987.09)">
                     <g class="nad-active">
                         <g transform="rotate(168.99)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4175,8 +4175,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="368">
             <desc>L62-67-1</desc>
             <g id="368.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="240.36,2537.04 380.68,2467.99"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(269.52,2522.69)">
+                <polyline class="nad-edge-path" points="240.36,2537.04 380.68,2467.99"/>
+                <g class="nad-edge-infos" transform="translate(269.52,2522.69)">
                     <g class="nad-active">
                         <g transform="rotate(63.80)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4187,8 +4187,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="368.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="520.99,2398.94 380.68,2467.99"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(491.83,2413.29)">
+                <polyline class="nad-edge-path" points="520.99,2398.94 380.68,2467.99"/>
+                <g class="nad-edge-infos" transform="translate(491.83,2413.29)">
                     <g class="nad-active">
                         <g transform="rotate(-116.20)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4202,8 +4202,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="369">
             <desc>L63-64-1</desc>
             <g id="369.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-439.24,2458.76 -463.98,2289.16"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-443.93,2426.60)">
+                <polyline class="nad-edge-path" points="-439.24,2458.76 -463.98,2289.16"/>
+                <g class="nad-edge-infos" transform="translate(-443.93,2426.60)">
                     <g class="nad-active">
                         <g transform="rotate(-8.30)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4214,8 +4214,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="369.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-488.71,2119.56 -463.98,2289.16"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-484.02,2151.72)">
+                <polyline class="nad-edge-path" points="-488.71,2119.56 -463.98,2289.16"/>
+                <g class="nad-edge-infos" transform="translate(-484.02,2151.72)">
                     <g class="nad-active">
                         <g transform="rotate(171.70)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4229,8 +4229,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="370">
             <desc>L64-65-1</desc>
             <g id="370.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-499.23,2065.64 -595.42,1673.64"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-506.98,2034.07)">
+                <polyline class="nad-edge-path" points="-499.23,2065.64 -595.42,1673.64"/>
+                <g class="nad-edge-infos" transform="translate(-506.98,2034.07)">
                     <g class="nad-active">
                         <g transform="rotate(-13.79)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4241,8 +4241,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="370.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-691.61,1281.65 -595.42,1673.64"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-683.86,1313.21)">
+                <polyline class="nad-edge-path" points="-691.61,1281.65 -595.42,1673.64"/>
+                <g class="nad-edge-infos" transform="translate(-683.86,1313.21)">
                     <g class="nad-active">
                         <g transform="rotate(166.21)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4256,8 +4256,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="371">
             <desc>L65-68-1</desc>
             <g id="371.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-704.72,1228.23 -816.58,772.81"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-712.47,1196.67)">
+                <polyline class="nad-edge-path" points="-704.72,1228.23 -816.58,772.81"/>
+                <g class="nad-edge-infos" transform="translate(-712.47,1196.67)">
                     <g class="nad-active">
                         <g transform="rotate(-13.80)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4268,8 +4268,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="371.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-928.43,317.38 -816.58,772.81"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-920.68,348.95)">
+                <polyline class="nad-edge-path" points="-928.43,317.38 -816.58,772.81"/>
+                <g class="nad-edge-infos" transform="translate(-920.68,348.95)">
                     <g class="nad-active">
                         <g transform="rotate(166.20)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4283,8 +4283,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="372">
             <desc>T65-66-1</desc>
             <g id="372.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-677.20,1272.74 -324.49,1572.15"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-652.42,1293.77)">
+                <polyline class="nad-edge-path" points="-677.20,1272.74 -324.49,1572.15"/>
+                <g class="nad-edge-infos" transform="translate(-652.42,1293.77)">
                     <g class="nad-active">
                         <g transform="rotate(130.33)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4295,8 +4295,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="372.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="73.95,1910.39 -278.75,1610.98"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(49.17,1889.36)">
+                <polyline class="nad-edge-path" points="73.95,1910.39 -278.75,1610.98"/>
+                <g class="nad-edge-infos" transform="translate(49.17,1889.36)">
                     <g class="nad-active">
                         <g transform="rotate(-49.67)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4306,7 +4306,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500-line nad-winding" cx="-309.25" cy="1585.09" r="20.00"/>
                 <circle class="nad-vl120to180-line nad-winding" cx="-294.00" cy="1598.04" r="20.00"/>
             </g>
@@ -4314,8 +4314,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="373">
             <desc>L66-67-1</desc>
             <g id="373.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="114.19,1947.80 320.29,2157.49"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(136.97,1970.98)">
+                <polyline class="nad-edge-path" points="114.19,1947.80 320.29,2157.49"/>
+                <g class="nad-edge-infos" transform="translate(136.97,1970.98)">
                     <g class="nad-active">
                         <g transform="rotate(135.49)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4326,8 +4326,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="373.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="526.39,2367.18 320.29,2157.49"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(503.60,2344.01)">
+                <polyline class="nad-edge-path" points="526.39,2367.18 320.29,2157.49"/>
+                <g class="nad-edge-infos" transform="translate(503.60,2344.01)">
                     <g class="nad-active">
                         <g transform="rotate(-44.51)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4341,8 +4341,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="374">
             <desc>L68-81-1</desc>
             <g id="374.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-916.42,270.39 -595.41,-80.25"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-894.48,246.42)">
+                <polyline class="nad-edge-path" points="-916.42,270.39 -595.41,-80.25"/>
+                <g class="nad-edge-infos" transform="translate(-894.48,246.42)">
                     <g class="nad-active">
                         <g transform="rotate(42.47)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4353,8 +4353,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="374.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-274.41,-430.89 -595.41,-80.25"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-296.35,-406.92)">
+                <polyline class="nad-edge-path" points="-274.41,-430.89 -595.41,-80.25"/>
+                <g class="nad-edge-infos" transform="translate(-296.35,-406.92)">
                     <g class="nad-active">
                         <g transform="rotate(-137.53)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4368,8 +4368,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="375">
             <desc>T68-69-1</desc>
             <g id="375.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-944.36,264.82 -994.47,126.42"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-955.42,234.26)">
+                <polyline class="nad-edge-path" points="-944.36,264.82 -994.47,126.42"/>
+                <g class="nad-edge-infos" transform="translate(-955.42,234.26)">
                     <g class="nad-active">
                         <g transform="rotate(-19.91)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4380,8 +4380,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="375.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1065.02,-68.39 -1014.90,70.01"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1053.95,-37.83)">
+                <polyline class="nad-edge-path" points="-1065.02,-68.39 -1014.90,70.01"/>
+                <g class="nad-edge-infos" transform="translate(-1053.95,-37.83)">
                     <g class="nad-active">
                         <g transform="rotate(160.09)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4391,7 +4391,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500-line nad-winding" cx="-1001.28" cy="107.62" r="20.00"/>
                 <circle class="nad-vl120to180-line nad-winding" cx="-1008.09" cy="88.81" r="20.00"/>
             </g>
@@ -4399,8 +4399,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="376">
             <desc>L69-70-1</desc>
             <g id="376.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1098.05,-108.24 -1619.76,-416.74"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1126.03,-124.78)">
+                <polyline class="nad-edge-path" points="-1098.05,-108.24 -1619.76,-416.74"/>
+                <g class="nad-edge-infos" transform="translate(-1126.03,-124.78)">
                     <g class="nad-active">
                         <g transform="rotate(-59.40)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4411,8 +4411,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="376.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2141.46,-725.23 -1619.76,-416.74"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-2113.48,-708.69)">
+                <polyline class="nad-edge-path" points="-2141.46,-725.23 -1619.76,-416.74"/>
+                <g class="nad-edge-infos" transform="translate(-2113.48,-708.69)">
                     <g class="nad-active">
                         <g transform="rotate(120.60)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4426,8 +4426,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="377">
             <desc>L69-75-1</desc>
             <g id="377.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1090.87,-116.26 -1393.91,-520.84"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1110.35,-142.27)">
+                <polyline class="nad-edge-path" points="-1090.87,-116.26 -1393.91,-520.84"/>
+                <g class="nad-edge-infos" transform="translate(-1110.35,-142.27)">
                     <g class="nad-active">
                         <g transform="rotate(-36.83)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4438,8 +4438,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="377.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1696.95,-925.42 -1393.91,-520.84"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1677.47,-899.41)">
+                <polyline class="nad-edge-path" points="-1696.95,-925.42 -1393.91,-520.84"/>
+                <g class="nad-edge-infos" transform="translate(-1677.47,-899.41)">
                     <g class="nad-active">
                         <g transform="rotate(143.17)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4453,8 +4453,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="378">
             <desc>L69-77-1</desc>
             <g id="378.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1066.44,-120.57 -929.04,-576.28"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1057.06,-151.69)">
+                <polyline class="nad-edge-path" points="-1066.44,-120.57 -929.04,-576.28"/>
+                <g class="nad-edge-infos" transform="translate(-1057.06,-151.69)">
                     <g class="nad-active">
                         <g transform="rotate(16.78)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4465,8 +4465,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="378.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-791.64,-1031.98 -929.04,-576.28"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-801.03,-1000.86)">
+                <polyline class="nad-edge-path" points="-791.64,-1031.98 -929.04,-576.28"/>
+                <g class="nad-edge-infos" transform="translate(-801.03,-1000.86)">
                     <g class="nad-active">
                         <g transform="rotate(-163.22)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4480,8 +4480,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="379">
             <desc>L70-71-1</desc>
             <g id="379.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2191.18,-748.05 -2505.81,-854.53"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-2221.96,-758.46)">
+                <polyline class="nad-edge-path" points="-2191.18,-748.05 -2505.81,-854.53"/>
+                <g class="nad-edge-infos" transform="translate(-2221.96,-758.46)">
                     <g class="nad-active">
                         <g transform="rotate(-71.30)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4492,8 +4492,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="379.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2820.43,-961.02 -2505.81,-854.53"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-2789.65,-950.60)">
+                <polyline class="nad-edge-path" points="-2820.43,-961.02 -2505.81,-854.53"/>
+                <g class="nad-edge-infos" transform="translate(-2789.65,-950.60)">
                     <g class="nad-active">
                         <g transform="rotate(108.70)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4507,8 +4507,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="380">
             <desc>L70-74-1</desc>
             <g id="380.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2170.52,-766.20 -2201.13,-919.51"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-2176.88,-798.07)">
+                <polyline class="nad-edge-path" points="-2170.52,-766.20 -2201.13,-919.51"/>
+                <g class="nad-edge-infos" transform="translate(-2176.88,-798.07)">
                     <g class="nad-active">
                         <g transform="rotate(-11.29)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4519,8 +4519,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="380.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2231.75,-1072.82 -2201.13,-919.51"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-2225.38,-1040.95)">
+                <polyline class="nad-edge-path" points="-2231.75,-1072.82 -2201.13,-919.51"/>
+                <g class="nad-edge-infos" transform="translate(-2225.38,-1040.95)">
                     <g class="nad-active">
                         <g transform="rotate(168.71)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4534,8 +4534,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="381">
             <desc>L70-75-1</desc>
             <g id="381.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2140.16,-750.74 -1939.29,-843.33"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-2110.64,-764.35)">
+                <polyline class="nad-edge-path" points="-2140.16,-750.74 -1939.29,-843.33"/>
+                <g class="nad-edge-infos" transform="translate(-2110.64,-764.35)">
                     <g class="nad-active">
                         <g transform="rotate(65.25)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4546,8 +4546,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="381.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1738.42,-935.92 -1939.29,-843.33"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1767.93,-922.32)">
+                <polyline class="nad-edge-path" points="-1738.42,-935.92 -1939.29,-843.33"/>
+                <g class="nad-edge-infos" transform="translate(-1767.93,-922.32)">
                     <g class="nad-active">
                         <g transform="rotate(-114.75)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4561,8 +4561,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="382">
             <desc>L71-72-1</desc>
             <g id="382.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2857.46,-944.62 -2925.28,-788.91"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-2870.44,-914.83)">
+                <polyline class="nad-edge-path" points="-2857.46,-944.62 -2925.28,-788.91"/>
+                <g class="nad-edge-infos" transform="translate(-2870.44,-914.83)">
                     <g class="nad-active">
                         <g transform="rotate(-156.46)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4573,8 +4573,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="382.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-2993.10,-633.19 -2925.28,-788.91"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-2980.13,-662.99)">
+                <polyline class="nad-edge-path" points="-2993.10,-633.19 -2925.28,-788.91"/>
+                <g class="nad-edge-infos" transform="translate(-2980.13,-662.99)">
                     <g class="nad-active">
                         <g transform="rotate(23.54)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4588,8 +4588,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="383">
             <desc>L71-73-1</desc>
             <g id="383.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2865.77,-989.44 -3004.85,-1130.82"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-2888.56,-1012.61)">
+                <polyline class="nad-edge-path" points="-2865.77,-989.44 -3004.85,-1130.82"/>
+                <g class="nad-edge-infos" transform="translate(-2888.56,-1012.61)">
                     <g class="nad-active">
                         <g transform="rotate(-44.53)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4600,8 +4600,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="383.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-3143.93,-1272.20 -3004.85,-1130.82"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-3121.14,-1249.03)">
+                <polyline class="nad-edge-path" points="-3143.93,-1272.20 -3004.85,-1130.82"/>
+                <g class="nad-edge-infos" transform="translate(-3121.14,-1249.03)">
                     <g class="nad-active">
                         <g transform="rotate(135.47)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4615,8 +4615,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="384">
             <desc>L74-75-1</desc>
             <g id="384.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-2210.73,-1092.10 -1975.29,-1023.61"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-2179.52,-1083.03)">
+                <polyline class="nad-edge-path" points="-2210.73,-1092.10 -1975.29,-1023.61"/>
+                <g class="nad-edge-infos" transform="translate(-2179.52,-1083.03)">
                     <g class="nad-active">
                         <g transform="rotate(106.22)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4627,8 +4627,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="384.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1739.85,-955.11 -1975.29,-1023.61"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1771.05,-964.19)">
+                <polyline class="nad-edge-path" points="-1739.85,-955.11 -1975.29,-1023.61"/>
+                <g class="nad-edge-infos" transform="translate(-1771.05,-964.19)">
                     <g class="nad-active">
                         <g transform="rotate(-73.78)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4642,8 +4642,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="385">
             <desc>L75-77-1</desc>
             <g id="385.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1686.13,-950.69 -1248.57,-1002.87"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1653.86,-954.54)">
+                <polyline class="nad-edge-path" points="-1686.13,-950.69 -1248.57,-1002.87"/>
+                <g class="nad-edge-infos" transform="translate(-1653.86,-954.54)">
                     <g class="nad-active">
                         <g transform="rotate(83.20)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4654,8 +4654,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="385.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-811.01,-1055.05 -1248.57,-1002.87"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-843.28,-1051.20)">
+                <polyline class="nad-edge-path" points="-811.01,-1055.05 -1248.57,-1002.87"/>
+                <g class="nad-edge-infos" transform="translate(-843.28,-1051.20)">
                     <g class="nad-active">
                         <g transform="rotate(-96.80)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4669,8 +4669,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="386">
             <desc>L76-77-1</desc>
             <g id="386.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1416.58,-1825.81 -1108.89,-1452.67"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1395.90,-1800.73)">
+                <polyline class="nad-edge-path" points="-1416.58,-1825.81 -1108.89,-1452.67"/>
+                <g class="nad-edge-infos" transform="translate(-1395.90,-1800.73)">
                     <g class="nad-active">
                         <g transform="rotate(140.49)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4681,8 +4681,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="386.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-801.20,-1079.52 -1108.89,-1452.67"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-821.88,-1104.60)">
+                <polyline class="nad-edge-path" points="-801.20,-1079.52 -1108.89,-1452.67"/>
+                <g class="nad-edge-infos" transform="translate(-821.88,-1104.60)">
                     <g class="nad-active">
                         <g transform="rotate(-39.51)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4696,8 +4696,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="387">
             <desc>L77-78-1</desc>
             <g id="387.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-785.35,-1085.76 -812.67,-1540.25"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-787.30,-1118.20)">
+                <polyline class="nad-edge-path" points="-785.35,-1085.76 -812.67,-1540.25"/>
+                <g class="nad-edge-infos" transform="translate(-787.30,-1118.20)">
                     <g class="nad-active">
                         <g transform="rotate(-3.44)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4708,8 +4708,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="387.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-839.99,-1994.75 -812.67,-1540.25"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-838.04,-1962.31)">
+                <polyline class="nad-edge-path" points="-839.99,-1994.75 -812.67,-1540.25"/>
+                <g class="nad-edge-infos" transform="translate(-838.04,-1962.31)">
                     <g class="nad-active">
                         <g transform="rotate(176.56)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4723,8 +4723,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="388">
             <desc>L77-80-1</desc>
             <g id="388.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-760.46,-1043.61 -716.10,-1015.54 -209.03,-995.03"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-686.12,-1014.33)">
+                <polyline class="nad-edge-path" points="-760.46,-1043.61 -716.10,-1015.54 -209.03,-995.03"/>
+                <g class="nad-edge-infos" transform="translate(-686.12,-1014.33)">
                     <g class="nad-active">
                         <g transform="rotate(92.32)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4735,8 +4735,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="388.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="344.53,-998.92 298.04,-974.53 -209.03,-995.03"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(268.07,-975.74)">
+                <polyline class="nad-edge-path" points="344.53,-998.92 298.04,-974.53 -209.03,-995.03"/>
+                <g class="nad-edge-infos" transform="translate(268.07,-975.74)">
                     <g class="nad-active">
                         <g transform="rotate(-87.68)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4750,8 +4750,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="389">
             <desc>L77-80-2</desc>
             <g id="389.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-759.35,-1071.08 -712.86,-1095.47 -205.79,-1074.97"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-682.89,-1094.26)">
+                <polyline class="nad-edge-path" points="-759.35,-1071.08 -712.86,-1095.47 -205.79,-1074.97"/>
+                <g class="nad-edge-infos" transform="translate(-682.89,-1094.26)">
                     <g class="nad-active">
                         <g transform="rotate(92.32)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4762,8 +4762,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="389.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="345.64,-1026.39 301.27,-1054.46 -205.79,-1074.97"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(271.30,-1055.67)">
+                <polyline class="nad-edge-path" points="345.64,-1026.39 301.27,-1054.46 -205.79,-1074.97"/>
+                <g class="nad-edge-infos" transform="translate(271.30,-1055.67)">
                     <g class="nad-active">
                         <g transform="rotate(-87.68)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4777,8 +4777,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="390">
             <desc>L77-82-1</desc>
             <g id="390.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-759.59,-1045.10 -220.74,-749.96"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-731.08,-1029.48)">
+                <polyline class="nad-edge-path" points="-759.59,-1045.10 -220.74,-749.96"/>
+                <g class="nad-edge-infos" transform="translate(-731.08,-1029.48)">
                     <g class="nad-active">
                         <g transform="rotate(118.71)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4789,8 +4789,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="390.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="318.10,-454.82 -220.74,-749.96"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(289.60,-470.43)">
+                <polyline class="nad-edge-path" points="318.10,-454.82 -220.74,-749.96"/>
+                <g class="nad-edge-infos" transform="translate(289.60,-470.43)">
                     <g class="nad-active">
                         <g transform="rotate(-61.29)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4804,8 +4804,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="391">
             <desc>L78-79-1</desc>
             <g id="391.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-815.75,-2012.95 -571.76,-1925.79"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-785.14,-2002.02)">
+                <polyline class="nad-edge-path" points="-815.75,-2012.95 -571.76,-1925.79"/>
+                <g class="nad-edge-infos" transform="translate(-785.14,-2002.02)">
                     <g class="nad-active">
                         <g transform="rotate(109.66)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4816,8 +4816,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="391.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-327.78,-1838.64 -571.76,-1925.79"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-358.38,-1849.57)">
+                <polyline class="nad-edge-path" points="-327.78,-1838.64 -571.76,-1925.79"/>
+                <g class="nad-edge-infos" transform="translate(-358.38,-1849.57)">
                     <g class="nad-active">
                         <g transform="rotate(-70.34)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4831,8 +4831,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="392">
             <desc>L79-80-1</desc>
             <g id="392.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-284.44,-1808.12 33.50,-1420.54"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-263.83,-1783.00)">
+                <polyline class="nad-edge-path" points="-284.44,-1808.12 33.50,-1420.54"/>
+                <g class="nad-edge-infos" transform="translate(-263.83,-1783.00)">
                     <g class="nad-active">
                         <g transform="rotate(140.64)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4843,8 +4843,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="392.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="351.44,-1032.95 33.50,-1420.54"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(330.83,-1058.08)">
+                <polyline class="nad-edge-path" points="351.44,-1032.95 33.50,-1420.54"/>
+                <g class="nad-edge-infos" transform="translate(330.83,-1058.08)">
                     <g class="nad-active">
                         <g transform="rotate(-39.36)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4858,8 +4858,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="393">
             <desc>L8-9-1</desc>
             <g id="393.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-844.75,-758.88 -1297.76,-466.98"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-872.07,-741.27)">
+                <polyline class="nad-edge-path" points="-844.75,-758.88 -1297.76,-466.98"/>
+                <g class="nad-edge-infos" transform="translate(-872.07,-741.27)">
                     <g class="nad-active">
                         <g transform="rotate(-122.80)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4870,8 +4870,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="393.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1750.76,-175.09 -1297.76,-466.98"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1723.44,-192.70)">
+                <polyline class="nad-edge-path" points="-1750.76,-175.09 -1297.76,-466.98"/>
+                <g class="nad-edge-infos" transform="translate(-1723.44,-192.70)">
                     <g class="nad-active">
                         <g transform="rotate(57.20)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4885,8 +4885,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="394">
             <desc>L80-96-1</desc>
             <g id="394.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="389.99,-994.07 625.78,-797.17"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(414.94,-973.24)">
+                <polyline class="nad-edge-path" points="389.99,-994.07 625.78,-797.17"/>
+                <g class="nad-edge-infos" transform="translate(414.94,-973.24)">
                     <g class="nad-active">
                         <g transform="rotate(129.86)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4897,8 +4897,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="394.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="861.57,-600.28 625.78,-797.17"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(836.62,-621.11)">
+                <polyline class="nad-edge-path" points="861.57,-600.28 625.78,-797.17"/>
+                <g class="nad-edge-infos" transform="translate(836.62,-621.11)">
                     <g class="nad-active">
                         <g transform="rotate(-50.14)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4912,8 +4912,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="395">
             <desc>L80-97-1</desc>
             <g id="395.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="395.37,-1004.28 545.26,-962.32"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(426.66,-995.52)">
+                <polyline class="nad-edge-path" points="395.37,-1004.28 545.26,-962.32"/>
+                <g class="nad-edge-infos" transform="translate(426.66,-995.52)">
                     <g class="nad-active">
                         <g transform="rotate(105.64)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4924,8 +4924,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="395.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="695.16,-920.37 545.26,-962.32"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(663.86,-929.13)">
+                <polyline class="nad-edge-path" points="695.16,-920.37 545.26,-962.32"/>
+                <g class="nad-edge-infos" transform="translate(663.86,-929.13)">
                     <g class="nad-active">
                         <g transform="rotate(-74.36)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4939,8 +4939,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="396">
             <desc>L80-98-1</desc>
             <g id="396.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="396.16,-1008.20 813.37,-954.70"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(428.40,-1004.06)">
+                <polyline class="nad-edge-path" points="396.16,-1008.20 813.37,-954.70"/>
+                <g class="nad-edge-infos" transform="translate(428.40,-1004.06)">
                     <g class="nad-active">
                         <g transform="rotate(97.31)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4951,8 +4951,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="396.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1230.58,-901.21 813.37,-954.70"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1198.35,-905.34)">
+                <polyline class="nad-edge-path" points="1230.58,-901.21 813.37,-954.70"/>
+                <g class="nad-edge-infos" transform="translate(1198.35,-905.34)">
                     <g class="nad-active">
                         <g transform="rotate(-82.69)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4966,8 +4966,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="397">
             <desc>L80-99-1</desc>
             <g id="397.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="395.86,-1017.03 845.81,-1106.07"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(427.74,-1023.34)">
+                <polyline class="nad-edge-path" points="395.86,-1017.03 845.81,-1106.07"/>
+                <g class="nad-edge-infos" transform="translate(427.74,-1023.34)">
                     <g class="nad-active">
                         <g transform="rotate(78.81)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4978,8 +4978,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="397.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1295.75,-1195.12 845.81,-1106.07"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1263.87,-1188.81)">
+                <polyline class="nad-edge-path" points="1295.75,-1195.12 845.81,-1106.07"/>
+                <g class="nad-edge-infos" transform="translate(1263.87,-1188.81)">
                     <g class="nad-active">
                         <g transform="rotate(-101.19)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -4993,8 +4993,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="398">
             <desc>T81-80-1</desc>
             <g id="398.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-235.37,-469.54 34.19,-711.40"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-211.18,-491.25)">
+                <polyline class="nad-edge-path" points="-235.37,-469.54 34.19,-711.40"/>
+                <g class="nad-edge-infos" transform="translate(-211.18,-491.25)">
                     <g class="nad-active">
                         <g transform="rotate(48.10)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5005,8 +5005,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="398.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="348.41,-993.33 78.85,-751.47"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(324.22,-971.62)">
+                <polyline class="nad-edge-path" points="348.41,-993.33 78.85,-751.47"/>
+                <g class="nad-edge-infos" transform="translate(324.22,-971.62)">
                     <g class="nad-active">
                         <g transform="rotate(-131.90)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5016,7 +5016,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500-line nad-winding" cx="49.08" cy="-724.76" r="20.00"/>
                 <circle class="nad-vl120to180-line nad-winding" cx="63.97" cy="-738.11" r="20.00"/>
             </g>
@@ -5024,8 +5024,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="399">
             <desc>L82-83-1</desc>
             <g id="399.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="359.29,-420.04 609.84,-103.60"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(379.46,-394.56)">
+                <polyline class="nad-edge-path" points="359.29,-420.04 609.84,-103.60"/>
+                <g class="nad-edge-infos" transform="translate(379.46,-394.56)">
                     <g class="nad-active">
                         <g transform="rotate(141.63)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5036,8 +5036,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="399.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="860.40,212.83 609.84,-103.60"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(840.22,187.35)">
+                <polyline class="nad-edge-path" points="860.40,212.83 609.84,-103.60"/>
+                <g class="nad-edge-infos" transform="translate(840.22,187.35)">
                     <g class="nad-active">
                         <g transform="rotate(-38.37)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5051,8 +5051,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="400">
             <desc>L82-96-1</desc>
             <g id="400.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="368.83,-448.55 612.45,-512.13"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(400.27,-456.76)">
+                <polyline class="nad-edge-path" points="368.83,-448.55 612.45,-512.13"/>
+                <g class="nad-edge-infos" transform="translate(400.27,-456.76)">
                     <g class="nad-active">
                         <g transform="rotate(75.37)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5063,8 +5063,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="400.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="856.07,-575.71 612.45,-512.13"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(824.62,-567.50)">
+                <polyline class="nad-edge-path" points="856.07,-575.71 612.45,-512.13"/>
+                <g class="nad-edge-infos" transform="translate(824.62,-567.50)">
                     <g class="nad-active">
                         <g transform="rotate(-104.63)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5078,8 +5078,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="401">
             <desc>L83-84-1</desc>
             <g id="401.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="894.71,255.81 1003.55,390.99"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(915.10,281.13)">
+                <polyline class="nad-edge-path" points="894.71,255.81 1003.55,390.99"/>
+                <g class="nad-edge-infos" transform="translate(915.10,281.13)">
                     <g class="nad-active">
                         <g transform="rotate(141.16)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5090,8 +5090,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="401.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1112.39,526.16 1003.55,390.99"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1092.01,500.85)">
+                <polyline class="nad-edge-path" points="1112.39,526.16 1003.55,390.99"/>
+                <g class="nad-edge-infos" transform="translate(1092.01,500.85)">
                     <g class="nad-active">
                         <g transform="rotate(-38.84)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5105,8 +5105,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="402">
             <desc>L83-85-1</desc>
             <g id="402.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="891.07,258.29 1089.47,606.70"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(907.16,286.53)">
+                <polyline class="nad-edge-path" points="891.07,258.29 1089.47,606.70"/>
+                <g class="nad-edge-infos" transform="translate(907.16,286.53)">
                     <g class="nad-active">
                         <g transform="rotate(150.34)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5117,8 +5117,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="402.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1287.87,955.11 1089.47,606.70"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1271.79,926.87)">
+                <polyline class="nad-edge-path" points="1287.87,955.11 1089.47,606.70"/>
+                <g class="nad-edge-infos" transform="translate(1271.79,926.87)">
                     <g class="nad-active">
                         <g transform="rotate(-29.66)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5132,8 +5132,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="403">
             <desc>L84-85-1</desc>
             <g id="403.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1139.81,573.13 1215.56,763.30"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1151.84,603.33)">
+                <polyline class="nad-edge-path" points="1139.81,573.13 1215.56,763.30"/>
+                <g class="nad-edge-infos" transform="translate(1151.84,603.33)">
                     <g class="nad-active">
                         <g transform="rotate(158.28)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5144,8 +5144,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="403.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1291.30,953.46 1215.56,763.30"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1279.27,923.27)">
+                <polyline class="nad-edge-path" points="1291.30,953.46 1215.56,763.30"/>
+                <g class="nad-edge-infos" transform="translate(1279.27,923.27)">
                     <g class="nad-active">
                         <g transform="rotate(-21.72)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5159,8 +5159,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="404">
             <desc>L85-86-1</desc>
             <g id="404.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1296.04,1005.97 1190.32,1529.85"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1289.61,1037.83)">
+                <polyline class="nad-edge-path" points="1296.04,1005.97 1190.32,1529.85"/>
+                <g class="nad-edge-infos" transform="translate(1289.61,1037.83)">
                     <g class="nad-active">
                         <g transform="rotate(-168.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5171,8 +5171,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="404.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1084.59,2053.73 1190.32,1529.85"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1091.02,2021.87)">
+                <polyline class="nad-edge-path" points="1084.59,2053.73 1190.32,1529.85"/>
+                <g class="nad-edge-infos" transform="translate(1091.02,2021.87)">
                     <g class="nad-active">
                         <g transform="rotate(11.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5186,8 +5186,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="405">
             <desc>L85-88-1</desc>
             <g id="405.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1328.27,985.19 1483.86,1021.07"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1359.94,992.49)">
+                <polyline class="nad-edge-path" points="1328.27,985.19 1483.86,1021.07"/>
+                <g class="nad-edge-infos" transform="translate(1359.94,992.49)">
                     <g class="nad-active">
                         <g transform="rotate(102.99)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5198,8 +5198,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="405.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1639.45,1056.96 1483.86,1021.07"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1607.78,1049.65)">
+                <polyline class="nad-edge-path" points="1639.45,1056.96 1483.86,1021.07"/>
+                <g class="nad-edge-infos" transform="translate(1607.78,1049.65)">
                     <g class="nad-active">
                         <g transform="rotate(-77.01)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5213,8 +5213,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="406">
             <desc>L85-89-1</desc>
             <g id="406.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1327.97,971.63 1622.43,889.62"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1359.28,962.91)">
+                <polyline class="nad-edge-path" points="1327.97,971.63 1622.43,889.62"/>
+                <g class="nad-edge-infos" transform="translate(1359.28,962.91)">
                     <g class="nad-active">
                         <g transform="rotate(74.44)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5225,8 +5225,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="406.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1916.90,807.61 1622.43,889.62"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1885.59,816.33)">
+                <polyline class="nad-edge-path" points="1916.90,807.61 1622.43,889.62"/>
+                <g class="nad-edge-infos" transform="translate(1885.59,816.33)">
                     <g class="nad-active">
                         <g transform="rotate(-105.56)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5240,8 +5240,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="407">
             <desc>L86-87-1</desc>
             <g id="407.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1068.85,2106.18 930.51,2448.46"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1056.67,2136.32)">
+                <polyline class="nad-edge-path" points="1068.85,2106.18 930.51,2448.46"/>
+                <g class="nad-edge-infos" transform="translate(1056.67,2136.32)">
                     <g class="nad-active">
                         <g transform="rotate(-157.99)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5252,8 +5252,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="407.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="792.16,2790.74 930.51,2448.46"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(804.34,2760.61)">
+                <polyline class="nad-edge-path" points="792.16,2790.74 930.51,2448.46"/>
+                <g class="nad-edge-infos" transform="translate(804.34,2760.61)">
                     <g class="nad-active">
                         <g transform="rotate(22.01)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5267,8 +5267,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="408">
             <desc>L88-89-1</desc>
             <g id="408.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1686.20,1044.21 1804.82,931.68"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1709.78,1021.84)">
+                <polyline class="nad-edge-path" points="1686.20,1044.21 1804.82,931.68"/>
+                <g class="nad-edge-infos" transform="translate(1709.78,1021.84)">
                     <g class="nad-active">
                         <g transform="rotate(46.51)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5279,8 +5279,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="408.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1923.44,819.16 1804.82,931.68"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1899.86,841.53)">
+                <polyline class="nad-edge-path" points="1923.44,819.16 1804.82,931.68"/>
+                <g class="nad-edge-infos" transform="translate(1899.86,841.53)">
                     <g class="nad-active">
                         <g transform="rotate(-133.49)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5294,8 +5294,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="409">
             <desc>L89-90-1</desc>
             <g id="409.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1959.45,822.55 1990.11,865.17 2148.55,936.60"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(2017.46,877.50)">
+                <polyline class="nad-edge-path" points="1959.45,822.55 1990.11,865.17 2148.55,936.60"/>
+                <g class="nad-edge-infos" transform="translate(2017.46,877.50)">
                     <g class="nad-active">
                         <g transform="rotate(114.27)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5306,8 +5306,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="409.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2359.22,1002.79 2306.98,1008.03 2148.55,936.60"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(2279.63,995.70)">
+                <polyline class="nad-edge-path" points="2359.22,1002.79 2306.98,1008.03 2148.55,936.60"/>
+                <g class="nad-edge-infos" transform="translate(2279.63,995.70)">
                     <g class="nad-active">
                         <g transform="rotate(-65.73)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5321,8 +5321,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="410">
             <desc>L89-90-2</desc>
             <g id="410.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1970.75,797.48 2022.99,792.24 2181.43,863.67"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(2050.34,804.57)">
+                <polyline class="nad-edge-path" points="1970.75,797.48 2022.99,792.24 2181.43,863.67"/>
+                <g class="nad-edge-infos" transform="translate(2050.34,804.57)">
                     <g class="nad-active">
                         <g transform="rotate(114.27)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5333,8 +5333,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="410.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2370.52,977.72 2339.86,935.10 2181.43,863.67"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(2312.51,922.77)">
+                <polyline class="nad-edge-path" points="2370.52,977.72 2339.86,935.10 2181.43,863.67"/>
+                <g class="nad-edge-infos" transform="translate(2312.51,922.77)">
                     <g class="nad-active">
                         <g transform="rotate(-65.73)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5348,8 +5348,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="411">
             <desc>L89-92-1</desc>
             <g id="411.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1966.35,785.10 2010.19,756.21 2161.56,454.18"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(2023.63,729.39)">
+                <polyline class="nad-edge-path" points="1966.35,785.10 2010.19,756.21 2161.56,454.18"/>
+                <g class="nad-edge-infos" transform="translate(2023.63,729.39)">
                     <g class="nad-active">
                         <g transform="rotate(26.62)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5360,8 +5360,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="411.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2309.84,99.73 2312.93,152.14 2161.56,454.18"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(2299.49,178.96)">
+                <polyline class="nad-edge-path" points="2309.84,99.73 2312.93,152.14 2161.56,454.18"/>
+                <g class="nad-edge-infos" transform="translate(2299.49,178.96)">
                     <g class="nad-active">
                         <g transform="rotate(-153.38)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5375,8 +5375,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="412">
             <desc>L89-92-2</desc>
             <g id="412.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1941.77,772.78 1938.67,720.37 2090.04,418.33"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1952.11,693.55)">
+                <polyline class="nad-edge-path" points="1941.77,772.78 1938.67,720.37 2090.04,418.33"/>
+                <g class="nad-edge-infos" transform="translate(1952.11,693.55)">
                     <g class="nad-active">
                         <g transform="rotate(26.62)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5387,8 +5387,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="412.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2285.25,87.41 2241.41,116.30 2090.04,418.33"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(2227.97,143.12)">
+                <polyline class="nad-edge-path" points="2285.25,87.41 2241.41,116.30 2090.04,418.33"/>
+                <g class="nad-edge-infos" transform="translate(2227.97,143.12)">
                     <g class="nad-active">
                         <g transform="rotate(-153.38)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5402,8 +5402,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="413">
             <desc>L90-91-1</desc>
             <g id="413.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2401.79,977.13 2504.92,821.81"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(2419.77,950.05)">
+                <polyline class="nad-edge-path" points="2401.79,977.13 2504.92,821.81"/>
+                <g class="nad-edge-infos" transform="translate(2419.77,950.05)">
                     <g class="nad-active">
                         <g transform="rotate(33.58)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5414,8 +5414,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="413.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2608.05,666.50 2504.92,821.81"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(2590.07,693.57)">
+                <polyline class="nad-edge-path" points="2608.05,666.50 2504.92,821.81"/>
+                <g class="nad-edge-infos" transform="translate(2590.07,693.57)">
                     <g class="nad-active">
                         <g transform="rotate(-146.42)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5429,8 +5429,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="414">
             <desc>L91-92-1</desc>
             <g id="414.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2609.98,619.51 2465.74,357.94"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(2594.29,591.05)">
+                <polyline class="nad-edge-path" points="2609.98,619.51 2465.74,357.94"/>
+                <g class="nad-edge-infos" transform="translate(2594.29,591.05)">
                     <g class="nad-active">
                         <g transform="rotate(-28.87)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5441,8 +5441,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="414.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2321.49,96.36 2465.74,357.94"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(2337.19,124.82)">
+                <polyline class="nad-edge-path" points="2321.49,96.36 2465.74,357.94"/>
+                <g class="nad-edge-infos" transform="translate(2337.19,124.82)">
                     <g class="nad-active">
                         <g transform="rotate(151.13)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5456,8 +5456,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="415">
             <desc>L92-93-1</desc>
             <g id="415.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2280.75,70.81 2144.44,63.51"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(2248.30,69.07)">
+                <polyline class="nad-edge-path" points="2280.75,70.81 2144.44,63.51"/>
+                <g class="nad-edge-infos" transform="translate(2248.30,69.07)">
                     <g class="nad-active">
                         <g transform="rotate(-86.93)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5468,8 +5468,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="415.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="2008.12,56.20 2144.44,63.51"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(2040.58,57.94)">
+                <polyline class="nad-edge-path" points="2008.12,56.20 2144.44,63.51"/>
+                <g class="nad-edge-infos" transform="translate(2040.58,57.94)">
                     <g class="nad-active">
                         <g transform="rotate(93.07)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5483,8 +5483,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="416">
             <desc>L92-94-1</desc>
             <g id="416.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="2285.15,57.31 1994.82,-131.19"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(2257.89,39.61)">
+                <polyline class="nad-edge-path" points="2285.15,57.31 1994.82,-131.19"/>
+                <g class="nad-edge-infos" transform="translate(2257.89,39.61)">
                     <g class="nad-active">
                         <g transform="rotate(-57.01)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5495,8 +5495,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="416.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1704.48,-319.68 1994.82,-131.19"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1731.74,-301.98)">
+                <polyline class="nad-edge-path" points="1704.48,-319.68 1994.82,-131.19"/>
+                <g class="nad-edge-infos" transform="translate(1731.74,-301.98)">
                     <g class="nad-active">
                         <g transform="rotate(122.99)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5510,8 +5510,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="417">
             <desc>L93-94-1</desc>
             <g id="417.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1963.91,32.93 1831.04,-139.96"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1944.10,7.16)">
+                <polyline class="nad-edge-path" points="1963.91,32.93 1831.04,-139.96"/>
+                <g class="nad-edge-infos" transform="translate(1944.10,7.16)">
                     <g class="nad-active">
                         <g transform="rotate(-37.54)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5522,8 +5522,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="417.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1698.18,-312.85 1831.04,-139.96"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1717.98,-287.08)">
+                <polyline class="nad-edge-path" points="1698.18,-312.85 1831.04,-139.96"/>
+                <g class="nad-edge-infos" transform="translate(1717.98,-287.08)">
                     <g class="nad-active">
                         <g transform="rotate(142.46)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5537,8 +5537,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="418">
             <desc>L94-95-1</desc>
             <g id="418.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1654.35,-339.50 1473.98,-371.76"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1622.36,-345.22)">
+                <polyline class="nad-edge-path" points="1654.35,-339.50 1473.98,-371.76"/>
+                <g class="nad-edge-infos" transform="translate(1622.36,-345.22)">
                     <g class="nad-active">
                         <g transform="rotate(-79.86)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5549,8 +5549,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="418.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1293.62,-404.02 1473.98,-371.76"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1325.61,-398.30)">
+                <polyline class="nad-edge-path" points="1293.62,-404.02 1473.98,-371.76"/>
+                <g class="nad-edge-infos" transform="translate(1325.61,-398.30)">
                     <g class="nad-active">
                         <g transform="rotate(100.14)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5564,8 +5564,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="419">
             <desc>L94-96-1</desc>
             <g id="419.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1655.16,-342.81 1282.05,-458.65"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1624.12,-352.44)">
+                <polyline class="nad-edge-path" points="1655.16,-342.81 1282.05,-458.65"/>
+                <g class="nad-edge-infos" transform="translate(1624.12,-352.44)">
                     <g class="nad-active">
                         <g transform="rotate(-72.75)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5576,8 +5576,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="419.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="908.94,-574.50 1282.05,-458.65"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(939.98,-564.86)">
+                <polyline class="nad-edge-path" points="908.94,-574.50 1282.05,-458.65"/>
+                <g class="nad-edge-infos" transform="translate(939.98,-564.86)">
                     <g class="nad-active">
                         <g transform="rotate(107.25)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5591,8 +5591,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="420">
             <desc>L95-96-1</desc>
             <g id="420.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1241.50,-420.21 1074.61,-495.76"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1211.89,-433.61)">
+                <polyline class="nad-edge-path" points="1241.50,-420.21 1074.61,-495.76"/>
+                <g class="nad-edge-infos" transform="translate(1211.89,-433.61)">
                     <g class="nad-active">
                         <g transform="rotate(-65.64)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5603,8 +5603,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="420.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="907.73,-571.31 1074.61,-495.76"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(937.34,-557.91)">
+                <polyline class="nad-edge-path" points="907.73,-571.31 1074.61,-495.76"/>
+                <g class="nad-edge-infos" transform="translate(937.34,-557.91)">
                     <g class="nad-active">
                         <g transform="rotate(114.36)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5618,8 +5618,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="421">
             <desc>L96-97-1</desc>
             <g id="421.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="870.62,-607.37 802.16,-747.80"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(856.38,-636.59)">
+                <polyline class="nad-edge-path" points="870.62,-607.37 802.16,-747.80"/>
+                <g class="nad-edge-infos" transform="translate(856.38,-636.59)">
                     <g class="nad-active">
                         <g transform="rotate(-25.99)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -5630,8 +5630,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="421.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="733.69,-888.24 802.16,-747.80"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(747.93,-859.02)">
+                <polyline class="nad-edge-path" points="733.69,-888.24 802.16,-747.80"/>
+                <g class="nad-edge-infos" transform="translate(747.93,-859.02)">
                     <g class="nad-active">
                         <g transform="rotate(154.01)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/IEEE_118_bus_partial.svg
+++ b/network-area-diagram/src/test/resources/IEEE_118_bus_partial.svg
@@ -195,8 +195,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="64">
             <desc>L40-42-1</desc>
             <g id="64.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-23.96,-747.67 7.54,-983.24"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-19.66,-779.88)">
+                <polyline class="nad-edge-path" points="-23.96,-747.67 7.54,-983.24"/>
+                <g class="nad-edge-infos" transform="translate(-19.66,-779.88)">
                     <g class="nad-active">
                         <g transform="rotate(7.62)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -210,8 +210,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="65">
             <desc>L41-42-1</desc>
             <g id="65.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-49.84,-704.21 -280.90,-535.87"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-76.10,-685.08)">
+                <polyline class="nad-edge-path" points="-49.84,-704.21 -280.90,-535.87"/>
+                <g class="nad-edge-infos" transform="translate(-76.10,-685.08)">
                     <g class="nad-active">
                         <g transform="rotate(-126.08)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -225,8 +225,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="66">
             <desc>L42-49-1</desc>
             <g id="66.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-33.89,-693.63 -45.88,-642.52 79.75,-226.40"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-37.21,-613.80)">
+                <polyline class="nad-edge-path" points="-33.89,-693.63 -45.88,-642.52 79.75,-226.40"/>
+                <g class="nad-edge-infos" transform="translate(-37.21,-613.80)">
                     <g class="nad-active">
                         <g transform="rotate(163.20)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -237,8 +237,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="66.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="243.64,225.65 205.37,189.71 79.75,-226.40"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(196.70,160.99)">
+                <polyline class="nad-edge-path" points="243.64,225.65 205.37,189.71 79.75,-226.40"/>
+                <g class="nad-edge-infos" transform="translate(196.70,160.99)">
                     <g class="nad-active">
                         <g transform="rotate(-16.80)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -252,8 +252,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="67">
             <desc>L42-49-2</desc>
             <g id="67.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-7.56,-701.58 30.71,-665.64 156.33,-249.53"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(39.38,-636.92)">
+                <polyline class="nad-edge-path" points="-7.56,-701.58 30.71,-665.64 156.33,-249.53"/>
+                <g class="nad-edge-infos" transform="translate(39.38,-636.92)">
                     <g class="nad-active">
                         <g transform="rotate(163.20)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -264,8 +264,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="67.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="269.97,217.71 281.96,166.59 156.33,-249.53"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(273.29,137.87)">
+                <polyline class="nad-edge-path" points="269.97,217.71 281.96,166.59 156.33,-249.53"/>
+                <g class="nad-edge-infos" transform="translate(273.29,137.87)">
                     <g class="nad-active">
                         <g transform="rotate(-16.80)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -279,8 +279,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="68">
             <desc>L44-45-1</desc>
             <g id="68.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="947.15,865.89 1129.94,963.18"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(975.84,881.16)">
+                <polyline class="nad-edge-path" points="947.15,865.89 1129.94,963.18"/>
+                <g class="nad-edge-infos" transform="translate(975.84,881.16)">
                     <g class="nad-active">
                         <g transform="rotate(118.02)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -294,8 +294,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="69">
             <desc>L45-46-1</desc>
             <g id="69.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="902.59,871.53 789.79,974.75"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(878.61,893.47)">
+                <polyline class="nad-edge-path" points="902.59,871.53 789.79,974.75"/>
+                <g class="nad-edge-infos" transform="translate(878.61,893.47)">
                     <g class="nad-active">
                         <g transform="rotate(-132.46)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -309,8 +309,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="70">
             <desc>L45-49-1</desc>
             <g id="70.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="902.67,834.31 593.28,548.72"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(878.78,812.27)">
+                <polyline class="nad-edge-path" points="902.67,834.31 593.28,548.72"/>
+                <g class="nad-edge-infos" transform="translate(878.78,812.27)">
                     <g class="nad-active">
                         <g transform="rotate(-47.29)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -321,8 +321,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="70.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="283.89,263.13 593.28,548.72"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(307.78,285.18)">
+                <polyline class="nad-edge-path" points="283.89,263.13 593.28,548.72"/>
+                <g class="nad-edge-infos" transform="translate(307.78,285.18)">
                     <g class="nad-active">
                         <g transform="rotate(132.71)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -336,8 +336,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="71">
             <desc>L46-47-1</desc>
             <g id="71.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="641.26,641.87 648.52,855.46"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(642.37,674.35)">
+                <polyline class="nad-edge-path" points="641.26,641.87 648.52,855.46"/>
+                <g class="nad-edge-infos" transform="translate(642.37,674.35)">
                     <g class="nad-active">
                         <g transform="rotate(178.05)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -351,8 +351,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="72">
             <desc>L47-49-1</desc>
             <g id="72.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="620.71,595.12 452.01,429.43"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(597.52,572.34)">
+                <polyline class="nad-edge-path" points="620.71,595.12 452.01,429.43"/>
+                <g class="nad-edge-infos" transform="translate(597.52,572.34)">
                     <g class="nad-active">
                         <g transform="rotate(-45.52)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -363,8 +363,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="72.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="283.31,263.75 452.01,429.43"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(306.49,286.52)">
+                <polyline class="nad-edge-path" points="283.31,263.75 452.01,429.43"/>
+                <g class="nad-edge-infos" transform="translate(306.49,286.52)">
                     <g class="nad-active">
                         <g transform="rotate(134.48)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -378,8 +378,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="73">
             <desc>L47-69-1</desc>
             <g id="73.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="646.06,587.49 681.25,422.31"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(652.83,555.70)">
+                <polyline class="nad-edge-path" points="646.06,587.49 681.25,422.31"/>
+                <g class="nad-edge-infos" transform="translate(652.83,555.70)">
                     <g class="nad-active">
                         <g transform="rotate(12.03)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -390,8 +390,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="73.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="716.43,257.12 681.25,422.31"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(709.66,288.91)">
+                <polyline class="nad-edge-path" points="716.43,257.12 681.25,422.31"/>
+                <g class="nad-edge-infos" transform="translate(709.66,288.91)">
                     <g class="nad-active">
                         <g transform="rotate(-167.97)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -405,8 +405,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="74">
             <desc>L46-48-1</desc>
             <g id="74.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="321.46,980.84 476.09,1034.20"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(352.18,991.45)">
+                <polyline class="nad-edge-path" points="321.46,980.84 476.09,1034.20"/>
+                <g class="nad-edge-infos" transform="translate(352.18,991.45)">
                     <g class="nad-active">
                         <g transform="rotate(109.04)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -420,8 +420,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="75">
             <desc>L48-49-1</desc>
             <g id="75.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="294.26,944.40 279.58,608.18"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(292.84,911.93)">
+                <polyline class="nad-edge-path" points="294.26,944.40 279.58,608.18"/>
+                <g class="nad-edge-infos" transform="translate(292.84,911.93)">
                     <g class="nad-active">
                         <g transform="rotate(-2.50)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -432,8 +432,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="75.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="264.89,271.95 279.58,608.18"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(266.31,304.42)">
+                <polyline class="nad-edge-path" points="264.89,271.95 279.58,608.18"/>
+                <g class="nad-edge-infos" transform="translate(266.31,304.42)">
                     <g class="nad-active">
                         <g transform="rotate(177.50)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -447,8 +447,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="76">
             <desc>L49-50-1</desc>
             <g id="76.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="243.07,262.68 48.23,434.74"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(218.71,284.19)">
+                <polyline class="nad-edge-path" points="243.07,262.68 48.23,434.74"/>
+                <g class="nad-edge-infos" transform="translate(218.71,284.19)">
                     <g class="nad-active">
                         <g transform="rotate(-131.45)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -459,8 +459,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="76.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-146.62,606.80 48.23,434.74"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-122.26,585.29)">
+                <polyline class="nad-edge-path" points="-146.62,606.80 48.23,434.74"/>
+                <g class="nad-edge-infos" transform="translate(-122.26,585.29)">
                     <g class="nad-active">
                         <g transform="rotate(48.55)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -474,8 +474,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="77">
             <desc>L49-51-1</desc>
             <g id="77.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="286.78,229.54 647.12,-3.64"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(314.06,211.88)">
+                <polyline class="nad-edge-path" points="286.78,229.54 647.12,-3.64"/>
+                <g class="nad-edge-infos" transform="translate(314.06,211.88)">
                     <g class="nad-active">
                         <g transform="rotate(57.09)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -486,8 +486,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="77.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1007.47,-236.82 647.12,-3.64"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(980.18,-219.16)">
+                <polyline class="nad-edge-path" points="1007.47,-236.82 647.12,-3.64"/>
+                <g class="nad-edge-infos" transform="translate(980.18,-219.16)">
                     <g class="nad-active">
                         <g transform="rotate(-122.91)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -501,8 +501,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="78">
             <desc>L49-54-1</desc>
             <g id="78.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="273.23,218.69 291.44,169.45 242.39,-117.42"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(286.38,139.88)">
+                <polyline class="nad-edge-path" points="273.23,218.69 291.44,169.45 242.39,-117.42"/>
+                <g class="nad-edge-infos" transform="translate(286.38,139.88)">
                     <g class="nad-active">
                         <g transform="rotate(-9.70)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -513,8 +513,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="78.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="159.81,-444.67 193.35,-404.28 242.39,-117.42"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(198.40,-374.71)">
+                <polyline class="nad-edge-path" points="159.81,-444.67 193.35,-404.28 242.39,-117.42"/>
+                <g class="nad-edge-infos" transform="translate(198.40,-374.71)">
                     <g class="nad-active">
                         <g transform="rotate(170.30)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -528,8 +528,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="79">
             <desc>L49-54-2</desc>
             <g id="79.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="246.12,223.32 212.58,182.93 163.54,-103.93"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(207.53,153.36)">
+                <polyline class="nad-edge-path" points="246.12,223.32 212.58,182.93 163.54,-103.93"/>
+                <g class="nad-edge-infos" transform="translate(207.53,153.36)">
                     <g class="nad-active">
                         <g transform="rotate(-9.70)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -540,8 +540,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="79.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="132.70,-440.04 114.49,-390.80 163.54,-103.93"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(119.55,-361.23)">
+                <polyline class="nad-edge-path" points="132.70,-440.04 114.49,-390.80 163.54,-103.93"/>
+                <g class="nad-edge-infos" transform="translate(119.55,-361.23)">
                     <g class="nad-active">
                         <g transform="rotate(170.30)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -555,8 +555,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="80">
             <desc>L49-66-1</desc>
             <g id="80.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="238.59,233.23 190.69,211.74 -278.35,259.78"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(160.85,214.80)">
+                <polyline class="nad-edge-path" points="238.59,233.23 190.69,211.74 -278.35,259.78"/>
+                <g class="nad-edge-infos" transform="translate(160.85,214.80)">
                     <g class="nad-active">
                         <g transform="rotate(-95.85)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -567,8 +567,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="80.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-789.95,338.55 -747.39,307.81 -278.35,259.78"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-717.55,304.75)">
+                <polyline class="nad-edge-path" points="-789.95,338.55 -747.39,307.81 -278.35,259.78"/>
+                <g class="nad-edge-infos" transform="translate(-717.55,304.75)">
                     <g class="nad-active">
                         <g transform="rotate(84.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -582,8 +582,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="81">
             <desc>L49-66-2</desc>
             <g id="81.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="241.40,260.58 198.84,291.33 -270.20,339.36"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(169.00,294.38)">
+                <polyline class="nad-edge-path" points="241.40,260.58 198.84,291.33 -270.20,339.36"/>
+                <g class="nad-edge-infos" transform="translate(169.00,294.38)">
                     <g class="nad-active">
                         <g transform="rotate(-95.85)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -594,8 +594,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="81.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-787.15,365.91 -739.24,387.39 -270.20,339.36"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-709.40,384.33)">
+                <polyline class="nad-edge-path" points="-787.15,365.91 -739.24,387.39 -270.20,339.36"/>
+                <g class="nad-edge-infos" transform="translate(-709.40,384.33)">
                     <g class="nad-active">
                         <g transform="rotate(84.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -609,8 +609,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="82">
             <desc>L49-69-1</desc>
             <g id="82.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="291.17,243.62 492.93,237.35"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(323.66,242.61)">
+                <polyline class="nad-edge-path" points="291.17,243.62 492.93,237.35"/>
+                <g class="nad-edge-infos" transform="translate(323.66,242.61)">
                     <g class="nad-active">
                         <g transform="rotate(88.22)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -621,8 +621,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="82.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="694.68,231.08 492.93,237.35"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(662.19,232.09)">
+                <polyline class="nad-edge-path" points="694.68,231.08 492.93,237.35"/>
+                <g class="nad-edge-infos" transform="translate(662.19,232.09)">
                     <g class="nad-active">
                         <g transform="rotate(-91.78)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -636,8 +636,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="83">
             <desc>L50-57-1</desc>
             <g id="83.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-176.76,599.21 -230.54,453.48"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-188.01,568.72)">
+                <polyline class="nad-edge-path" points="-176.76,599.21 -230.54,453.48"/>
+                <g class="nad-edge-infos" transform="translate(-188.01,568.72)">
                     <g class="nad-active">
                         <g transform="rotate(-20.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -648,8 +648,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="83.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-284.33,307.75 -230.54,453.48"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-273.08,338.24)">
+                <polyline class="nad-edge-path" points="-284.33,307.75 -230.54,453.48"/>
+                <g class="nad-edge-infos" transform="translate(-273.08,338.24)">
                     <g class="nad-active">
                         <g transform="rotate(159.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -663,8 +663,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="84">
             <desc>L51-52-1</desc>
             <g id="84.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1035.66,-278.78 1082.59,-527.25"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1041.69,-310.72)">
+                <polyline class="nad-edge-path" points="1035.66,-278.78 1082.59,-527.25"/>
+                <g class="nad-edge-infos" transform="translate(1041.69,-310.72)">
                     <g class="nad-active">
                         <g transform="rotate(10.70)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -675,8 +675,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="84.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1129.52,-775.72 1082.59,-527.25"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1123.49,-743.78)">
+                <polyline class="nad-edge-path" points="1129.52,-775.72 1082.59,-527.25"/>
+                <g class="nad-edge-infos" transform="translate(1123.49,-743.78)">
                     <g class="nad-active">
                         <g transform="rotate(-169.30)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -690,8 +690,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="85">
             <desc>L51-58-1</desc>
             <g id="85.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1003.17,-249.30 847.58,-235.35"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(970.80,-246.40)">
+                <polyline class="nad-edge-path" points="1003.17,-249.30 847.58,-235.35"/>
+                <g class="nad-edge-infos" transform="translate(970.80,-246.40)">
                     <g class="nad-active">
                         <g transform="rotate(-95.13)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -702,8 +702,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="85.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="691.99,-221.39 847.58,-235.35"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(724.36,-224.29)">
+                <polyline class="nad-edge-path" points="691.99,-221.39 847.58,-235.35"/>
+                <g class="nad-edge-infos" transform="translate(724.36,-224.29)">
                     <g class="nad-active">
                         <g transform="rotate(84.87)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -717,8 +717,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="86">
             <desc>L52-53-1</desc>
             <g id="86.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1107.97,-809.51 904.22,-861.28"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1076.47,-817.52)">
+                <polyline class="nad-edge-path" points="1107.97,-809.51 904.22,-861.28"/>
+                <g class="nad-edge-infos" transform="translate(1076.47,-817.52)">
                     <g class="nad-active">
                         <g transform="rotate(-75.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -729,8 +729,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="86.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="700.46,-913.06 904.22,-861.28"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(731.96,-905.05)">
+                <polyline class="nad-edge-path" points="700.46,-913.06 904.22,-861.28"/>
+                <g class="nad-edge-infos" transform="translate(731.96,-905.05)">
                     <g class="nad-active">
                         <g transform="rotate(104.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -744,8 +744,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="87">
             <desc>L53-54-1</desc>
             <g id="87.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="652.90,-901.97 408.03,-692.83"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(628.19,-880.86)">
+                <polyline class="nad-edge-path" points="652.90,-901.97 408.03,-692.83"/>
+                <g class="nad-edge-infos" transform="translate(628.19,-880.86)">
                     <g class="nad-active">
                         <g transform="rotate(-130.50)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -756,8 +756,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="87.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="163.15,-483.69 408.03,-692.83"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(187.87,-504.80)">
+                <polyline class="nad-edge-path" points="163.15,-483.69 408.03,-692.83"/>
+                <g class="nad-edge-infos" transform="translate(187.87,-504.80)">
                     <g class="nad-active">
                         <g transform="rotate(49.50)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -771,8 +771,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="88">
             <desc>L54-55-1</desc>
             <g id="88.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="114.84,-468.09 -47.13,-481.42"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(82.45,-470.75)">
+                <polyline class="nad-edge-path" points="114.84,-468.09 -47.13,-481.42"/>
+                <g class="nad-edge-infos" transform="translate(82.45,-470.75)">
                     <g class="nad-active">
                         <g transform="rotate(-85.29)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -783,8 +783,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="88.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-209.10,-494.76 -47.13,-481.42"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-176.71,-492.09)">
+                <polyline class="nad-edge-path" points="-209.10,-494.76 -47.13,-481.42"/>
+                <g class="nad-edge-infos" transform="translate(-176.71,-492.09)">
                     <g class="nad-active">
                         <g transform="rotate(94.71)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -798,8 +798,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="89">
             <desc>L54-56-1</desc>
             <g id="89.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="125.07,-444.35 39.29,-337.04"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(104.78,-418.96)">
+                <polyline class="nad-edge-path" points="125.07,-444.35 39.29,-337.04"/>
+                <g class="nad-edge-infos" transform="translate(104.78,-418.96)">
                     <g class="nad-active">
                         <g transform="rotate(-141.36)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -810,8 +810,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="89.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-46.49,-229.72 39.29,-337.04"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-26.19,-255.11)">
+                <polyline class="nad-edge-path" points="-46.49,-229.72 39.29,-337.04"/>
+                <g class="nad-edge-infos" transform="translate(-26.19,-255.11)">
                     <g class="nad-active">
                         <g transform="rotate(38.64)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -825,8 +825,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="90">
             <desc>L54-59-1</desc>
             <g id="90.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="116.28,-474.90 -199.71,-585.29"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(85.60,-485.62)">
+                <polyline class="nad-edge-path" points="116.28,-474.90 -199.71,-585.29"/>
+                <g class="nad-edge-infos" transform="translate(85.60,-485.62)">
                     <g class="nad-active">
                         <g transform="rotate(-70.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -837,8 +837,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="90.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-515.71,-695.67 -199.71,-585.29"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-485.03,-684.95)">
+                <polyline class="nad-edge-path" points="-515.71,-695.67 -199.71,-585.29"/>
+                <g class="nad-edge-infos" transform="translate(-485.03,-684.95)">
                     <g class="nad-active">
                         <g transform="rotate(109.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -852,8 +852,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="91">
             <desc>L55-56-1</desc>
             <g id="91.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-222.38,-473.42 -150.08,-352.63"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-205.69,-445.54)">
+                <polyline class="nad-edge-path" points="-222.38,-473.42 -150.08,-352.63"/>
+                <g class="nad-edge-infos" transform="translate(-205.69,-445.54)">
                     <g class="nad-active">
                         <g transform="rotate(149.10)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -864,8 +864,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="91.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-77.78,-231.84 -150.08,-352.63"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-94.47,-259.72)">
+                <polyline class="nad-edge-path" points="-77.78,-231.84 -150.08,-352.63"/>
+                <g class="nad-edge-infos" transform="translate(-94.47,-259.72)">
                     <g class="nad-active">
                         <g transform="rotate(-30.90)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -879,8 +879,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="92">
             <desc>L55-59-1</desc>
             <g id="92.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-259.24,-512.49 -389.09,-600.88"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-286.11,-530.78)">
+                <polyline class="nad-edge-path" points="-259.24,-512.49 -389.09,-600.88"/>
+                <g class="nad-edge-infos" transform="translate(-286.11,-530.78)">
                     <g class="nad-active">
                         <g transform="rotate(-55.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -891,8 +891,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="92.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-518.94,-689.27 -389.09,-600.88"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-492.07,-670.98)">
+                <polyline class="nad-edge-path" points="-518.94,-689.27 -389.09,-600.88"/>
+                <g class="nad-edge-infos" transform="translate(-492.07,-670.98)">
                     <g class="nad-active">
                         <g transform="rotate(124.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -906,8 +906,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="93">
             <desc>L56-57-1</desc>
             <g id="93.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-75.35,-183.35 -178.76,36.85"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-89.16,-153.93)">
+                <polyline class="nad-edge-path" points="-75.35,-183.35 -178.76,36.85"/>
+                <g class="nad-edge-infos" transform="translate(-89.16,-153.93)">
                     <g class="nad-active">
                         <g transform="rotate(-154.85)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -918,8 +918,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="93.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-282.16,257.06 -178.76,36.85"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-268.35,227.64)">
+                <polyline class="nad-edge-path" points="-282.16,257.06 -178.76,36.85"/>
+                <g class="nad-edge-infos" transform="translate(-268.35,227.64)">
                     <g class="nad-active">
                         <g transform="rotate(25.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -933,8 +933,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="94">
             <desc>L56-58-1</desc>
             <g id="94.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-36.16,-208.65 300.47,-213.59"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-3.66,-209.12)">
+                <polyline class="nad-edge-path" points="-36.16,-208.65 300.47,-213.59"/>
+                <g class="nad-edge-infos" transform="translate(-3.66,-209.12)">
                     <g class="nad-active">
                         <g transform="rotate(89.16)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -945,8 +945,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="94.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="637.10,-218.53 300.47,-213.59"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(604.61,-218.05)">
+                <polyline class="nad-edge-path" points="637.10,-218.53 300.47,-213.59"/>
+                <g class="nad-edge-infos" transform="translate(604.61,-218.05)">
                     <g class="nad-active">
                         <g transform="rotate(-90.84)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -960,8 +960,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="95">
             <desc>L56-59-1</desc>
             <g id="95.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-70.27,-234.94 -82.89,-285.89 -273.85,-484.23"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-103.70,-307.51)">
+                <polyline class="nad-edge-path" points="-70.27,-234.94 -82.89,-285.89 -273.85,-484.23"/>
+                <g class="nad-edge-infos" transform="translate(-103.70,-307.51)">
                     <g class="nad-active">
                         <g transform="rotate(-43.91)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -972,8 +972,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="95.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-515.25,-697.12 -464.80,-682.57 -273.85,-484.23"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-444.00,-660.96)">
+                <polyline class="nad-edge-path" points="-515.25,-697.12 -464.80,-682.57 -273.85,-484.23"/>
+                <g class="nad-edge-infos" transform="translate(-444.00,-660.96)">
                     <g class="nad-active">
                         <g transform="rotate(136.09)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -987,8 +987,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="96">
             <desc>L56-59-2</desc>
             <g id="96.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-90.08,-215.86 -140.52,-230.41 -331.48,-428.75"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-161.33,-252.02)">
+                <polyline class="nad-edge-path" points="-90.08,-215.86 -140.52,-230.41 -331.48,-428.75"/>
+                <g class="nad-edge-infos" transform="translate(-161.33,-252.02)">
                     <g class="nad-active">
                         <g transform="rotate(-43.91)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -999,8 +999,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="96.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-535.06,-678.05 -522.43,-627.09 -331.48,-428.75"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-501.63,-605.48)">
+                <polyline class="nad-edge-path" points="-535.06,-678.05 -522.43,-627.09 -331.48,-428.75"/>
+                <g class="nad-edge-infos" transform="translate(-501.63,-605.48)">
                     <g class="nad-active">
                         <g transform="rotate(136.09)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1014,8 +1014,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="97">
             <desc>L59-60-1</desc>
             <g id="97.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-567.13,-694.35 -783.30,-606.16"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-597.22,-682.08)">
+                <polyline class="nad-edge-path" points="-567.13,-694.35 -783.30,-606.16"/>
+                <g class="nad-edge-infos" transform="translate(-597.22,-682.08)">
                     <g class="nad-active">
                         <g transform="rotate(-112.19)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1026,8 +1026,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="97.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-999.46,-517.97 -783.30,-606.16"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-969.37,-530.25)">
+                <polyline class="nad-edge-path" points="-999.46,-517.97 -783.30,-606.16"/>
+                <g class="nad-edge-infos" transform="translate(-969.37,-530.25)">
                     <g class="nad-active">
                         <g transform="rotate(67.81)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1041,8 +1041,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="98">
             <desc>L59-61-1</desc>
             <g id="98.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-568.89,-708.65 -816.28,-744.22"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-601.06,-713.28)">
+                <polyline class="nad-edge-path" points="-568.89,-708.65 -816.28,-744.22"/>
+                <g class="nad-edge-infos" transform="translate(-601.06,-713.28)">
                     <g class="nad-active">
                         <g transform="rotate(-81.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1053,8 +1053,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="98.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1063.67,-779.78 -816.28,-744.22"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1031.50,-775.16)">
+                <polyline class="nad-edge-path" points="-1063.67,-779.78 -816.28,-744.22"/>
+                <g class="nad-edge-infos" transform="translate(-1031.50,-775.16)">
                     <g class="nad-active">
                         <g transform="rotate(98.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1068,8 +1068,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="99">
             <desc>T63-59-1</desc>
             <g id="99.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-735.70,-1186.28 -655.04,-986.09"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-723.55,-1156.13)">
+                <polyline class="nad-edge-path" points="-735.70,-1186.28 -655.04,-986.09"/>
+                <g class="nad-edge-infos" transform="translate(-723.55,-1156.13)">
                     <g class="nad-active">
                         <g transform="rotate(158.05)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1080,8 +1080,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="99.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-551.95,-730.25 -632.61,-930.44"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-564.09,-760.39)">
+                <polyline class="nad-edge-path" points="-551.95,-730.25 -632.61,-930.44"/>
+                <g class="nad-edge-infos" transform="translate(-564.09,-760.39)">
                     <g class="nad-active">
                         <g transform="rotate(-21.95)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1091,7 +1091,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500-line nad-winding" cx="-647.56" cy="-967.54" r="20.00"/>
                 <circle class="nad-vl120to180-line nad-winding" cx="-640.09" cy="-948.99" r="20.00"/>
             </g>
@@ -1099,8 +1099,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="100">
             <desc>L60-61-1</desc>
             <g id="100.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1031.32,-534.33 -1057.91,-645.64"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1038.87,-565.94)">
+                <polyline class="nad-edge-path" points="-1031.32,-534.33 -1057.91,-645.64"/>
+                <g class="nad-edge-infos" transform="translate(-1038.87,-565.94)">
                     <g class="nad-active">
                         <g transform="rotate(-13.44)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1111,8 +1111,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="100.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1084.50,-756.95 -1057.91,-645.64"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1076.95,-725.34)">
+                <polyline class="nad-edge-path" points="-1084.50,-756.95 -1057.91,-645.64"/>
+                <g class="nad-edge-infos" transform="translate(-1076.95,-725.34)">
                     <g class="nad-active">
                         <g transform="rotate(166.56)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1126,8 +1126,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="101">
             <desc>L60-62-1</desc>
             <g id="101.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1035.26,-482.10 -1089.14,-349.25"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1047.48,-451.98)">
+                <polyline class="nad-edge-path" points="-1035.26,-482.10 -1089.14,-349.25"/>
+                <g class="nad-edge-infos" transform="translate(-1047.48,-451.98)">
                     <g class="nad-active">
                         <g transform="rotate(-157.92)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1141,8 +1141,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="102">
             <desc>L61-62-1</desc>
             <g id="102.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1093.77,-756.35 -1122.12,-487.31"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1097.17,-724.03)">
+                <polyline class="nad-edge-path" points="-1093.77,-756.35 -1122.12,-487.31"/>
+                <g class="nad-edge-infos" transform="translate(-1097.17,-724.03)">
                     <g class="nad-active">
                         <g transform="rotate(-173.98)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1157,8 +1157,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
             <desc>T64-61-1</desc>
             <g id="103.1" class="nad-vl300to500-line"></g>
             <g id="103.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1093.47,-811.08 -1109.32,-978.93"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1096.53,-843.43)">
+                <polyline class="nad-edge-path" points="-1093.47,-811.08 -1109.32,-978.93"/>
+                <g class="nad-edge-infos" transform="translate(-1096.53,-843.43)">
                     <g class="nad-active">
                         <g transform="rotate(-5.39)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1168,7 +1168,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500-line nad-winding" cx="-1113.08" cy="-1018.76" r="20.00"/>
                 <circle class="nad-vl120to180-line nad-winding" cx="-1111.20" cy="-998.85" r="20.00"/>
             </g>
@@ -1176,8 +1176,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="104">
             <desc>L63-64-1</desc>
             <g id="104.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-773.43,-1213.35 -939.68,-1222.85"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-805.88,-1215.21)">
+                <polyline class="nad-edge-path" points="-773.43,-1213.35 -939.68,-1222.85"/>
+                <g class="nad-edge-infos" transform="translate(-805.88,-1215.21)">
                     <g class="nad-active">
                         <g transform="rotate(-86.73)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1191,8 +1191,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="105">
             <desc>L62-66-1</desc>
             <g id="105.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-826.82,331.34 -982.80,81.87"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-844.05,303.78)">
+                <polyline class="nad-edge-path" points="-826.82,331.34 -982.80,81.87"/>
+                <g class="nad-edge-infos" transform="translate(-844.05,303.78)">
                     <g class="nad-active">
                         <g transform="rotate(-32.02)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1206,8 +1206,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="106">
             <desc>L66-67-1</desc>
             <g id="106.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-839.10,360.57 -1053.12,407.71"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-870.83,367.56)">
+                <polyline class="nad-edge-path" points="-839.10,360.57 -1053.12,407.71"/>
+                <g class="nad-edge-infos" transform="translate(-870.83,367.56)">
                     <g class="nad-active">
                         <g transform="rotate(-102.42)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1222,8 +1222,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
             <desc>T65-66-1</desc>
             <g id="107.1" class="nad-vl300to500-line"></g>
             <g id="107.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-821.74,380.46 -887.30,558.61"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-832.96,410.96)">
+                <polyline class="nad-edge-path" points="-821.74,380.46 -887.30,558.61"/>
+                <g class="nad-edge-infos" transform="translate(-832.96,410.96)">
                     <g class="nad-active">
                         <g transform="rotate(-159.80)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1233,7 +1233,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500-line nad-winding" cx="-901.12" cy="596.15" r="20.00"/>
                 <circle class="nad-vl120to180-line nad-winding" cx="-894.21" cy="577.38" r="20.00"/>
             </g>
@@ -1241,8 +1241,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="108">
             <desc>L69-70-1</desc>
             <g id="108.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="701.20,248.03 515.45,405.81"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(676.43,269.07)">
+                <polyline class="nad-edge-path" points="701.20,248.03 515.45,405.81"/>
+                <g class="nad-edge-infos" transform="translate(676.43,269.07)">
                     <g class="nad-active">
                         <g transform="rotate(-130.35)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1256,8 +1256,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="109">
             <desc>L69-75-1</desc>
             <g id="109.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="725.93,202.98 770.23,-117.61"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(730.38,170.79)">
+                <polyline class="nad-edge-path" points="725.93,202.98 770.23,-117.61"/>
+                <g class="nad-edge-infos" transform="translate(730.38,170.79)">
                     <g class="nad-active">
                         <g transform="rotate(7.87)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1271,8 +1271,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="110">
             <desc>L69-77-1</desc>
             <g id="110.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="749.49,233.27 994.00,260.49"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(781.79,236.86)">
+                <polyline class="nad-edge-path" points="749.49,233.27 994.00,260.49"/>
+                <g class="nad-edge-infos" transform="translate(781.79,236.86)">
                     <g class="nad-active">
                         <g transform="rotate(96.35)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1287,8 +1287,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
             <desc>T68-69-1</desc>
             <g id="111.1" class="nad-vl300to500-line"></g>
             <g id="111.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="702.46,211.04 618.50,129.26"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(679.18,188.36)">
+                <polyline class="nad-edge-path" points="702.46,211.04 618.50,129.26"/>
+                <g class="nad-edge-infos" transform="translate(679.18,188.36)">
                     <g class="nad-active">
                         <g transform="rotate(-45.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1298,7 +1298,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500-line nad-winding" cx="589.84" cy="101.35" r="20.00"/>
                 <circle class="nad-vl120to180-line nad-winding" cx="604.17" cy="115.31" r="20.00"/>
             </g>

--- a/network-area-diagram/src/test/resources/IEEE_118_bus_partial_non_connected.svg
+++ b/network-area-diagram/src/test/resources/IEEE_118_bus_partial_non_connected.svg
@@ -155,8 +155,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="54">
             <desc>L17-113-1</desc>
             <g id="54.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="419.19,560.26 277.19,644.77"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(391.26,576.88)">
+                <polyline class="nad-edge-path" points="419.19,560.26 277.19,644.77"/>
+                <g class="nad-edge-infos" transform="translate(391.26,576.88)">
                     <g class="nad-active">
                         <g transform="rotate(-120.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -170,8 +170,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="55">
             <desc>L32-113-1</desc>
             <g id="55.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="806.15,350.29 636.59,441.72"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(777.54,365.72)">
+                <polyline class="nad-edge-path" points="806.15,350.29 636.59,441.72"/>
+                <g class="nad-edge-infos" transform="translate(777.54,365.72)">
                     <g class="nad-active">
                         <g transform="rotate(-118.33)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -182,8 +182,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="55.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="467.02,533.14 636.59,441.72"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(495.63,517.72)">
+                <polyline class="nad-edge-path" points="467.02,533.14 636.59,441.72"/>
+                <g class="nad-edge-infos" transform="translate(495.63,517.72)">
                     <g class="nad-active">
                         <g transform="rotate(61.67)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -197,8 +197,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="56">
             <desc>L32-114-1</desc>
             <g id="56.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="810.03,318.71 673.28,194.01"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(786.02,296.81)">
+                <polyline class="nad-edge-path" points="810.03,318.71 673.28,194.01"/>
+                <g class="nad-edge-infos" transform="translate(786.02,296.81)">
                     <g class="nad-active">
                         <g transform="rotate(-47.64)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -209,8 +209,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="56.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="536.53,69.30 673.28,194.01"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(560.55,91.20)">
+                <polyline class="nad-edge-path" points="536.53,69.30 673.28,194.01"/>
+                <g class="nad-edge-infos" transform="translate(560.55,91.20)">
                     <g class="nad-active">
                         <g transform="rotate(132.36)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -224,8 +224,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="57">
             <desc>L114-115-1</desc>
             <g id="57.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="517.43,23.30 524.32,-131.93"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(518.87,-9.17)">
+                <polyline class="nad-edge-path" points="517.43,23.30 524.32,-131.93"/>
+                <g class="nad-edge-infos" transform="translate(518.87,-9.17)">
                     <g class="nad-active">
                         <g transform="rotate(2.54)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -239,8 +239,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="58">
             <desc>L22-23-1</desc>
             <g id="58.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1418.58,249.97 1528.51,396.91"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1438.05,275.99)">
+                <polyline class="nad-edge-path" points="1418.58,249.97 1528.51,396.91"/>
+                <g class="nad-edge-infos" transform="translate(1438.05,275.99)">
                     <g class="nad-active">
                         <g transform="rotate(143.20)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -254,8 +254,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="59">
             <desc>L23-24-1</desc>
             <g id="59.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1426.41,215.07 1603.28,121.31"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1455.12,199.85)">
+                <polyline class="nad-edge-path" points="1426.41,215.07 1603.28,121.31"/>
+                <g class="nad-edge-infos" transform="translate(1455.12,199.85)">
                     <g class="nad-active">
                         <g transform="rotate(62.07)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -269,8 +269,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="60">
             <desc>L23-25-1</desc>
             <g id="60.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1395.66,201.21 1353.87,27.97"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1388.04,169.62)">
+                <polyline class="nad-edge-path" points="1395.66,201.21 1353.87,27.97"/>
+                <g class="nad-edge-infos" transform="translate(1388.04,169.62)">
                     <g class="nad-active">
                         <g transform="rotate(-13.56)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -284,8 +284,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="61">
             <desc>L23-32-1</desc>
             <g id="61.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1375.10,233.11 1116.23,282.59"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1343.18,239.21)">
+                <polyline class="nad-edge-path" points="1375.10,233.11 1116.23,282.59"/>
+                <g class="nad-edge-infos" transform="translate(1343.18,239.21)">
                     <g class="nad-active">
                         <g transform="rotate(-100.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -296,8 +296,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="61.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="857.36,332.08 1116.23,282.59"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(889.29,325.98)">
+                <polyline class="nad-edge-path" points="857.36,332.08 1116.23,282.59"/>
+                <g class="nad-edge-infos" transform="translate(889.29,325.98)">
                     <g class="nad-active">
                         <g transform="rotate(79.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -311,8 +311,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="62">
             <desc>L25-27-1</desc>
             <g id="62.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="952.04,-247.88 1115.39,-212.83"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(983.81,-241.06)">
+                <polyline class="nad-edge-path" points="952.04,-247.88 1115.39,-212.83"/>
+                <g class="nad-edge-infos" transform="translate(983.81,-241.06)">
                     <g class="nad-active">
                         <g transform="rotate(102.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -326,8 +326,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="63">
             <desc>L27-28-1</desc>
             <g id="63.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="929.68,-280.77 963.73,-484.83"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(935.03,-312.83)">
+                <polyline class="nad-edge-path" points="929.68,-280.77 963.73,-484.83"/>
+                <g class="nad-edge-infos" transform="translate(935.03,-312.83)">
                     <g class="nad-active">
                         <g transform="rotate(9.48)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -341,8 +341,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="64">
             <desc>L27-32-1</desc>
             <g id="64.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="920.79,-226.49 877.75,41.80"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(915.64,-194.40)">
+                <polyline class="nad-edge-path" points="920.79,-226.49 877.75,41.80"/>
+                <g class="nad-edge-infos" transform="translate(915.64,-194.40)">
                     <g class="nad-active">
                         <g transform="rotate(-170.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -353,8 +353,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="64.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="834.71,310.09 877.75,41.80"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(839.86,278.00)">
+                <polyline class="nad-edge-path" points="834.71,310.09 877.75,41.80"/>
+                <g class="nad-edge-infos" transform="translate(839.86,278.00)">
                     <g class="nad-active">
                         <g transform="rotate(9.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -368,8 +368,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="65">
             <desc>L27-115-1</desc>
             <g id="65.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="897.97,-257.87 728.79,-284.14"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(865.86,-262.85)">
+                <polyline class="nad-edge-path" points="897.97,-257.87 728.79,-284.14"/>
+                <g class="nad-edge-infos" transform="translate(865.86,-262.85)">
                     <g class="nad-active">
                         <g transform="rotate(-81.17)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -383,8 +383,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="66">
             <desc>L8-30-1</desc>
             <g id="66.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-410.76,509.75 -430.32,720.57"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-413.76,542.11)">
+                <polyline class="nad-edge-path" points="-410.76,509.75 -430.32,720.57"/>
+                <g class="nad-edge-infos" transform="translate(-413.76,542.11)">
                     <g class="nad-active">
                         <g transform="rotate(-174.70)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -398,8 +398,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="67">
             <desc>L26-30-1</desc>
             <g id="67.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-432.72,494.84 -602.49,581.23"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-461.69,509.58)">
+                <polyline class="nad-edge-path" points="-432.72,494.84 -602.49,581.23"/>
+                <g class="nad-edge-infos" transform="translate(-461.69,509.58)">
                     <g class="nad-active">
                         <g transform="rotate(-116.97)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -413,8 +413,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="68">
             <desc>L30-38-1</desc>
             <g id="68.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-413.30,455.34 -480.09,100.79"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-419.32,423.40)">
+                <polyline class="nad-edge-path" points="-413.30,455.34 -480.09,100.79"/>
+                <g class="nad-edge-infos" transform="translate(-419.32,423.40)">
                     <g class="nad-active">
                         <g transform="rotate(-10.67)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -425,8 +425,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="68.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-546.87,-253.77 -480.09,100.79"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-540.85,-221.83)">
+                <polyline class="nad-edge-path" points="-546.87,-253.77 -480.09,100.79"/>
+                <g class="nad-edge-infos" transform="translate(-540.85,-221.83)">
                     <g class="nad-active">
                         <g transform="rotate(169.33)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -440,8 +440,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="69">
             <desc>T30-17-1</desc>
             <g id="69.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-383.64,494.71 -175.13,599.40"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-354.59,509.29)">
+                <polyline class="nad-edge-path" points="-383.64,494.71 -175.13,599.40"/>
+                <g class="nad-edge-infos" transform="translate(-354.59,509.29)">
                     <g class="nad-active">
                         <g transform="rotate(116.66)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -452,7 +452,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="69.2" class="nad-vl120to180-line"></g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500-line nad-winding" cx="-157.26" cy="608.37" r="20.00"/>
                 <circle class="nad-vl120to180-line nad-winding" cx="-139.39" cy="617.34" r="20.00"/>
             </g>
@@ -460,8 +460,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="70">
             <desc>L17-31-1</desc>
             <g id="70.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="570.59,903.79 354.06,828.11"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(539.91,893.07)">
+                <polyline class="nad-edge-path" points="570.59,903.79 354.06,828.11"/>
+                <g class="nad-edge-infos" transform="translate(539.91,893.07)">
                     <g class="nad-active">
                         <g transform="rotate(-70.73)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -475,8 +475,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="71">
             <desc>L29-31-1</desc>
             <g id="71.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="601.80,939.86 638.40,1128.21"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(608.00,971.76)">
+                <polyline class="nad-edge-path" points="601.80,939.86 638.40,1128.21"/>
+                <g class="nad-edge-infos" transform="translate(608.00,971.76)">
                     <g class="nad-active">
                         <g transform="rotate(169.00)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -490,8 +490,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="72">
             <desc>L31-32-1</desc>
             <g id="72.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="606.90,887.39 713.45,625.05"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(619.13,857.27)">
+                <polyline class="nad-edge-path" points="606.90,887.39 713.45,625.05"/>
+                <g class="nad-edge-infos" transform="translate(619.13,857.27)">
                     <g class="nad-active">
                         <g transform="rotate(22.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -502,8 +502,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="72.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="820.01,362.72 713.45,625.05"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(807.77,392.83)">
+                <polyline class="nad-edge-path" points="820.01,362.72 713.45,625.05"/>
+                <g class="nad-edge-infos" transform="translate(807.77,392.83)">
                     <g class="nad-active">
                         <g transform="rotate(-157.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -517,8 +517,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="73">
             <desc>L35-37-1</desc>
             <g id="73.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1183.60,-334.78 -1136.32,-167.43"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1174.76,-303.50)">
+                <polyline class="nad-edge-path" points="-1183.60,-334.78 -1136.32,-167.43"/>
+                <g class="nad-edge-infos" transform="translate(-1174.76,-303.50)">
                     <g class="nad-active">
                         <g transform="rotate(164.23)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -532,8 +532,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="74">
             <desc>L33-37-1</desc>
             <g id="74.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1218.20,-365.79 -1421.48,-399.88"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1250.25,-371.16)">
+                <polyline class="nad-edge-path" points="-1218.20,-365.79 -1421.48,-399.88"/>
+                <g class="nad-edge-infos" transform="translate(-1250.25,-371.16)">
                     <g class="nad-active">
                         <g transform="rotate(-80.48)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -547,8 +547,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="75">
             <desc>L34-37-1</desc>
             <g id="75.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1209.90,-341.20 -1361.01,-180.32"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1232.15,-317.51)">
+                <polyline class="nad-edge-path" points="-1209.90,-341.20 -1361.01,-180.32"/>
+                <g class="nad-edge-infos" transform="translate(-1232.15,-317.51)">
                     <g class="nad-active">
                         <g transform="rotate(-136.79)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -562,8 +562,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="76">
             <desc>L37-39-1</desc>
             <g id="76.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1202.11,-386.43 -1289.26,-585.37"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1215.15,-416.20)">
+                <polyline class="nad-edge-path" points="-1202.11,-386.43 -1289.26,-585.37"/>
+                <g class="nad-edge-infos" transform="translate(-1215.15,-416.20)">
                     <g class="nad-active">
                         <g transform="rotate(-23.66)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -577,8 +577,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="77">
             <desc>L37-40-1</desc>
             <g id="77.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1174.65,-383.30 -1072.16,-520.98"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1155.25,-409.37)">
+                <polyline class="nad-edge-path" points="-1174.65,-383.30 -1072.16,-520.98"/>
+                <g class="nad-edge-infos" transform="translate(-1155.25,-409.37)">
                     <g class="nad-active">
                         <g transform="rotate(36.66)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -592,8 +592,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="78">
             <desc>T38-37-1</desc>
             <g id="78.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-579.24,-284.23 -841.75,-317.27"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-611.49,-288.29)">
+                <polyline class="nad-edge-path" points="-579.24,-284.23 -841.75,-317.27"/>
+                <g class="nad-edge-infos" transform="translate(-611.49,-288.29)">
                     <g class="nad-active">
                         <g transform="rotate(-82.83)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -604,8 +604,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="78.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1163.79,-357.81 -901.28,-324.76"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1131.54,-353.75)">
+                <polyline class="nad-edge-path" points="-1163.79,-357.81 -901.28,-324.76"/>
+                <g class="nad-edge-infos" transform="translate(-1131.54,-353.75)">
                     <g class="nad-active">
                         <g transform="rotate(97.17)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -615,7 +615,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500-line nad-winding" cx="-861.59" cy="-319.77" r="20.00"/>
                 <circle class="nad-vl120to180-line nad-winding" cx="-881.44" cy="-322.27" r="20.00"/>
             </g>
@@ -623,8 +623,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="79">
             <desc>L38-65-1</desc>
             <g id="79.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-541.64,-306.28 -408.08,-636.14"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-529.44,-336.41)">
+                <polyline class="nad-edge-path" points="-541.64,-306.28 -408.08,-636.14"/>
+                <g class="nad-edge-infos" transform="translate(-529.44,-336.41)">
                     <g class="nad-active">
                         <g transform="rotate(22.04)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -635,8 +635,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="79.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-274.53,-966.00 -408.08,-636.14"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-286.73,-935.87)">
+                <polyline class="nad-edge-path" points="-274.53,-966.00 -408.08,-636.14"/>
+                <g class="nad-edge-infos" transform="translate(-286.73,-935.87)">
                     <g class="nad-active">
                         <g transform="rotate(-157.96)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -650,8 +650,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="80">
             <desc>L64-65-1</desc>
             <g id="80.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-237.63,-998.55 -56.15,-1046.80"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-206.23,-1006.90)">
+                <polyline class="nad-edge-path" points="-237.63,-998.55 -56.15,-1046.80"/>
+                <g class="nad-edge-infos" transform="translate(-206.23,-1006.90)">
                     <g class="nad-active">
                         <g transform="rotate(75.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -665,8 +665,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="81">
             <desc>L65-68-1</desc>
             <g id="81.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-281.91,-1012.53 -400.73,-1153.82"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-302.83,-1037.41)">
+                <polyline class="nad-edge-path" points="-281.91,-1012.53 -400.73,-1153.82"/>
+                <g class="nad-edge-infos" transform="translate(-302.83,-1037.41)">
                     <g class="nad-active">
                         <g transform="rotate(-40.06)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -680,8 +680,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="82">
             <desc>T65-66-1</desc>
             <g id="82.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-255.45,-1017.55 -192.96,-1203.45"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-245.09,-1048.36)">
+                <polyline class="nad-edge-path" points="-255.45,-1017.55 -192.96,-1203.45"/>
+                <g class="nad-edge-infos" transform="translate(-245.09,-1048.36)">
                     <g class="nad-active">
                         <g transform="rotate(18.58)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -692,7 +692,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="82.2" class="nad-vl120to180-line"></g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500-line nad-winding" cx="-186.59" cy="-1222.40" r="20.00"/>
                 <circle class="nad-vl120to180-line nad-winding" cx="-180.22" cy="-1241.36" r="20.00"/>
             </g>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus.svg
@@ -97,8 +97,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="25">
             <desc>L1-2-1</desc>
             <g id="25.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="172.27,-645.72 122.28,-526.91"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(159.67,-615.77)">
+                <polyline class="nad-edge-path" points="172.27,-645.72 122.28,-526.91"/>
+                <g class="nad-edge-infos" transform="translate(159.67,-615.77)">
                     <g class="nad-active">
                         <g transform="rotate(-157.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -109,8 +109,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="25.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="72.29,-408.09 122.28,-526.91"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(84.89,-438.04)">
+                <polyline class="nad-edge-path" points="72.29,-408.09 122.28,-526.91"/>
+                <g class="nad-edge-infos" transform="translate(84.89,-438.04)">
                     <g class="nad-active">
                         <g transform="rotate(22.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -124,8 +124,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="26">
             <desc>L1-5-1</desc>
             <g id="26.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="182.96,-643.74 192.16,-349.65"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(183.97,-611.26)">
+                <polyline class="nad-edge-path" points="182.96,-643.74 192.16,-349.65"/>
+                <g class="nad-edge-infos" transform="translate(183.97,-611.26)">
                     <g class="nad-active">
                         <g transform="rotate(178.21)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -136,8 +136,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="26.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="201.36,-55.55 192.16,-349.65"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(199.41,-118.02)">
+                <polyline class="nad-edge-path" points="201.36,-55.55 192.16,-349.65"/>
+                <g class="nad-edge-infos" transform="translate(199.41,-118.02)">
                     <g class="nad-active">
                         <g transform="rotate(-1.79)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -151,8 +151,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="27">
             <desc>L9-10-1</desc>
             <g id="27.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-172.20,-92.74 -361.39,-1.64"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-219.50,-69.97)">
+                <polyline class="nad-edge-path" points="-172.20,-92.74 -361.39,-1.64"/>
+                <g class="nad-edge-infos" transform="translate(-219.50,-69.97)">
                     <g class="nad-active">
                         <g transform="rotate(-115.71)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -163,8 +163,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="27.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-550.59,89.46 -361.39,-1.64"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-521.31,75.36)">
+                <polyline class="nad-edge-path" points="-550.59,89.46 -361.39,-1.64"/>
+                <g class="nad-edge-infos" transform="translate(-521.31,75.36)">
                     <g class="nad-active">
                         <g transform="rotate(64.29)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -178,8 +178,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="28">
             <desc>L10-11-1</desc>
             <g id="28.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-553.14,115.79 -434.62,204.42"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-527.12,135.25)">
+                <polyline class="nad-edge-path" points="-553.14,115.79 -434.62,204.42"/>
+                <g class="nad-edge-infos" transform="translate(-527.12,135.25)">
                     <g class="nad-active">
                         <g transform="rotate(126.79)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -190,8 +190,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="28.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-316.10,293.04 -434.62,204.42"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-342.13,273.58)">
+                <polyline class="nad-edge-path" points="-316.10,293.04 -434.62,204.42"/>
+                <g class="nad-edge-infos" transform="translate(-342.13,273.58)">
                     <g class="nad-active">
                         <g transform="rotate(-53.21)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -205,8 +205,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="29">
             <desc>L6-11-1</desc>
             <g id="29.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="156.26,1.13 -59.17,147.56"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(129.38,19.40)">
+                <polyline class="nad-edge-path" points="156.26,1.13 -59.17,147.56"/>
+                <g class="nad-edge-infos" transform="translate(129.38,19.40)">
                     <g class="nad-active">
                         <g transform="rotate(-124.20)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -217,8 +217,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="29.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-274.59,293.98 -59.17,147.56"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-247.71,275.71)">
+                <polyline class="nad-edge-path" points="-274.59,293.98 -59.17,147.56"/>
+                <g class="nad-edge-infos" transform="translate(-247.71,275.71)">
                     <g class="nad-active">
                         <g transform="rotate(55.80)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -232,8 +232,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="30">
             <desc>L6-12-1</desc>
             <g id="30.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="256.41,-18.36 462.83,26.19"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(288.18,-11.50)">
+                <polyline class="nad-edge-path" points="256.41,-18.36 462.83,26.19"/>
+                <g class="nad-edge-infos" transform="translate(288.18,-11.50)">
                     <g class="nad-active">
                         <g transform="rotate(102.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -244,8 +244,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="30.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="669.26,70.75 462.83,26.19"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(637.49,63.89)">
+                <polyline class="nad-edge-path" points="669.26,70.75 462.83,26.19"/>
+                <g class="nad-edge-infos" transform="translate(637.49,63.89)">
                     <g class="nad-active">
                         <g transform="rotate(-77.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -259,8 +259,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="31">
             <desc>L12-13-1</desc>
             <g id="31.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="677.38,95.31 581.29,205.02"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(655.97,119.76)">
+                <polyline class="nad-edge-path" points="677.38,95.31 581.29,205.02"/>
+                <g class="nad-edge-infos" transform="translate(655.97,119.76)">
                     <g class="nad-active">
                         <g transform="rotate(-138.79)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -271,8 +271,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="31.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="485.20,314.73 581.29,205.02"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(506.62,290.29)">
+                <polyline class="nad-edge-path" points="485.20,314.73 581.29,205.02"/>
+                <g class="nad-edge-infos" transform="translate(506.62,290.29)">
                     <g class="nad-active">
                         <g transform="rotate(41.21)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -286,8 +286,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="32">
             <desc>L6-13-1</desc>
             <g id="32.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="234.93,14.73 344.14,164.03"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(254.11,40.96)">
+                <polyline class="nad-edge-path" points="234.93,14.73 344.14,164.03"/>
+                <g class="nad-edge-infos" transform="translate(254.11,40.96)">
                     <g class="nad-active">
                         <g transform="rotate(143.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -298,8 +298,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="32.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="453.35,313.34 344.14,164.03"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(434.16,287.10)">
+                <polyline class="nad-edge-path" points="453.35,313.34 344.14,164.03"/>
+                <g class="nad-edge-infos" transform="translate(434.16,287.10)">
                     <g class="nad-active">
                         <g transform="rotate(-36.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -313,8 +313,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="33">
             <desc>L13-14-1</desc>
             <g id="33.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="443.61,339.86 290.26,376.58"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(412.00,347.42)">
+                <polyline class="nad-edge-path" points="443.61,339.86 290.26,376.58"/>
+                <g class="nad-edge-infos" transform="translate(412.00,347.42)">
                     <g class="nad-active">
                         <g transform="rotate(-103.47)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -325,8 +325,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="33.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="136.91,413.30 290.26,376.58"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(168.52,405.73)">
+                <polyline class="nad-edge-path" points="136.91,413.30 290.26,376.58"/>
+                <g class="nad-edge-infos" transform="translate(168.52,405.73)">
                     <g class="nad-active">
                         <g transform="rotate(76.53)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -340,8 +340,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="34">
             <desc>L9-14-1</desc>
             <g id="34.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-124.89,-76.12 -11.89,160.06"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-102.23,-28.76)">
+                <polyline class="nad-edge-path" points="-124.89,-76.12 -11.89,160.06"/>
+                <g class="nad-edge-infos" transform="translate(-102.23,-28.76)">
                     <g class="nad-active">
                         <g transform="rotate(154.43)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -352,8 +352,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="34.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="101.11,396.24 -11.89,160.06"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(87.08,366.92)">
+                <polyline class="nad-edge-path" points="101.11,396.24 -11.89,160.06"/>
+                <g class="nad-edge-infos" transform="translate(87.08,366.92)">
                     <g class="nad-active">
                         <g transform="rotate(-25.57)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -367,8 +367,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="35">
             <desc>L2-3-1</desc>
             <g id="35.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="87.83,-382.63 220.71,-372.43"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(120.23,-380.14)">
+                <polyline class="nad-edge-path" points="87.83,-382.63 220.71,-372.43"/>
+                <g class="nad-edge-infos" transform="translate(120.23,-380.14)">
                     <g class="nad-active">
                         <g transform="rotate(94.39)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -379,8 +379,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="35.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="353.59,-362.22 220.71,-372.43"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(321.18,-364.71)">
+                <polyline class="nad-edge-path" points="353.59,-362.22 220.71,-372.43"/>
+                <g class="nad-edge-infos" transform="translate(321.18,-364.71)">
                     <g class="nad-active">
                         <g transform="rotate(-85.61)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -394,8 +394,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="36">
             <desc>L2-4-1</desc>
             <g id="36.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="47.33,-364.02 -30.04,-258.46"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(28.11,-337.80)">
+                <polyline class="nad-edge-path" points="47.33,-364.02 -30.04,-258.46"/>
+                <g class="nad-edge-infos" transform="translate(28.11,-337.80)">
                     <g class="nad-active">
                         <g transform="rotate(-143.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -406,8 +406,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="36.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-107.40,-152.91 -30.04,-258.46"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-88.19,-179.12)">
+                <polyline class="nad-edge-path" points="-107.40,-152.91 -30.04,-258.46"/>
+                <g class="nad-edge-infos" transform="translate(-88.19,-179.12)">
                     <g class="nad-active">
                         <g transform="rotate(36.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -421,8 +421,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="37">
             <desc>L2-5-1</desc>
             <g id="37.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="71.75,-360.86 132.28,-207.32"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(83.67,-330.62)">
+                <polyline class="nad-edge-path" points="71.75,-360.86 132.28,-207.32"/>
+                <g class="nad-edge-infos" transform="translate(83.67,-330.62)">
                     <g class="nad-active">
                         <g transform="rotate(158.48)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -433,8 +433,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="37.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="192.81,-53.79 132.28,-207.32"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(169.88,-111.93)">
+                <polyline class="nad-edge-path" points="192.81,-53.79 132.28,-207.32"/>
+                <g class="nad-edge-infos" transform="translate(169.88,-111.93)">
                     <g class="nad-active">
                         <g transform="rotate(-21.52)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -448,8 +448,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="38">
             <desc>L3-4-1</desc>
             <g id="38.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="356.07,-349.13 132.89,-240.76"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(326.84,-334.94)">
+                <polyline class="nad-edge-path" points="356.07,-349.13 132.89,-240.76"/>
+                <g class="nad-edge-infos" transform="translate(326.84,-334.94)">
                     <g class="nad-active">
                         <g transform="rotate(-115.90)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -460,8 +460,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="38.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-90.28,-132.39 132.89,-240.76"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-61.05,-146.59)">
+                <polyline class="nad-edge-path" points="-90.28,-132.39 132.89,-240.76"/>
+                <g class="nad-edge-infos" transform="translate(-61.05,-146.59)">
                     <g class="nad-active">
                         <g transform="rotate(64.10)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -475,8 +475,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="39">
             <desc>L4-5-1</desc>
             <g id="39.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-86.10,-95.81 45.60,-65.77"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-54.41,-88.58)">
+                <polyline class="nad-edge-path" points="-86.10,-95.81 45.60,-65.77"/>
+                <g class="nad-edge-infos" transform="translate(-54.41,-88.58)">
                     <g class="nad-active">
                         <g transform="rotate(102.85)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -487,8 +487,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="39.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="177.30,-35.73 45.60,-65.77"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(116.36,-49.63)">
+                <polyline class="nad-edge-path" points="177.30,-35.73 45.60,-65.77"/>
+                <g class="nad-edge-infos" transform="translate(116.36,-49.63)">
                     <g class="nad-active">
                         <g transform="rotate(-77.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -502,8 +502,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="40">
             <desc>L7-8-1</desc>
             <g id="40.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-151.72,-118.53 -326.82,-276.46"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-205.56,-167.09)">
+                <polyline class="nad-edge-path" points="-151.72,-118.53 -326.82,-276.46"/>
+                <g class="nad-edge-infos" transform="translate(-205.56,-167.09)">
                     <g class="nad-active">
                         <g transform="rotate(-47.95)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -514,8 +514,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="40.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-501.91,-434.40 -326.82,-276.46"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-477.78,-412.63)">
+                <polyline class="nad-edge-path" points="-501.91,-434.40 -326.82,-276.46"/>
+                <g class="nad-edge-infos" transform="translate(-477.78,-412.63)">
                     <g class="nad-active">
                         <g transform="rotate(132.05)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -579,7 +579,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl0to30 nad-winding" cx="-225.95" cy="-192.69" r="20.00"/>
                 <circle class="nad-vl0to30 nad-winding" cx="-210.78" cy="-205.72" r="20.00"/>
             </g>
@@ -610,7 +610,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl0to30 nad-winding" cx="-24.12" cy="-140.13" r="20.00"/>
                 <circle class="nad-vl0to30 nad-winding" cx="-20.43" cy="-120.47" r="20.00"/>
             </g>
@@ -641,7 +641,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl0to30 nad-winding" cx="287.94" cy="-114.57" r="20.00"/>
                 <circle class="nad-vl0to30 nad-winding" cx="300.75" cy="-99.21" r="20.00"/>
             </g>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_disconnection.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_disconnection.svg
@@ -97,8 +97,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="22">
             <desc>L1-2-1</desc>
             <g id="22.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="172.27,-645.72 122.28,-526.91"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(159.67,-615.77)">
+                <polyline class="nad-edge-path" points="172.27,-645.72 122.28,-526.91"/>
+                <g class="nad-edge-infos" transform="translate(159.67,-615.77)">
                     <g class="nad-active">
                         <g transform="rotate(-157.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -109,8 +109,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="22.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="72.29,-408.09 122.28,-526.91"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(84.89,-438.04)">
+                <polyline class="nad-edge-path" points="72.29,-408.09 122.28,-526.91"/>
+                <g class="nad-edge-infos" transform="translate(84.89,-438.04)">
                     <g class="nad-active">
                         <g transform="rotate(22.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -124,8 +124,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="23">
             <desc>L1-5-1</desc>
             <g id="23.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="182.96,-643.74 191.93,-356.89"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(183.97,-611.26)">
+                <polyline class="nad-edge-path" points="182.96,-643.74 191.93,-356.89"/>
+                <g class="nad-edge-infos" transform="translate(183.97,-611.26)">
                     <g class="nad-active">
                         <g transform="rotate(178.21)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -136,8 +136,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="23.2" class="nad-disconnected nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="200.91,-70.05 191.93,-356.89"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(199.89,-102.53)">
+                <polyline class="nad-edge-path" points="200.91,-70.05 191.93,-356.89"/>
+                <g class="nad-edge-infos" transform="translate(199.89,-102.53)">
                     <g class="nad-active">
                         <g transform="rotate(-1.79)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -151,8 +151,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="24">
             <desc>L9-10-1</desc>
             <g id="24.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-190.22,-84.07 -370.40,2.69"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-219.50,-69.97)">
+                <polyline class="nad-edge-path" points="-190.22,-84.07 -370.40,2.69"/>
+                <g class="nad-edge-infos" transform="translate(-219.50,-69.97)">
                     <g class="nad-active">
                         <g transform="rotate(-115.71)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -163,8 +163,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="24.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-550.59,89.46 -370.40,2.69"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-521.31,75.36)">
+                <polyline class="nad-edge-path" points="-550.59,89.46 -370.40,2.69"/>
+                <g class="nad-edge-infos" transform="translate(-521.31,75.36)">
                     <g class="nad-active">
                         <g transform="rotate(64.29)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -178,8 +178,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="25">
             <desc>L10-11-1</desc>
             <g id="25.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-553.14,115.79 -434.62,204.42"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-527.12,135.25)">
+                <polyline class="nad-edge-path" points="-553.14,115.79 -434.62,204.42"/>
+                <g class="nad-edge-infos" transform="translate(-527.12,135.25)">
                     <g class="nad-active">
                         <g transform="rotate(126.79)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -190,8 +190,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="25.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-316.10,293.04 -434.62,204.42"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-342.13,273.58)">
+                <polyline class="nad-edge-path" points="-316.10,293.04 -434.62,204.42"/>
+                <g class="nad-edge-infos" transform="translate(-342.13,273.58)">
                     <g class="nad-active">
                         <g transform="rotate(-53.21)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -205,8 +205,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="26">
             <desc>L6-11-1</desc>
             <g id="26.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="181.07,-15.73 -46.76,139.12"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(154.19,2.54)">
+                <polyline class="nad-edge-path" points="181.07,-15.73 -46.76,139.12"/>
+                <g class="nad-edge-infos" transform="translate(154.19,2.54)">
                     <g class="nad-active">
                         <g transform="rotate(-124.20)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -217,8 +217,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="26.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-274.59,293.98 -46.76,139.12"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-247.71,275.71)">
+                <polyline class="nad-edge-path" points="-274.59,293.98 -46.76,139.12"/>
+                <g class="nad-edge-infos" transform="translate(-247.71,275.71)">
                     <g class="nad-active">
                         <g transform="rotate(55.80)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -232,8 +232,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="27">
             <desc>L6-12-1</desc>
             <g id="27.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="227.08,-24.69 448.17,23.03"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(258.85,-17.83)">
+                <polyline class="nad-edge-path" points="227.08,-24.69 448.17,23.03"/>
+                <g class="nad-edge-infos" transform="translate(258.85,-17.83)">
                     <g class="nad-active">
                         <g transform="rotate(102.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -244,8 +244,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="27.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="669.26,70.75 448.17,23.03"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(637.49,63.89)">
+                <polyline class="nad-edge-path" points="669.26,70.75 448.17,23.03"/>
+                <g class="nad-edge-infos" transform="translate(637.49,63.89)">
                     <g class="nad-active">
                         <g transform="rotate(-77.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -259,8 +259,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="28">
             <desc>L12-13-1</desc>
             <g id="28.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="677.38,95.31 581.29,205.02"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(655.97,119.76)">
+                <polyline class="nad-edge-path" points="677.38,95.31 581.29,205.02"/>
+                <g class="nad-edge-infos" transform="translate(655.97,119.76)">
                     <g class="nad-active">
                         <g transform="rotate(-138.79)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -271,8 +271,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="28.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="485.20,314.73 581.29,205.02"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(506.62,290.29)">
+                <polyline class="nad-edge-path" points="485.20,314.73 581.29,205.02"/>
+                <g class="nad-edge-infos" transform="translate(506.62,290.29)">
                     <g class="nad-active">
                         <g transform="rotate(41.21)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -286,8 +286,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="29">
             <desc>L6-13-1</desc>
             <g id="29.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="217.21,-9.48 335.28,151.93"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(236.40,16.75)">
+                <polyline class="nad-edge-path" points="217.21,-9.48 335.28,151.93"/>
+                <g class="nad-edge-infos" transform="translate(236.40,16.75)">
                     <g class="nad-active">
                         <g transform="rotate(143.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -298,8 +298,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="29.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="453.35,313.34 335.28,151.93"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(434.16,287.10)">
+                <polyline class="nad-edge-path" points="453.35,313.34 335.28,151.93"/>
+                <g class="nad-edge-infos" transform="translate(434.16,287.10)">
                     <g class="nad-active">
                         <g transform="rotate(-36.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -313,8 +313,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="30" class="nad-disconnected">
             <desc>L13-14-1</desc>
             <g id="30.1" class="nad-disconnected nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="443.61,339.86 297.31,374.89"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(412.00,347.42)">
+                <polyline class="nad-edge-path" points="443.61,339.86 297.31,374.89"/>
+                <g class="nad-edge-infos" transform="translate(412.00,347.42)">
                     <g class="nad-active">
                         <g transform="rotate(-103.47)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -325,8 +325,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="30.2" class="nad-disconnected nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="151.01,409.92 297.31,374.89"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(182.62,402.35)">
+                <polyline class="nad-edge-path" points="151.01,409.92 297.31,374.89"/>
+                <g class="nad-edge-infos" transform="translate(182.62,402.35)">
                     <g class="nad-active">
                         <g transform="rotate(76.53)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -340,8 +340,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="31" class="nad-disconnected">
             <desc>L9-14-1</desc>
             <g id="31.1" class="nad-disconnected nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-116.26,-58.08 -10.70,162.54"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-102.23,-28.76)">
+                <polyline class="nad-edge-path" points="-116.26,-58.08 -10.70,162.54"/>
+                <g class="nad-edge-infos" transform="translate(-102.23,-28.76)">
                     <g class="nad-active">
                         <g transform="rotate(154.43)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -352,8 +352,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="31.2" class="nad-disconnected nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="94.85,383.16 -10.70,162.54"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(80.82,353.84)">
+                <polyline class="nad-edge-path" points="94.85,383.16 -10.70,162.54"/>
+                <g class="nad-edge-infos" transform="translate(80.82,353.84)">
                     <g class="nad-active">
                         <g transform="rotate(-25.57)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -367,8 +367,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="32">
             <desc>L2-3-1</desc>
             <g id="32.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="87.83,-382.63 220.71,-372.43"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(120.23,-380.14)">
+                <polyline class="nad-edge-path" points="87.83,-382.63 220.71,-372.43"/>
+                <g class="nad-edge-infos" transform="translate(120.23,-380.14)">
                     <g class="nad-active">
                         <g transform="rotate(94.39)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -379,8 +379,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="32.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="353.59,-362.22 220.71,-372.43"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(321.18,-364.71)">
+                <polyline class="nad-edge-path" points="353.59,-362.22 220.71,-372.43"/>
+                <g class="nad-edge-infos" transform="translate(321.18,-364.71)">
                     <g class="nad-active">
                         <g transform="rotate(-85.61)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -394,8 +394,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="33">
             <desc>L2-4-1</desc>
             <g id="33.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="47.33,-364.02 -25.75,-264.31"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(28.11,-337.80)">
+                <polyline class="nad-edge-path" points="47.33,-364.02 -25.75,-264.31"/>
+                <g class="nad-edge-infos" transform="translate(28.11,-337.80)">
                     <g class="nad-active">
                         <g transform="rotate(-143.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -406,8 +406,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="33.2" class="nad-disconnected nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-98.83,-164.61 -25.75,-264.31"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-79.62,-190.82)">
+                <polyline class="nad-edge-path" points="-98.83,-164.61 -25.75,-264.31"/>
+                <g class="nad-edge-infos" transform="translate(-79.62,-190.82)">
                     <g class="nad-active">
                         <g transform="rotate(36.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -421,8 +421,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="34">
             <desc>L2-5-1</desc>
             <g id="34.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="71.75,-360.86 129.62,-214.07"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(83.67,-330.62)">
+                <polyline class="nad-edge-path" points="71.75,-360.86 129.62,-214.07"/>
+                <g class="nad-edge-infos" transform="translate(83.67,-330.62)">
                     <g class="nad-active">
                         <g transform="rotate(158.48)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -433,8 +433,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="34.2" class="nad-disconnected nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="187.49,-67.28 129.62,-214.07"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(175.57,-97.51)">
+                <polyline class="nad-edge-path" points="187.49,-67.28 129.62,-214.07"/>
+                <g class="nad-edge-infos" transform="translate(175.57,-97.51)">
                     <g class="nad-active">
                         <g transform="rotate(-21.52)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -448,8 +448,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="35" class="nad-disconnected">
             <desc>L3-4-1</desc>
             <g id="35.1" class="nad-disconnected nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="356.07,-349.13 139.42,-243.93"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(326.84,-334.94)">
+                <polyline class="nad-edge-path" points="356.07,-349.13 139.42,-243.93"/>
+                <g class="nad-edge-infos" transform="translate(326.84,-334.94)">
                     <g class="nad-active">
                         <g transform="rotate(-115.90)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -460,8 +460,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="35.2" class="nad-disconnected nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-77.24,-138.72 139.42,-243.93"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-48.01,-152.92)">
+                <polyline class="nad-edge-path" points="-77.24,-138.72 139.42,-243.93"/>
+                <g class="nad-edge-infos" transform="translate(-48.01,-152.92)">
                     <g class="nad-active">
                         <g transform="rotate(64.10)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -475,8 +475,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="36" class="nad-disconnected">
             <desc>L4-5-1</desc>
             <g id="36.1" class="nad-disconnected nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-71.96,-92.58 45.60,-65.77"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-40.28,-85.35)">
+                <polyline class="nad-edge-path" points="-71.96,-92.58 45.60,-65.77"/>
+                <g class="nad-edge-infos" transform="translate(-40.28,-85.35)">
                     <g class="nad-active">
                         <g transform="rotate(102.85)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -487,8 +487,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="36.2" class="nad-disconnected nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="163.16,-38.96 45.60,-65.77"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(131.47,-46.19)">
+                <polyline class="nad-edge-path" points="163.16,-38.96 45.60,-65.77"/>
+                <g class="nad-edge-infos" transform="translate(131.47,-46.19)">
                     <g class="nad-active">
                         <g transform="rotate(-77.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -502,8 +502,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="37">
             <desc>L7-8-1</desc>
             <g id="37.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-159.15,-125.23 -330.53,-279.81"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-205.56,-167.09)">
+                <polyline class="nad-edge-path" points="-159.15,-125.23 -330.53,-279.81"/>
+                <g class="nad-edge-infos" transform="translate(-205.56,-167.09)">
                     <g class="nad-active">
                         <g transform="rotate(-47.95)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -514,8 +514,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="37.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-501.91,-434.40 -330.53,-279.81"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-477.78,-412.63)">
+                <polyline class="nad-edge-path" points="-501.91,-434.40 -330.53,-279.81"/>
+                <g class="nad-edge-infos" transform="translate(-477.78,-412.63)">
                     <g class="nad-active">
                         <g transform="rotate(132.05)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -579,7 +579,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-disconnected nad-vl0to30 nad-winding" cx="-225.95" cy="-192.69" r="20.00"/>
                 <circle class="nad-vl0to30 nad-winding" cx="-210.78" cy="-205.72" r="20.00"/>
             </g>
@@ -610,7 +610,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-disconnected nad-vl0to30 nad-winding" cx="-24.12" cy="-140.13" r="20.00"/>
                 <circle class="nad-vl0to30 nad-winding" cx="-20.43" cy="-120.47" r="20.00"/>
             </g>
@@ -641,7 +641,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-disconnected nad-vl0to30 nad-winding" cx="287.94" cy="-114.57" r="20.00"/>
                 <circle class="nad-vl0to30 nad-winding" cx="300.75" cy="-99.21" r="20.00"/>
             </g>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_fictitious.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_fictitious.svg
@@ -106,8 +106,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="28">
             <desc>L1-2-1</desc>
             <g id="28.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="390.84,-874.92 467.85,-719.67"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(405.28,-845.81)">
+                <polyline class="nad-edge-path" points="390.84,-874.92 467.85,-719.67"/>
+                <g class="nad-edge-infos" transform="translate(405.28,-845.81)">
                     <g class="nad-active">
                         <g transform="rotate(153.61)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -118,8 +118,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="28.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="544.87,-564.41 467.85,-719.67"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(530.43,-593.53)">
+                <polyline class="nad-edge-path" points="544.87,-564.41 467.85,-719.67"/>
+                <g class="nad-edge-infos" transform="translate(530.43,-593.53)">
                     <g class="nad-active">
                         <g transform="rotate(-26.39)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -133,8 +133,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="29">
             <desc>L1-5-1</desc>
             <g id="29.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="366.82,-875.64 277.59,-719.97"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(350.66,-847.44)">
+                <polyline class="nad-edge-path" points="366.82,-875.64 277.59,-719.97"/>
+                <g class="nad-edge-infos" transform="translate(350.66,-847.44)">
                     <g class="nad-active">
                         <g transform="rotate(-150.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -145,8 +145,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="29.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="188.36,-564.31 277.59,-719.97"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(204.52,-592.50)">
+                <polyline class="nad-edge-path" points="188.36,-564.31 277.59,-719.97"/>
+                <g class="nad-edge-infos" transform="translate(204.52,-592.50)">
                     <g class="nad-active">
                         <g transform="rotate(29.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -160,8 +160,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="30">
             <desc>L9-10-1</desc>
             <g id="30.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="62.59,339.48 -249.07,332.57"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(30.10,338.76)">
+                <polyline class="nad-edge-path" points="62.59,339.48 -249.07,332.57"/>
+                <g class="nad-edge-infos" transform="translate(30.10,338.76)">
                     <g class="nad-active">
                         <g transform="rotate(-88.73)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -172,8 +172,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="30.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-560.72,325.65 -249.07,332.57"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-528.23,326.37)">
+                <polyline class="nad-edge-path" points="-560.72,325.65 -249.07,332.57"/>
+                <g class="nad-edge-infos" transform="translate(-528.23,326.37)">
                     <g class="nad-active">
                         <g transform="rotate(91.27)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -187,8 +187,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="31">
             <desc>L10-11-1</desc>
             <g id="31.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-597.01,301.99 -683.85,116.23"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-610.78,272.54)">
+                <polyline class="nad-edge-path" points="-597.01,301.99 -683.85,116.23"/>
+                <g class="nad-edge-infos" transform="translate(-610.78,272.54)">
                     <g class="nad-active">
                         <g transform="rotate(-25.05)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -199,8 +199,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="31.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-770.69,-69.53 -683.85,116.23"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-756.92,-40.09)">
+                <polyline class="nad-edge-path" points="-770.69,-69.53 -683.85,116.23"/>
+                <g class="nad-edge-infos" transform="translate(-756.92,-40.09)">
                     <g class="nad-active">
                         <g transform="rotate(154.95)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -214,8 +214,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="32">
             <desc>L6-11-1</desc>
             <g id="32.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-424.87,-353.00 -592.88,-230.34"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-451.12,-333.84)">
+                <polyline class="nad-edge-path" points="-424.87,-353.00 -592.88,-230.34"/>
+                <g class="nad-edge-infos" transform="translate(-451.12,-333.84)">
                     <g class="nad-active">
                         <g transform="rotate(-126.13)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -226,8 +226,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="32.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-760.89,-107.67 -592.88,-230.34"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-734.64,-126.83)">
+                <polyline class="nad-edge-path" points="-760.89,-107.67 -592.88,-230.34"/>
+                <g class="nad-edge-infos" transform="translate(-734.64,-126.83)">
                     <g class="nad-active">
                         <g transform="rotate(53.87)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -241,8 +241,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="33">
             <desc>L6-12-1</desc>
             <g id="33.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-382.10,-355.46 -274.09,-294.19"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-353.83,-339.42)">
+                <polyline class="nad-edge-path" points="-382.10,-355.46 -274.09,-294.19"/>
+                <g class="nad-edge-infos" transform="translate(-353.83,-339.42)">
                     <g class="nad-active">
                         <g transform="rotate(119.56)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -253,8 +253,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="33.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-166.08,-232.92 -274.09,-294.19"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-194.35,-248.96)">
+                <polyline class="nad-edge-path" points="-166.08,-232.92 -274.09,-294.19"/>
+                <g class="nad-edge-infos" transform="translate(-194.35,-248.96)">
                     <g class="nad-active">
                         <g transform="rotate(-60.44)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -268,8 +268,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="34">
             <desc>L12-13-1</desc>
             <g id="34.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-161.45,-218.26 -225.22,-83.99"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-175.39,-188.90)">
+                <polyline class="nad-edge-path" points="-161.45,-218.26 -225.22,-83.99"/>
+                <g class="nad-edge-infos" transform="translate(-175.39,-188.90)">
                     <g class="nad-active">
                         <g transform="rotate(-154.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -280,8 +280,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="34.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-289.00,50.28 -225.22,-83.99"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-275.05,20.93)">
+                <polyline class="nad-edge-path" points="-289.00,50.28 -225.22,-83.99"/>
+                <g class="nad-edge-infos" transform="translate(-275.05,20.93)">
                     <g class="nad-active">
                         <g transform="rotate(25.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -295,8 +295,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="35">
             <desc>L6-13-1</desc>
             <g id="35.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-398.41,-343.22 -352.11,-147.36"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-390.93,-311.60)">
+                <polyline class="nad-edge-path" points="-398.41,-343.22 -352.11,-147.36"/>
+                <g class="nad-edge-infos" transform="translate(-390.93,-311.60)">
                     <g class="nad-active">
                         <g transform="rotate(166.70)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -307,8 +307,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="35.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-305.80,48.50 -352.11,-147.36"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-313.28,16.87)">
+                <polyline class="nad-edge-path" points="-305.80,48.50 -352.11,-147.36"/>
+                <g class="nad-edge-infos" transform="translate(-313.28,16.87)">
                     <g class="nad-active">
                         <g transform="rotate(-13.30)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -322,8 +322,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="36">
             <desc>L13-14-1</desc>
             <g id="36.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-294.89,98.31 -249.72,322.22"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-288.47,130.17)">
+                <polyline class="nad-edge-path" points="-294.89,98.31 -249.72,322.22"/>
+                <g class="nad-edge-infos" transform="translate(-288.47,130.17)">
                     <g class="nad-active">
                         <g transform="rotate(168.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -334,8 +334,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="36.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-204.55,546.12 -249.72,322.22"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-210.98,514.26)">
+                <polyline class="nad-edge-path" points="-204.55,546.12 -249.72,322.22"/>
+                <g class="nad-edge-infos" transform="translate(-210.98,514.26)">
                     <g class="nad-active">
                         <g transform="rotate(-11.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -349,8 +349,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="37">
             <desc>L9-14-1</desc>
             <g id="37.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="67.63,355.28 -63.21,452.71"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(41.57,374.69)">
+                <polyline class="nad-edge-path" points="67.63,355.28 -63.21,452.71"/>
+                <g class="nad-edge-infos" transform="translate(41.57,374.69)">
                     <g class="nad-active">
                         <g transform="rotate(-126.67)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -361,8 +361,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="37.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-194.05,550.14 -63.21,452.71"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-167.98,530.73)">
+                <polyline class="nad-edge-path" points="-194.05,550.14 -63.21,452.71"/>
+                <g class="nad-edge-infos" transform="translate(-167.98,530.73)">
                     <g class="nad-active">
                         <g transform="rotate(53.33)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -376,8 +376,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="38">
             <desc>L2-3-1</desc>
             <g id="38.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="575.95,-525.43 700.51,-423.67"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(601.12,-504.87)">
+                <polyline class="nad-edge-path" points="575.95,-525.43 700.51,-423.67"/>
+                <g class="nad-edge-infos" transform="translate(601.12,-504.87)">
                     <g class="nad-active">
                         <g transform="rotate(129.25)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -388,8 +388,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="38.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="825.06,-321.90 700.51,-423.67"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(799.89,-342.46)">
+                <polyline class="nad-edge-path" points="825.06,-321.90 700.51,-423.67"/>
+                <g class="nad-edge-infos" transform="translate(799.89,-342.46)">
                     <g class="nad-active">
                         <g transform="rotate(-50.75)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -403,8 +403,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="39">
             <desc>L2-4-1</desc>
             <g id="39.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="550.76,-516.66 508.07,-321.54"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(543.81,-484.91)">
+                <polyline class="nad-edge-path" points="550.76,-516.66 508.07,-321.54"/>
+                <g class="nad-edge-infos" transform="translate(543.81,-484.91)">
                     <g class="nad-active">
                         <g transform="rotate(-167.66)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -415,8 +415,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="39.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="465.38,-126.42 508.07,-321.54"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(472.32,-158.17)">
+                <polyline class="nad-edge-path" points="465.38,-126.42 508.07,-321.54"/>
+                <g class="nad-edge-infos" transform="translate(472.32,-158.17)">
                     <g class="nad-active">
                         <g transform="rotate(12.34)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -430,8 +430,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="40">
             <desc>L2-5-1</desc>
             <g id="40.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="530.71,-541.61 365.94,-541.88"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(498.21,-541.66)">
+                <polyline class="nad-edge-path" points="530.71,-541.61 365.94,-541.88"/>
+                <g class="nad-edge-infos" transform="translate(498.21,-541.66)">
                     <g class="nad-active">
                         <g transform="rotate(-89.91)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -442,8 +442,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="40.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="201.18,-542.14 365.94,-541.88"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(233.68,-542.09)">
+                <polyline class="nad-edge-path" points="201.18,-542.14 365.94,-541.88"/>
+                <g class="nad-edge-infos" transform="translate(233.68,-542.09)">
                     <g class="nad-active">
                         <g transform="rotate(90.09)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -457,8 +457,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="41">
             <desc>L3-4-1</desc>
             <g id="41.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="822.28,-293.81 652.36,-203.64"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(793.57,-278.58)">
+                <polyline class="nad-edge-path" points="822.28,-293.81 652.36,-203.64"/>
+                <g class="nad-edge-infos" transform="translate(793.57,-278.58)">
                     <g class="nad-active">
                         <g transform="rotate(-117.96)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -469,8 +469,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="41.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="482.45,-113.46 652.36,-203.64"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(511.16,-128.70)">
+                <polyline class="nad-edge-path" points="482.45,-113.46 652.36,-203.64"/>
+                <g class="nad-edge-infos" transform="translate(511.16,-128.70)">
                     <g class="nad-active">
                         <g transform="rotate(62.04)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -484,8 +484,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="42">
             <desc>L4-5-1</desc>
             <g id="42.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="446.10,-122.94 317.80,-321.85"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(428.49,-150.25)">
+                <polyline class="nad-edge-path" points="446.10,-122.94 317.80,-321.85"/>
+                <g class="nad-edge-infos" transform="translate(428.49,-150.25)">
                     <g class="nad-active">
                         <g transform="rotate(-32.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -496,8 +496,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="42.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="189.50,-520.76 317.80,-321.85"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(207.12,-493.44)">
+                <polyline class="nad-edge-path" points="189.50,-520.76 317.80,-321.85"/>
+                <g class="nad-edge-infos" transform="translate(207.12,-493.44)">
                     <g class="nad-active">
                         <g transform="rotate(147.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -511,8 +511,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="43">
             <desc>T4-7-1</desc>
             <g id="43.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="463.46,-76.25 489.26,107.81"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(467.97,-44.07)">
+                <polyline class="nad-edge-path" points="463.46,-76.25 489.26,107.81"/>
+                <g class="nad-edge-infos" transform="translate(467.97,-44.07)">
                     <g class="nad-active">
                         <g transform="rotate(172.02)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -523,8 +523,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="43.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="523.38,351.30 497.59,167.23"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(518.87,319.12)">
+                <polyline class="nad-edge-path" points="523.38,351.30 497.59,167.23"/>
+                <g class="nad-edge-infos" transform="translate(518.87,319.12)">
                     <g class="nad-active">
                         <g transform="rotate(-7.98)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -534,7 +534,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl120to180 nad-winding" cx="492.04" cy="127.62" r="20.00"/>
                 <circle class="nad-vl0to30 nad-winding" cx="494.81" cy="147.43" r="20.00"/>
             </g>
@@ -542,8 +542,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="44">
             <desc>T4-9-1</desc>
             <g id="44.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="443.50,-82.00 293.33,96.32"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(422.56,-57.14)">
+                <polyline class="nad-edge-path" points="443.50,-82.00 293.33,96.32"/>
+                <g class="nad-edge-infos" transform="translate(422.56,-57.14)">
                     <g class="nad-active">
                         <g transform="rotate(-139.90)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -554,8 +554,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="44.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="104.51,320.54 254.68,142.22"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(125.44,295.68)">
+                <polyline class="nad-edge-path" points="104.51,320.54 254.68,142.22"/>
+                <g class="nad-edge-infos" transform="translate(125.44,295.68)">
                     <g class="nad-active">
                         <g transform="rotate(40.10)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -565,7 +565,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl120to180 nad-winding" cx="280.45" cy="111.62" r="20.00"/>
                 <circle class="nad-vl0to30 nad-winding" cx="267.56" cy="126.92" r="20.00"/>
             </g>
@@ -573,8 +573,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="45">
             <desc>T5-6-1</desc>
             <g id="45.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="151.26,-534.85 -85.57,-463.74"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(120.13,-525.50)">
+                <polyline class="nad-edge-path" points="151.26,-534.85 -85.57,-463.74"/>
+                <g class="nad-edge-infos" transform="translate(120.13,-525.50)">
                     <g class="nad-active">
                         <g transform="rotate(-106.71)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -585,8 +585,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="45.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-379.86,-375.37 -143.03,-446.49"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-348.73,-384.72)">
+                <polyline class="nad-edge-path" points="-379.86,-375.37 -143.03,-446.49"/>
+                <g class="nad-edge-infos" transform="translate(-348.73,-384.72)">
                     <g class="nad-active">
                         <g transform="rotate(73.29)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -596,7 +596,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl120to180 nad-winding" cx="-104.72" cy="-457.99" r="20.00"/>
                 <circle class="nad-vl0to30 nad-winding" cx="-123.88" cy="-452.24" r="20.00"/>
             </g>
@@ -604,8 +604,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="46">
             <desc>L7-8-1</desc>
             <g id="46.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="543.84,395.63 666.97,534.43"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(565.41,419.94)">
+                <polyline class="nad-edge-path" points="543.84,395.63 666.97,534.43"/>
+                <g class="nad-edge-infos" transform="translate(565.41,419.94)">
                     <g class="nad-active">
                         <g transform="rotate(138.42)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -616,8 +616,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="46.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="790.10,673.23 666.97,534.43"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(768.53,648.91)">
+                <polyline class="nad-edge-path" points="790.10,673.23 666.97,534.43"/>
+                <g class="nad-edge-infos" transform="translate(768.53,648.91)">
                     <g class="nad-active">
                         <g transform="rotate(-41.58)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -631,8 +631,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="47">
             <desc>L7-9-1</desc>
             <g id="47.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="501.51,374.44 307.50,358.30"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(469.12,371.75)">
+                <polyline class="nad-edge-path" points="501.51,374.44 307.50,358.30"/>
+                <g class="nad-edge-infos" transform="translate(469.12,371.75)">
                     <g class="nad-active">
                         <g transform="rotate(-85.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -643,8 +643,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="47.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="113.50,342.16 307.50,358.30"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(145.88,344.85)">
+                <polyline class="nad-edge-path" points="113.50,342.16 307.50,358.30"/>
+                <g class="nad-edge-infos" transform="translate(145.88,344.85)">
                     <g class="nad-active">
                         <g transform="rotate(94.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_text_nodes.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_text_nodes.svg
@@ -106,8 +106,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="28">
             <desc>L1-2-1</desc>
             <g id="28.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1165.81,211.87 1006.86,198.76"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1133.42,209.19)">
+                <polyline class="nad-edge-path" points="1165.81,211.87 1006.86,198.76"/>
+                <g class="nad-edge-infos" transform="translate(1133.42,209.19)">
                     <g class="nad-active">
                         <g transform="rotate(-85.29)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -118,8 +118,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="28.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="847.91,185.65 1006.86,198.76"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(880.30,188.32)">
+                <polyline class="nad-edge-path" points="847.91,185.65 1006.86,198.76"/>
+                <g class="nad-edge-infos" transform="translate(880.30,188.32)">
                     <g class="nad-active">
                         <g transform="rotate(94.71)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -133,8 +133,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="29">
             <desc>L1-5-1</desc>
             <g id="29.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1169.89,199.99 932.83,44.68"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1142.70,182.18)">
+                <polyline class="nad-edge-path" points="1169.89,199.99 932.83,44.68"/>
+                <g class="nad-edge-infos" transform="translate(1142.70,182.18)">
                     <g class="nad-active">
                         <g transform="rotate(-56.77)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -145,8 +145,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="29.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="695.78,-110.62 932.83,44.68"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(722.96,-92.81)">
+                <polyline class="nad-edge-path" points="695.78,-110.62 932.83,44.68"/>
+                <g class="nad-edge-infos" transform="translate(722.96,-92.81)">
                     <g class="nad-active">
                         <g transform="rotate(123.23)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -160,8 +160,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="30">
             <desc>L9-10-1</desc>
             <g id="30.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-427.58,312.84 -724.27,60.01"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-452.31,291.76)">
+                <polyline class="nad-edge-path" points="-427.58,312.84 -724.27,60.01"/>
+                <g class="nad-edge-infos" transform="translate(-452.31,291.76)">
                     <g class="nad-active">
                         <g transform="rotate(-49.56)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -172,8 +172,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="30.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1020.97,-192.81 -724.27,60.01"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-996.23,-171.73)">
+                <polyline class="nad-edge-path" points="-1020.97,-192.81 -724.27,60.01"/>
+                <g class="nad-edge-infos" transform="translate(-996.23,-171.73)">
                     <g class="nad-active">
                         <g transform="rotate(130.44)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -187,8 +187,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="31">
             <desc>L10-11-1</desc>
             <g id="31.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1031.43,-233.23 -936.48,-486.71"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1020.03,-263.66)">
+                <polyline class="nad-edge-path" points="-1031.43,-233.23 -936.48,-486.71"/>
+                <g class="nad-edge-infos" transform="translate(-1020.03,-263.66)">
                     <g class="nad-active">
                         <g transform="rotate(20.53)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -199,8 +199,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="31.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-841.53,-740.20 -936.48,-486.71"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-852.93,-709.76)">
+                <polyline class="nad-edge-path" points="-841.53,-740.20 -936.48,-486.71"/>
+                <g class="nad-edge-infos" transform="translate(-852.93,-709.76)">
                     <g class="nad-active">
                         <g transform="rotate(-159.47)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -214,8 +214,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="32">
             <desc>L6-11-1</desc>
             <g id="32.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-172.86,-702.75 -490.03,-732.23"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-205.22,-705.75)">
+                <polyline class="nad-edge-path" points="-172.86,-702.75 -490.03,-732.23"/>
+                <g class="nad-edge-infos" transform="translate(-205.22,-705.75)">
                     <g class="nad-active">
                         <g transform="rotate(-84.69)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -226,8 +226,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="32.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-807.20,-761.72 -490.03,-732.23"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-774.84,-758.71)">
+                <polyline class="nad-edge-path" points="-807.20,-761.72 -490.03,-732.23"/>
+                <g class="nad-edge-infos" transform="translate(-774.84,-758.71)">
                     <g class="nad-active">
                         <g transform="rotate(95.31)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -241,8 +241,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="33">
             <desc>L6-12-1</desc>
             <g id="33.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-130.50,-719.43 -43.07,-817.57"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-108.89,-743.69)">
+                <polyline class="nad-edge-path" points="-130.50,-719.43 -43.07,-817.57"/>
+                <g class="nad-edge-infos" transform="translate(-108.89,-743.69)">
                     <g class="nad-active">
                         <g transform="rotate(41.70)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -253,8 +253,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="33.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="44.35,-915.71 -43.07,-817.57"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(22.74,-891.44)">
+                <polyline class="nad-edge-path" points="44.35,-915.71 -43.07,-817.57"/>
+                <g class="nad-edge-infos" transform="translate(22.74,-891.44)">
                     <g class="nad-active">
                         <g transform="rotate(-138.30)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -268,8 +268,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="34">
             <desc>L12-13-1</desc>
             <g id="34.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="45.39,-914.83 -144.53,-677.23"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(25.10,-889.44)">
+                <polyline class="nad-edge-path" points="45.39,-914.83 -144.53,-677.23"/>
+                <g class="nad-edge-infos" transform="translate(25.10,-889.44)">
                     <g class="nad-active">
                         <g transform="rotate(-141.36)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -280,8 +280,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="34.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-334.45,-439.64 -144.53,-677.23"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-314.16,-465.02)">
+                <polyline class="nad-edge-path" points="-334.45,-439.64 -144.53,-677.23"/>
+                <g class="nad-edge-infos" transform="translate(-314.16,-465.02)">
                     <g class="nad-active">
                         <g transform="rotate(38.64)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -295,8 +295,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="35">
             <desc>L6-13-1</desc>
             <g id="35.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-162.41,-679.72 -248.92,-560.05"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-181.45,-653.38)">
+                <polyline class="nad-edge-path" points="-162.41,-679.72 -248.92,-560.05"/>
+                <g class="nad-edge-infos" transform="translate(-181.45,-653.38)">
                     <g class="nad-active">
                         <g transform="rotate(-144.14)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -307,8 +307,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="35.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-335.43,-440.39 -248.92,-560.05"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-316.39,-466.72)">
+                <polyline class="nad-edge-path" points="-335.43,-440.39 -248.92,-560.05"/>
+                <g class="nad-edge-infos" transform="translate(-316.39,-466.72)">
                     <g class="nad-active">
                         <g transform="rotate(35.86)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -322,8 +322,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="36">
             <desc>L13-14-1</desc>
             <g id="36.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-364.66,-398.60 -550.16,-124.47"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-382.88,-371.68)">
+                <polyline class="nad-edge-path" points="-364.66,-398.60 -550.16,-124.47"/>
+                <g class="nad-edge-infos" transform="translate(-382.88,-371.68)">
                     <g class="nad-active">
                         <g transform="rotate(-145.91)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -334,8 +334,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="36.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-735.66,149.66 -550.16,-124.47"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-717.45,122.75)">
+                <polyline class="nad-edge-path" points="-735.66,149.66 -550.16,-124.47"/>
+                <g class="nad-edge-infos" transform="translate(-717.45,122.75)">
                     <g class="nad-active">
                         <g transform="rotate(34.09)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -349,8 +349,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="37">
             <desc>L9-14-1</desc>
             <g id="37.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-431.30,318.64 -579.06,250.08"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-460.78,304.96)">
+                <polyline class="nad-edge-path" points="-431.30,318.64 -579.06,250.08"/>
+                <g class="nad-edge-infos" transform="translate(-460.78,304.96)">
                     <g class="nad-active">
                         <g transform="rotate(-65.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -361,8 +361,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="37.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-726.82,181.51 -579.06,250.08"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-697.34,195.19)">
+                <polyline class="nad-edge-path" points="-726.82,181.51 -579.06,250.08"/>
+                <g class="nad-edge-infos" transform="translate(-697.34,195.19)">
                     <g class="nad-active">
                         <g transform="rotate(114.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -376,8 +376,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="38">
             <desc>L2-3-1</desc>
             <g id="38.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="822.87,158.05 826.50,-90.07"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(823.34,125.56)">
+                <polyline class="nad-edge-path" points="822.87,158.05 826.50,-90.07"/>
+                <g class="nad-edge-infos" transform="translate(823.34,125.56)">
                     <g class="nad-active">
                         <g transform="rotate(0.84)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -388,8 +388,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="38.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="830.14,-338.20 826.50,-90.07"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(829.66,-305.70)">
+                <polyline class="nad-edge-path" points="830.14,-338.20 826.50,-90.07"/>
+                <g class="nad-edge-infos" transform="translate(829.66,-305.70)">
                     <g class="nad-active">
                         <g transform="rotate(-179.16)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -403,8 +403,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="39">
             <desc>L2-4-1</desc>
             <g id="39.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="797.16,180.66 586.55,156.65"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(764.87,176.98)">
+                <polyline class="nad-edge-path" points="797.16,180.66 586.55,156.65"/>
+                <g class="nad-edge-infos" transform="translate(764.87,176.98)">
                     <g class="nad-active">
                         <g transform="rotate(-83.49)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -415,8 +415,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="39.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="375.93,132.63 586.55,156.65"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(408.23,136.31)">
+                <polyline class="nad-edge-path" points="375.93,132.63 586.55,156.65"/>
+                <g class="nad-edge-infos" transform="translate(408.23,136.31)">
                     <g class="nad-active">
                         <g transform="rotate(96.51)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -430,8 +430,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="40">
             <desc>L2-5-1</desc>
             <g id="40.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="811.45,160.57 748.47,29.48"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(797.38,131.27)">
+                <polyline class="nad-edge-path" points="811.45,160.57 748.47,29.48"/>
+                <g class="nad-edge-infos" transform="translate(797.38,131.27)">
                     <g class="nad-active">
                         <g transform="rotate(-25.66)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -442,8 +442,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="40.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="685.49,-101.61 748.47,29.48"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(699.56,-72.32)">
+                <polyline class="nad-edge-path" points="685.49,-101.61 748.47,29.48"/>
+                <g class="nad-edge-infos" transform="translate(699.56,-72.32)">
                     <g class="nad-active">
                         <g transform="rotate(154.34)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -457,8 +457,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="41">
             <desc>L3-4-1</desc>
             <g id="41.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="812.74,-345.42 590.56,-116.98"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(790.08,-322.12)">
+                <polyline class="nad-edge-path" points="812.74,-345.42 590.56,-116.98"/>
+                <g class="nad-edge-infos" transform="translate(790.08,-322.12)">
                     <g class="nad-active">
                         <g transform="rotate(-135.80)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -469,8 +469,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="41.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="368.38,111.46 590.56,-116.98"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(391.04,88.17)">
+                <polyline class="nad-edge-path" points="368.38,111.46 590.56,-116.98"/>
+                <g class="nad-edge-infos" transform="translate(391.04,88.17)">
                     <g class="nad-active">
                         <g transform="rotate(44.20)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -484,8 +484,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="42">
             <desc>L4-5-1</desc>
             <g id="42.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="370.65,113.99 512.52,2.57"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(396.21,93.92)">
+                <polyline class="nad-edge-path" points="370.65,113.99 512.52,2.57"/>
+                <g class="nad-edge-infos" transform="translate(396.21,93.92)">
                     <g class="nad-active">
                         <g transform="rotate(51.85)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -496,8 +496,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="42.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="654.39,-108.85 512.52,2.57"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(628.83,-88.77)">
+                <polyline class="nad-edge-path" points="654.39,-108.85 512.52,2.57"/>
+                <g class="nad-edge-infos" transform="translate(628.83,-88.77)">
                     <g class="nad-active">
                         <g transform="rotate(-128.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -511,8 +511,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="43">
             <desc>T4-7-1</desc>
             <g id="43.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="338.58,152.23 217.88,377.97"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(323.25,180.89)">
+                <polyline class="nad-edge-path" points="338.58,152.23 217.88,377.97"/>
+                <g class="nad-edge-infos" transform="translate(323.25,180.89)">
                     <g class="nad-active">
                         <g transform="rotate(-151.87)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -523,8 +523,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="43.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="68.90,656.62 189.59,430.88"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(84.22,627.96)">
+                <polyline class="nad-edge-path" points="68.90,656.62 189.59,430.88"/>
+                <g class="nad-edge-infos" transform="translate(84.22,627.96)">
                     <g class="nad-active">
                         <g transform="rotate(28.13)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -534,7 +534,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl120to180 nad-winding" cx="208.45" cy="395.61" r="20.00"/>
                 <circle class="nad-vl0to30 nad-winding" cx="199.02" cy="413.24" r="20.00"/>
             </g>
@@ -542,8 +542,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="44">
             <desc>T4-9-1</desc>
             <g id="44.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="325.94,136.23 0.23,221.93"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(294.51,144.50)">
+                <polyline class="nad-edge-path" points="325.94,136.23 0.23,221.93"/>
+                <g class="nad-edge-infos" transform="translate(294.51,144.50)">
                     <g class="nad-active">
                         <g transform="rotate(-104.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -554,8 +554,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="44.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-383.51,322.89 -57.80,237.19"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-352.08,314.62)">
+                <polyline class="nad-edge-path" points="-383.51,322.89 -57.80,237.19"/>
+                <g class="nad-edge-infos" transform="translate(-352.08,314.62)">
                     <g class="nad-active">
                         <g transform="rotate(75.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -565,7 +565,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl120to180 nad-winding" cx="-19.11" cy="227.02" r="20.00"/>
                 <circle class="nad-vl0to30 nad-winding" cx="-38.46" cy="232.10" r="20.00"/>
             </g>
@@ -573,8 +573,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="45">
             <desc>T5-6-1</desc>
             <g id="45.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="653.56,-139.23 288.06,-395.28"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(626.94,-157.88)">
+                <polyline class="nad-edge-path" points="653.56,-139.23 288.06,-395.28"/>
+                <g class="nad-edge-infos" transform="translate(626.94,-157.88)">
                     <g class="nad-active">
                         <g transform="rotate(-54.99)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -585,8 +585,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="45.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-126.58,-685.76 238.92,-429.70"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-99.96,-667.11)">
+                <polyline class="nad-edge-path" points="-126.58,-685.76 238.92,-429.70"/>
+                <g class="nad-edge-infos" transform="translate(-99.96,-667.11)">
                     <g class="nad-active">
                         <g transform="rotate(125.01)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -596,7 +596,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl120to180 nad-winding" cx="271.68" cy="-406.75" r="20.00"/>
                 <circle class="nad-vl0to30 nad-winding" cx="255.30" cy="-418.23" r="20.00"/>
             </g>
@@ -604,8 +604,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="46">
             <desc>L7-8-1</desc>
             <g id="46.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="60.55,704.34 93.04,927.51"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(65.23,736.50)">
+                <polyline class="nad-edge-path" points="60.55,704.34 93.04,927.51"/>
+                <g class="nad-edge-infos" transform="translate(65.23,736.50)">
                     <g class="nad-active">
                         <g transform="rotate(171.72)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -616,8 +616,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="46.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="125.54,1150.67 93.04,927.51"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(120.85,1118.51)">
+                <polyline class="nad-edge-path" points="125.54,1150.67 93.04,927.51"/>
+                <g class="nad-edge-infos" transform="translate(120.85,1118.51)">
                     <g class="nad-active">
                         <g transform="rotate(-8.28)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -631,8 +631,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="47">
             <desc>L7-9-1</desc>
             <g id="47.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="36.49,663.78 -175.65,504.24"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(10.52,644.24)">
+                <polyline class="nad-edge-path" points="36.49,663.78 -175.65,504.24"/>
+                <g class="nad-edge-infos" transform="translate(10.52,644.24)">
                     <g class="nad-active">
                         <g transform="rotate(-53.06)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -643,8 +643,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="47.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-387.79,344.70 -175.65,504.24"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-361.81,364.24)">
+                <polyline class="nad-edge-path" points="-387.79,344.70 -175.65,504.24"/>
+                <g class="nad-edge-infos" transform="translate(-361.81,364.24)">
                     <g class="nad-active">
                         <g transform="rotate(126.94)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter1.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter1.svg
@@ -129,8 +129,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
     <g class="nad-branch-edges">
         <g id="16">
             <g id="16.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-9.74,-220.22 -66.50,-107.27"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-24.33,-191.18)">
+                <polyline class="nad-edge-path" points="-9.74,-220.22 -66.50,-107.27"/>
+                <g class="nad-edge-infos" transform="translate(-24.33,-191.18)">
                     <g class="nad-active">
                         <g transform="rotate(-153.32)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -141,8 +141,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="16.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-123.27,5.69 -66.50,-107.27"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-108.67,-23.35)">
+                <polyline class="nad-edge-path" points="-123.27,5.69 -66.50,-107.27"/>
+                <g class="nad-edge-infos" transform="translate(-108.67,-23.35)">
                     <g class="nad-active">
                         <g transform="rotate(26.68)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -155,8 +155,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="17">
             <g id="17.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="4.72,-217.37 22.56,14.25"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(7.22,-184.97)">
+                <polyline class="nad-edge-path" points="4.72,-217.37 22.56,14.25"/>
+                <g class="nad-edge-infos" transform="translate(7.22,-184.97)">
                     <g class="nad-active">
                         <g transform="rotate(175.60)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -167,8 +167,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="17.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="40.40,245.87 22.56,14.25"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(37.91,213.46)">
+                <polyline class="nad-edge-path" points="40.40,245.87 22.56,14.25"/>
+                <g class="nad-edge-infos" transform="translate(37.91,213.46)">
                     <g class="nad-active">
                         <g transform="rotate(-4.40)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -181,8 +181,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="18">
             <g id="18.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-152.61,8.64 -233.35,-94.06"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-172.70,-16.91)">
+                <polyline class="nad-edge-path" points="-152.61,8.64 -233.35,-94.06"/>
+                <g class="nad-edge-infos" transform="translate(-172.70,-16.91)">
                     <g class="nad-active">
                         <g transform="rotate(-38.17)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -193,8 +193,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="18.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-314.08,-196.75 -233.35,-94.06"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-293.99,-171.20)">
+                <polyline class="nad-edge-path" points="-314.08,-196.75 -233.35,-94.06"/>
+                <g class="nad-edge-infos" transform="translate(-293.99,-171.20)">
                     <g class="nad-active">
                         <g transform="rotate(141.83)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -207,8 +207,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="19">
             <g id="19.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-108.70,24.63 66.26,-11.91"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-76.88,17.99)">
+                <polyline class="nad-edge-path" points="-108.70,24.63 66.26,-11.91"/>
+                <g class="nad-edge-infos" transform="translate(-76.88,17.99)">
                     <g class="nad-active">
                         <g transform="rotate(78.20)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -219,8 +219,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="19.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="241.22,-48.46 66.26,-11.91"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(209.41,-41.82)">
+                <polyline class="nad-edge-path" points="241.22,-48.46 66.26,-11.91"/>
+                <g class="nad-edge-infos" transform="translate(209.41,-41.82)">
                     <g class="nad-active">
                         <g transform="rotate(-101.80)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -233,8 +233,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="20">
             <g id="20.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-119.36,52.44 -46.55,151.77"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-100.15,78.65)">
+                <polyline class="nad-edge-path" points="-119.36,52.44 -46.55,151.77"/>
+                <g class="nad-edge-infos" transform="translate(-100.15,78.65)">
                     <g class="nad-active">
                         <g transform="rotate(143.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -245,8 +245,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="20.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="26.26,251.11 -46.55,151.77"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(7.05,224.89)">
+                <polyline class="nad-edge-path" points="26.26,251.11 -46.55,151.77"/>
+                <g class="nad-edge-infos" transform="translate(7.05,224.89)">
                     <g class="nad-active">
                         <g transform="rotate(-36.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -259,8 +259,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="21">
             <g id="21.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-304.55,-211.10 -31.47,-136.23"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-273.21,-202.51)">
+                <polyline class="nad-edge-path" points="-304.55,-211.10 -31.47,-136.23"/>
+                <g class="nad-edge-infos" transform="translate(-273.21,-202.51)">
                     <g class="nad-active">
                         <g transform="rotate(105.33)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -271,8 +271,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="21.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="241.62,-61.36 -31.47,-136.23"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(210.28,-69.95)">
+                <polyline class="nad-edge-path" points="241.62,-61.36 -31.47,-136.23"/>
+                <g class="nad-edge-infos" transform="translate(210.28,-69.95)">
                     <g class="nad-active">
                         <g transform="rotate(-74.67)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -285,8 +285,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="22">
             <g id="22.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="252.53,-31.44 155.33,109.60"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(234.09,-4.68)">
+                <polyline class="nad-edge-path" points="252.53,-31.44 155.33,109.60"/>
+                <g class="nad-edge-infos" transform="translate(234.09,-4.68)">
                     <g class="nad-active">
                         <g transform="rotate(-145.43)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -297,8 +297,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="22.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="58.12,250.64 155.33,109.60"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(76.56,223.88)">
+                <polyline class="nad-edge-path" points="58.12,250.64 155.33,109.60"/>
+                <g class="nad-edge-infos" transform="translate(76.56,223.88)">
                     <g class="nad-active">
                         <g transform="rotate(34.57)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -311,8 +311,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="23">
             <g id="23.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="294.18,-45.25 457.03,9.97"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(324.96,-34.82)">
+                <polyline class="nad-edge-path" points="294.18,-45.25 457.03,9.97"/>
+                <g class="nad-edge-infos" transform="translate(324.96,-34.82)">
                     <g class="nad-active">
                         <g transform="rotate(108.73)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -323,15 +323,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="23.2" class="nad-vl0to30-line"></g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl120to180-line nad-winding" cx="475.97" cy="16.39" r="20.00"/>
                 <circle class="nad-vl0to30-line nad-winding" cx="494.91" cy="22.81" r="20.00"/>
             </g>
         </g>
         <g id="24">
             <g id="24.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="284.78,-75.98 395.16,-221.14"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(304.45,-101.85)">
+                <polyline class="nad-edge-path" points="284.78,-75.98 395.16,-221.14"/>
+                <g class="nad-edge-infos" transform="translate(304.45,-101.85)">
                     <g class="nad-active">
                         <g transform="rotate(37.25)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -342,15 +342,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="24.2" class="nad-vl0to30-line"></g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl120to180-line nad-winding" cx="407.26" cy="-237.07" r="20.00"/>
                 <circle class="nad-vl0to30-line nad-winding" cx="419.37" cy="-252.99" r="20.00"/>
             </g>
         </g>
         <g id="25">
             <g id="25.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="28.62,297.02 -54.50,438.93"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(12.19,325.06)">
+                <polyline class="nad-edge-path" points="28.62,297.02 -54.50,438.93"/>
+                <g class="nad-edge-infos" transform="translate(12.19,325.06)">
                     <g class="nad-active">
                         <g transform="rotate(-149.64)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -361,7 +361,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="25.2" class="nad-vl0to30-line"></g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl120to180-line nad-winding" cx="-64.60" cy="456.18" r="20.00"/>
                 <circle class="nad-vl0to30-line nad-winding" cx="-74.71" cy="473.44" r="20.00"/>
             </g>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter2.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter2.svg
@@ -147,8 +147,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
     <g class="nad-branch-edges">
         <g id="28">
             <g id="28.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="921.47,-326.15 769.62,-348.15"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(889.31,-330.81)">
+                <polyline class="nad-edge-path" points="921.47,-326.15 769.62,-348.15"/>
+                <g class="nad-edge-infos" transform="translate(889.31,-330.81)">
                     <g class="nad-active">
                         <g transform="rotate(-81.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -159,8 +159,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="28.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="617.76,-370.14 769.62,-348.15"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(649.92,-365.48)">
+                <polyline class="nad-edge-path" points="617.76,-370.14 769.62,-348.15"/>
+                <g class="nad-edge-infos" transform="translate(649.92,-365.48)">
                     <g class="nad-active">
                         <g transform="rotate(98.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -173,8 +173,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="29">
             <g id="29.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="927.78,-304.35 778.46,-176.83"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(903.07,-283.24)">
+                <polyline class="nad-edge-path" points="927.78,-304.35 778.46,-176.83"/>
+                <g class="nad-edge-infos" transform="translate(903.07,-283.24)">
                     <g class="nad-active">
                         <g transform="rotate(-130.50)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -185,8 +185,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="29.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="629.14,-49.31 778.46,-176.83"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(653.86,-70.41)">
+                <polyline class="nad-edge-path" points="629.14,-49.31 778.46,-176.83"/>
+                <g class="nad-edge-infos" transform="translate(653.86,-70.41)">
                     <g class="nad-active">
                         <g transform="rotate(49.50)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -199,8 +199,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="30">
             <g id="30.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-365.18,66.20 -362.23,282.03"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-364.73,98.69)">
+                <polyline class="nad-edge-path" points="-365.18,66.20 -362.23,282.03"/>
+                <g class="nad-edge-infos" transform="translate(-364.73,98.69)">
                     <g class="nad-active">
                         <g transform="rotate(179.22)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -211,8 +211,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="30.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-359.28,497.87 -362.23,282.03"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-359.72,465.37)">
+                <polyline class="nad-edge-path" points="-359.28,497.87 -362.23,282.03"/>
+                <g class="nad-edge-infos" transform="translate(-359.72,465.37)">
                     <g class="nad-active">
                         <g transform="rotate(-0.78)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -225,8 +225,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="31">
             <g id="31.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-332.76,533.92 -163.36,589.33"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-301.87,544.02)">
+                <polyline class="nad-edge-path" points="-332.76,533.92 -163.36,589.33"/>
+                <g class="nad-edge-infos" transform="translate(-301.87,544.02)">
                     <g class="nad-active">
                         <g transform="rotate(108.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -239,8 +239,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="32">
             <g id="32.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-365.22,11.20 -362.47,-219.01"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-364.84,-21.30)">
+                <polyline class="nad-edge-path" points="-365.22,11.20 -362.47,-219.01"/>
+                <g class="nad-edge-infos" transform="translate(-364.84,-21.30)">
                     <g class="nad-active">
                         <g transform="rotate(0.68)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -251,8 +251,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="32.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-359.72,-449.21 -362.47,-219.01"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-360.11,-416.72)">
+                <polyline class="nad-edge-path" points="-359.72,-449.21 -362.47,-219.01"/>
+                <g class="nad-edge-infos" transform="translate(-360.11,-416.72)">
                     <g class="nad-active">
                         <g transform="rotate(-179.32)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -265,8 +265,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="33">
             <g id="33.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-332.15,-472.99 -182.29,-452.52"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-299.95,-468.59)">
+                <polyline class="nad-edge-path" points="-332.15,-472.99 -182.29,-452.52"/>
+                <g class="nad-edge-infos" transform="translate(-299.95,-468.59)">
                     <g class="nad-active">
                         <g transform="rotate(97.78)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -279,8 +279,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="34">
             <g id="34.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="563.47,-369.25 452.47,-349.43"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(531.48,-363.54)">
+                <polyline class="nad-edge-path" points="563.47,-369.25 452.47,-349.43"/>
+                <g class="nad-edge-infos" transform="translate(531.48,-363.54)">
                     <g class="nad-active">
                         <g transform="rotate(-100.13)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -291,8 +291,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="34.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="341.46,-329.60 452.47,-349.43"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(373.46,-335.31)">
+                <polyline class="nad-edge-path" points="341.46,-329.60 452.47,-349.43"/>
+                <g class="nad-edge-infos" transform="translate(373.46,-335.31)">
                     <g class="nad-active">
                         <g transform="rotate(79.87)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -305,8 +305,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="35">
             <g id="35.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="566.17,-361.34 323.37,-234.38"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(537.37,-346.28)">
+                <polyline class="nad-edge-path" points="566.17,-361.34 323.37,-234.38"/>
+                <g class="nad-edge-infos" transform="translate(537.37,-346.28)">
                     <g class="nad-active">
                         <g transform="rotate(-117.60)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -317,8 +317,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="35.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="80.57,-107.43 323.37,-234.38"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(109.37,-122.48)">
+                <polyline class="nad-edge-path" points="80.57,-107.43 323.37,-234.38"/>
+                <g class="nad-edge-infos" transform="translate(109.37,-122.48)">
                     <g class="nad-active">
                         <g transform="rotate(62.40)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -331,8 +331,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="36">
             <g id="36.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="591.96,-346.62 599.39,-202.77"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(593.64,-314.16)">
+                <polyline class="nad-edge-path" points="591.96,-346.62 599.39,-202.77"/>
+                <g class="nad-edge-infos" transform="translate(593.64,-314.16)">
                     <g class="nad-active">
                         <g transform="rotate(177.04)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -343,8 +343,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="36.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="606.81,-58.91 599.39,-202.77"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(605.14,-91.37)">
+                <polyline class="nad-edge-path" points="606.81,-58.91 599.39,-202.77"/>
+                <g class="nad-edge-infos" transform="translate(605.14,-91.37)">
                     <g class="nad-active">
                         <g transform="rotate(-2.96)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -357,8 +357,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="37">
             <g id="37.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="293.86,-306.47 185.30,-209.72"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(269.60,-284.85)">
+                <polyline class="nad-edge-path" points="293.86,-306.47 185.30,-209.72"/>
+                <g class="nad-edge-infos" transform="translate(269.60,-284.85)">
                     <g class="nad-active">
                         <g transform="rotate(-131.70)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -369,8 +369,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="37.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="76.73,-112.98 185.30,-209.72"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(100.99,-134.60)">
+                <polyline class="nad-edge-path" points="76.73,-112.98 185.30,-209.72"/>
+                <g class="nad-edge-infos" transform="translate(100.99,-134.60)">
                     <g class="nad-active">
                         <g transform="rotate(48.30)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -383,8 +383,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="38">
             <g id="38.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="83.52,-91.55 332.22,-63.06"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(115.81,-87.85)">
+                <polyline class="nad-edge-path" points="83.52,-91.55 332.22,-63.06"/>
+                <g class="nad-edge-infos" transform="translate(115.81,-87.85)">
                     <g class="nad-active">
                         <g transform="rotate(96.53)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -395,8 +395,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="38.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="580.91,-34.58 332.22,-63.06"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(548.62,-38.27)">
+                <polyline class="nad-edge-path" points="580.91,-34.58 332.22,-63.06"/>
+                <g class="nad-edge-infos" transform="translate(548.62,-38.27)">
                     <g class="nad-active">
                         <g transform="rotate(-83.47)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -409,8 +409,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="39">
             <g id="39.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="28.81,-97.19 -257.13,-123.38"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-3.55,-100.16)">
+                <polyline class="nad-edge-path" points="28.81,-97.19 -257.13,-123.38"/>
+                <g class="nad-edge-infos" transform="translate(-3.55,-100.16)">
                     <g class="nad-active">
                         <g transform="rotate(-84.77)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -421,8 +421,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="39.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-602.82,-155.04 -316.88,-128.85"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-570.45,-152.08)">
+                <polyline class="nad-edge-path" points="-602.82,-155.04 -316.88,-128.85"/>
+                <g class="nad-edge-infos" transform="translate(-570.45,-152.08)">
                     <g class="nad-active">
                         <g transform="rotate(95.23)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -432,15 +432,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl120to180-line nad-winding" cx="-277.04" cy="-125.21" r="20.00"/>
                 <circle class="nad-vl0to30-line nad-winding" cx="-296.96" cy="-127.03" r="20.00"/>
             </g>
         </g>
         <g id="40">
             <g id="40.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="29.98,-86.39 -126.07,-37.04"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1.01,-76.59)">
+                <polyline class="nad-edge-path" points="29.98,-86.39 -126.07,-37.04"/>
+                <g class="nad-edge-infos" transform="translate(-1.01,-76.59)">
                     <g class="nad-active">
                         <g transform="rotate(-107.55)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -451,8 +451,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="40.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-339.33,30.41 -183.28,-18.95"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-308.35,20.61)">
+                <polyline class="nad-edge-path" points="-339.33,30.41 -183.28,-18.95"/>
+                <g class="nad-edge-infos" transform="translate(-308.35,20.61)">
                     <g class="nad-active">
                         <g transform="rotate(72.45)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -462,15 +462,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl120to180-line nad-winding" cx="-145.14" cy="-31.01" r="20.00"/>
                 <circle class="nad-vl0to30-line nad-winding" cx="-164.21" cy="-24.98" r="20.00"/>
             </g>
         </g>
         <g id="41">
             <g id="41.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="590.90,-10.10 498.70,103.48"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(570.42,15.14)">
+                <polyline class="nad-edge-path" points="590.90,-10.10 498.70,103.48"/>
+                <g class="nad-edge-infos" transform="translate(570.42,15.14)">
                     <g class="nad-active">
                         <g transform="rotate(-140.93)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -481,8 +481,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="41.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="368.68,263.64 460.88,150.06"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(389.16,238.41)">
+                <polyline class="nad-edge-path" points="368.68,263.64 460.88,150.06"/>
+                <g class="nad-edge-infos" transform="translate(389.16,238.41)">
                     <g class="nad-active">
                         <g transform="rotate(39.07)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -492,15 +492,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl120to180-line nad-winding" cx="486.09" cy="119.01" r="20.00"/>
                 <circle class="nad-vl0to30-line nad-winding" cx="473.48" cy="134.53" r="20.00"/>
             </g>
         </g>
         <g id="42">
             <g id="42.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="333.33,305.77 191.76,469.14"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(312.05,330.33)">
+                <polyline class="nad-edge-path" points="333.33,305.77 191.76,469.14"/>
+                <g class="nad-edge-infos" transform="translate(312.05,330.33)">
                     <g class="nad-active">
                         <g transform="rotate(-139.09)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -513,8 +513,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="43">
             <g id="43.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="370.65,304.57 521.89,457.91"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(393.48,327.71)">
+                <polyline class="nad-edge-path" points="370.65,304.57 521.89,457.91"/>
+                <g class="nad-edge-infos" transform="translate(393.48,327.71)">
                     <g class="nad-active">
                         <g transform="rotate(135.40)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -527,8 +527,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="44">
             <g id="44.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="339.05,260.39 173.08,-71.66"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(324.52,231.32)">
+                <polyline class="nad-edge-path" points="339.05,260.39 173.08,-71.66"/>
+                <g class="nad-edge-infos" transform="translate(324.52,231.32)">
                     <g class="nad-active">
                         <g transform="rotate(-26.56)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -541,8 +541,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="45">
             <g id="45.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-655.01,-169.41 -831.71,-253.89"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-684.33,-183.43)">
+                <polyline class="nad-edge-path" points="-655.01,-169.41 -831.71,-253.89"/>
+                <g class="nad-edge-infos" transform="translate(-684.33,-183.43)">
                     <g class="nad-active">
                         <g transform="rotate(-64.45)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -553,8 +553,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="45.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1008.40,-338.36 -831.71,-253.89"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-979.08,-324.34)">
+                <polyline class="nad-edge-path" points="-1008.40,-338.36 -831.71,-253.89"/>
+                <g class="nad-edge-infos" transform="translate(-979.08,-324.34)">
                     <g class="nad-active">
                         <g transform="rotate(115.55)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -567,8 +567,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="46">
             <g id="46.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-608.11,-141.17 -497.88,-59.43"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-582.01,-121.81)">
+                <polyline class="nad-edge-path" points="-608.11,-141.17 -497.88,-59.43"/>
+                <g class="nad-edge-infos" transform="translate(-582.01,-121.81)">
                     <g class="nad-active">
                         <g transform="rotate(126.56)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -579,8 +579,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="46.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-387.64,22.32 -497.88,-59.43"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-413.75,2.96)">
+                <polyline class="nad-edge-path" points="-387.64,22.32 -497.88,-59.43"/>
+                <g class="nad-edge-infos" transform="translate(-413.75,2.96)">
                     <g class="nad-active">
                         <g transform="rotate(-53.44)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter3.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter3.svg
@@ -132,8 +132,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
     <g class="nad-branch-edges">
         <g id="22">
             <g id="22.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="194.50,12.94 397.25,100.67"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(224.33,25.85)">
+                <polyline class="nad-edge-path" points="194.50,12.94 397.25,100.67"/>
+                <g class="nad-edge-infos" transform="translate(224.33,25.85)">
                     <g class="nad-active">
                         <g transform="rotate(113.40)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -144,8 +144,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="22.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="599.99,188.39 397.25,100.67"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(570.16,175.49)">
+                <polyline class="nad-edge-path" points="599.99,188.39 397.25,100.67"/>
+                <g class="nad-edge-infos" transform="translate(570.16,175.49)">
                     <g class="nad-active">
                         <g transform="rotate(-66.60)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -158,8 +158,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="23">
             <g id="23.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="652.55,202.48 823.41,222.32"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(684.83,206.23)">
+                <polyline class="nad-edge-path" points="652.55,202.48 823.41,222.32"/>
+                <g class="nad-edge-infos" transform="translate(684.83,206.23)">
                     <g class="nad-active">
                         <g transform="rotate(96.62)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -172,8 +172,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="24">
             <g id="24.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="183.91,-21.25 295.66,-198.86"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(201.22,-48.76)">
+                <polyline class="nad-edge-path" points="183.91,-21.25 295.66,-198.86"/>
+                <g class="nad-edge-infos" transform="translate(201.22,-48.76)">
                     <g class="nad-active">
                         <g transform="rotate(32.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -184,8 +184,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="24.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="407.41,-376.47 295.66,-198.86"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(390.10,-348.96)">
+                <polyline class="nad-edge-path" points="407.41,-376.47 295.66,-198.86"/>
+                <g class="nad-edge-infos" transform="translate(390.10,-348.96)">
                     <g class="nad-active">
                         <g transform="rotate(-147.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -198,8 +198,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="25">
             <g id="25.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="435.04,-423.99 515.16,-573.64"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(450.38,-452.64)">
+                <polyline class="nad-edge-path" points="435.04,-423.99 515.16,-573.64"/>
+                <g class="nad-edge-infos" transform="translate(450.38,-452.64)">
                     <g class="nad-active">
                         <g transform="rotate(28.16)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -212,8 +212,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="26">
             <g id="26.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-375.81,-119.37 -542.62,-243.79"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-401.87,-138.80)">
+                <polyline class="nad-edge-path" points="-375.81,-119.37 -542.62,-243.79"/>
+                <g class="nad-edge-infos" transform="translate(-401.87,-138.80)">
                     <g class="nad-active">
                         <g transform="rotate(-53.28)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -226,8 +226,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="27">
             <g id="27.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-349.81,-130.14 -321.64,-323.75"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-345.13,-162.30)">
+                <polyline class="nad-edge-path" points="-349.81,-130.14 -321.64,-323.75"/>
+                <g class="nad-edge-infos" transform="translate(-345.13,-162.30)">
                     <g class="nad-active">
                         <g transform="rotate(8.28)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -240,8 +240,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="28">
             <g id="28.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-377.87,-89.68 -552.38,6.19"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-406.36,-74.03)">
+                <polyline class="nad-edge-path" points="-377.87,-89.68 -552.38,6.19"/>
+                <g class="nad-edge-infos" transform="translate(-406.36,-74.03)">
                     <g class="nad-active">
                         <g transform="rotate(-118.78)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -254,8 +254,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="29">
             <g id="29.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-340.64,-78.76 -258.20,72.85"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-325.11,-50.21)">
+                <polyline class="nad-edge-path" points="-340.64,-78.76 -258.20,72.85"/>
+                <g class="nad-edge-infos" transform="translate(-325.11,-50.21)">
                     <g class="nad-active">
                         <g transform="rotate(151.47)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -266,8 +266,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="29.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-147.11,277.18 -229.54,125.56"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-162.64,248.62)">
+                <polyline class="nad-edge-path" points="-147.11,277.18 -229.54,125.56"/>
+                <g class="nad-edge-infos" transform="translate(-162.64,248.62)">
                     <g class="nad-active">
                         <g transform="rotate(-28.53)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -277,15 +277,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl120to180-line nad-winding" cx="-248.65" cy="90.42" r="20.00"/>
                 <circle class="nad-vl0to30-line nad-winding" cx="-239.10" cy="107.99" r="20.00"/>
             </g>
         </g>
         <g id="30">
             <g id="30.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-326.81,-97.51 -121.67,-56.35"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-294.94,-91.12)">
+                <polyline class="nad-edge-path" points="-326.81,-97.51 -121.67,-56.35"/>
+                <g class="nad-edge-infos" transform="translate(-294.94,-91.12)">
                     <g class="nad-active">
                         <g transform="rotate(101.35)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -296,8 +296,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="30.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="142.30,-3.39 -62.84,-44.55"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(110.44,-9.78)">
+                <polyline class="nad-edge-path" points="142.30,-3.39 -62.84,-44.55"/>
+                <g class="nad-edge-infos" transform="translate(110.44,-9.78)">
                     <g class="nad-active">
                         <g transform="rotate(-78.65)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -307,15 +307,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl120to180-line nad-winding" cx="-102.06" cy="-52.42" r="20.00"/>
                 <circle class="nad-vl0to30-line nad-winding" cx="-82.45" cy="-48.48" r="20.00"/>
             </g>
         </g>
         <g id="31">
             <g id="31.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-135.11,328.81 -142.82,516.64"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-136.44,361.29)">
+                <polyline class="nad-edge-path" points="-135.11,328.81 -142.82,516.64"/>
+                <g class="nad-edge-infos" transform="translate(-136.44,361.29)">
                     <g class="nad-active">
                         <g transform="rotate(-177.65)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -326,8 +326,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="31.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-150.54,704.46 -142.82,516.64"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-149.21,671.99)">
+                <polyline class="nad-edge-path" points="-150.54,704.46 -142.82,516.64"/>
+                <g class="nad-edge-infos" transform="translate(-149.21,671.99)">
                     <g class="nad-active">
                         <g transform="rotate(2.35)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -340,8 +340,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="32">
             <g id="32.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-114.40,282.02 17.64,151.68"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-91.27,259.19)">
+                <polyline class="nad-edge-path" points="-114.40,282.02 17.64,151.68"/>
+                <g class="nad-edge-infos" transform="translate(-91.27,259.19)">
                     <g class="nad-active">
                         <g transform="rotate(45.37)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -352,8 +352,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="32.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="149.69,21.34 17.64,151.68"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(126.56,44.17)">
+                <polyline class="nad-edge-path" points="149.69,21.34 17.64,151.68"/>
+                <g class="nad-edge-infos" transform="translate(126.56,44.17)">
                     <g class="nad-active">
                         <g transform="rotate(-134.63)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter4.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter4.svg
@@ -141,8 +141,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
     <g class="nad-branch-edges">
         <g id="22">
             <g id="22.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="349.88,-264.11 163.53,-356.97"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(320.80,-278.60)">
+                <polyline class="nad-edge-path" points="349.88,-264.11 163.53,-356.97"/>
+                <g class="nad-edge-infos" transform="translate(320.80,-278.60)">
                     <g class="nad-active">
                         <g transform="rotate(-63.51)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -153,8 +153,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="22.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-22.83,-449.83 163.53,-356.97"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(6.26,-435.33)">
+                <polyline class="nad-edge-path" points="-22.83,-449.83 163.53,-356.97"/>
+                <g class="nad-edge-infos" transform="translate(6.26,-435.33)">
                     <g class="nad-active">
                         <g transform="rotate(116.49)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -167,8 +167,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="23">
             <g id="23.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-71.81,-449.34 -233.74,-364.60"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-100.60,-434.27)">
+                <polyline class="nad-edge-path" points="-71.81,-449.34 -233.74,-364.60"/>
+                <g class="nad-edge-infos" transform="translate(-100.60,-434.27)">
                     <g class="nad-active">
                         <g transform="rotate(-117.62)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -179,8 +179,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="23.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-395.67,-279.86 -233.74,-364.60"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-366.88,-294.93)">
+                <polyline class="nad-edge-path" points="-395.67,-279.86 -233.74,-364.60"/>
+                <g class="nad-edge-infos" transform="translate(-366.88,-294.93)">
                     <g class="nad-active">
                         <g transform="rotate(62.38)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -193,8 +193,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="24">
             <g id="24.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-534.29,158.65 -480.73,-40.95"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-525.86,127.26)">
+                <polyline class="nad-edge-path" points="-534.29,158.65 -480.73,-40.95"/>
+                <g class="nad-edge-infos" transform="translate(-525.86,127.26)">
                     <g class="nad-active">
                         <g transform="rotate(15.02)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -205,8 +205,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="24.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-427.17,-240.55 -480.73,-40.95"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-435.59,-209.16)">
+                <polyline class="nad-edge-path" points="-427.17,-240.55 -480.73,-40.95"/>
+                <g class="nad-edge-infos" transform="translate(-435.59,-209.16)">
                     <g class="nad-active">
                         <g transform="rotate(-164.98)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -219,8 +219,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="25">
             <g id="25.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-536.48,212.26 -504.69,386.59"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-530.65,244.23)">
+                <polyline class="nad-edge-path" points="-536.48,212.26 -504.69,386.59"/>
+                <g class="nad-edge-infos" transform="translate(-530.65,244.23)">
                     <g class="nad-active">
                         <g transform="rotate(169.66)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -231,8 +231,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="25.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-472.90,560.92 -504.69,386.59"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-478.73,528.95)">
+                <polyline class="nad-edge-path" points="-472.90,560.92 -504.69,386.59"/>
+                <g class="nad-edge-infos" transform="translate(-478.73,528.95)">
                     <g class="nad-active">
                         <g transform="rotate(-10.34)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -245,8 +245,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="26">
             <g id="26.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-444.48,573.66 -314.18,494.26"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-416.73,556.75)">
+                <polyline class="nad-edge-path" points="-444.48,573.66 -314.18,494.26"/>
+                <g class="nad-edge-infos" transform="translate(-416.73,556.75)">
                     <g class="nad-active">
                         <g transform="rotate(58.64)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -257,8 +257,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="26.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-183.87,414.85 -314.18,494.26"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-211.62,431.76)">
+                <polyline class="nad-edge-path" points="-183.87,414.85 -314.18,494.26"/>
+                <g class="nad-edge-infos" transform="translate(-211.62,431.76)">
                     <g class="nad-active">
                         <g transform="rotate(-121.36)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -271,8 +271,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="27">
             <g id="27.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-517.47,198.74 -350.90,292.87"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-489.18,214.73)">
+                <polyline class="nad-edge-path" points="-517.47,198.74 -350.90,292.87"/>
+                <g class="nad-edge-infos" transform="translate(-489.18,214.73)">
                     <g class="nad-active">
                         <g transform="rotate(119.47)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -283,8 +283,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="27.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-184.33,387.01 -350.90,292.87"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-212.62,371.02)">
+                <polyline class="nad-edge-path" points="-184.33,387.01 -350.90,292.87"/>
+                <g class="nad-edge-infos" transform="translate(-212.62,371.02)">
                     <g class="nad-active">
                         <g transform="rotate(-60.53)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -297,8 +297,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="28">
             <g id="28.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-136.14,387.57 31.19,298.04"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-107.48,372.24)">
+                <polyline class="nad-edge-path" points="-136.14,387.57 31.19,298.04"/>
+                <g class="nad-edge-infos" transform="translate(-107.48,372.24)">
                     <g class="nad-active">
                         <g transform="rotate(61.85)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -309,8 +309,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="28.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="198.53,208.52 31.19,298.04"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(169.87,223.85)">
+                <polyline class="nad-edge-path" points="198.53,208.52 31.19,298.04"/>
+                <g class="nad-edge-infos" transform="translate(169.87,223.85)">
                     <g class="nad-active">
                         <g transform="rotate(-118.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -323,8 +323,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="29">
             <g id="29.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="365.67,-225.80 298.64,-28.15"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(355.23,-195.02)">
+                <polyline class="nad-edge-path" points="365.67,-225.80 298.64,-28.15"/>
+                <g class="nad-edge-infos" transform="translate(355.23,-195.02)">
                     <g class="nad-active">
                         <g transform="rotate(-161.27)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -335,8 +335,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="29.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="231.61,169.51 298.64,-28.15"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(242.05,138.73)">
+                <polyline class="nad-edge-path" points="231.61,169.51 298.64,-28.15"/>
+                <g class="nad-edge-infos" transform="translate(242.05,138.73)">
                     <g class="nad-active">
                         <g transform="rotate(18.73)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -350,8 +350,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="30">
             <g id="30.1" class="nad-vl120to180-line"></g>
             <g id="30.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-567.94,177.94 -716.50,137.27"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-599.28,169.36)">
+                <polyline class="nad-edge-path" points="-567.94,177.94 -716.50,137.27"/>
+                <g class="nad-edge-infos" transform="translate(-599.28,169.36)">
                     <g class="nad-active">
                         <g transform="rotate(-74.69)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -361,15 +361,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl120to180-line nad-winding" cx="-755.08" cy="126.71" r="20.00"/>
                 <circle class="nad-vl0to30-line nad-winding" cx="-735.79" cy="131.99" r="20.00"/>
             </g>
         </g>
         <g id="31">
             <g id="31.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="775.45,-498.23 928.69,-572.21"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(804.72,-512.36)">
+                <polyline class="nad-edge-path" points="775.45,-498.23 928.69,-572.21"/>
+                <g class="nad-edge-infos" transform="translate(804.72,-512.36)">
                     <g class="nad-active">
                         <g transform="rotate(64.23)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -380,8 +380,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="31.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1081.92,-646.20 928.69,-572.21"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1052.66,-632.07)">
+                <polyline class="nad-edge-path" points="1081.92,-646.20 928.69,-572.21"/>
+                <g class="nad-edge-infos" transform="translate(1052.66,-632.07)">
                     <g class="nad-active">
                         <g transform="rotate(-115.77)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -394,8 +394,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="32">
             <g id="32.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="727.35,-471.73 562.59,-369.06"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(699.76,-454.54)">
+                <polyline class="nad-edge-path" points="727.35,-471.73 562.59,-369.06"/>
+                <g class="nad-edge-infos" transform="translate(699.76,-454.54)">
                     <g class="nad-active">
                         <g transform="rotate(-121.93)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -406,8 +406,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="32.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="397.84,-266.39 562.59,-369.06"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(425.42,-283.57)">
+                <polyline class="nad-edge-path" points="397.84,-266.39 562.59,-369.06"/>
+                <g class="nad-edge-infos" transform="translate(425.42,-283.57)">
                     <g class="nad-active">
                         <g transform="rotate(58.07)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -421,8 +421,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="33">
             <g id="33.1" class="nad-vl120to180-line"></g>
             <g id="33.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="750.14,-458.78 747.83,-342.54"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(749.49,-426.28)">
+                <polyline class="nad-edge-path" points="750.14,-458.78 747.83,-342.54"/>
+                <g class="nad-edge-infos" transform="translate(749.49,-426.28)">
                     <g class="nad-active">
                         <g transform="rotate(-178.86)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -432,7 +432,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl120to180-line nad-winding" cx="747.03" cy="-302.55" r="20.00"/>
                 <circle class="nad-vl0to30-line nad-winding" cx="747.43" cy="-322.54" r="20.00"/>
             </g>
@@ -440,8 +440,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="34">
             <g id="34.1" class="nad-vl120to180-line"></g>
             <g id="34.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="400.79,-243.79 530.45,-204.11"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(431.87,-234.28)">
+                <polyline class="nad-edge-path" points="400.79,-243.79 530.45,-204.11"/>
+                <g class="nad-edge-infos" transform="translate(431.87,-234.28)">
                     <g class="nad-active">
                         <g transform="rotate(107.02)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -451,7 +451,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl120to180-line nad-winding" cx="568.70" cy="-192.40" r="20.00"/>
                 <circle class="nad-vl0to30-line nad-winding" cx="549.57" cy="-198.26" r="20.00"/>
             </g>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter5.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter5.svg
@@ -132,8 +132,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
     <g class="nad-branch-edges">
         <g id="18">
             <g id="18.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-248.44,310.22 -245.05,149.62"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-247.75,277.73)">
+                <polyline class="nad-edge-path" points="-248.44,310.22 -245.05,149.62"/>
+                <g class="nad-edge-infos" transform="translate(-247.75,277.73)">
                     <g class="nad-active">
                         <g transform="rotate(1.21)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -144,8 +144,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="18.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-241.67,-10.99 -245.05,149.62"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-242.36,21.50)">
+                <polyline class="nad-edge-path" points="-241.67,-10.99 -245.05,149.62"/>
+                <g class="nad-edge-infos" transform="translate(-242.36,21.50)">
                     <g class="nad-active">
                         <g transform="rotate(-178.79)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -158,8 +158,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="19">
             <g id="19.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-225.42,323.59 -72.82,232.24"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-197.53,306.90)">
+                <polyline class="nad-edge-path" points="-225.42,323.59 -72.82,232.24"/>
+                <g class="nad-edge-infos" transform="translate(-197.53,306.90)">
                     <g class="nad-active">
                         <g transform="rotate(59.09)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -170,8 +170,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="19.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="79.77,140.90 -72.82,232.24"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(51.89,157.59)">
+                <polyline class="nad-edge-path" points="79.77,140.90 -72.82,232.24"/>
+                <g class="nad-edge-infos" transform="translate(51.89,157.59)">
                     <g class="nad-active">
                         <g transform="rotate(-120.91)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -184,8 +184,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="20">
             <g id="20.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-251.52,-63.93 -310.50,-207.82"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-263.85,-94.01)">
+                <polyline class="nad-edge-path" points="-251.52,-63.93 -310.50,-207.82"/>
+                <g class="nad-edge-infos" transform="translate(-263.85,-94.01)">
                     <g class="nad-active">
                         <g transform="rotate(-22.29)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -196,8 +196,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="20.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-369.48,-351.70 -310.50,-207.82"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-357.15,-321.63)">
+                <polyline class="nad-edge-path" points="-369.48,-351.70 -310.50,-207.82"/>
+                <g class="nad-edge-infos" transform="translate(-357.15,-321.63)">
                     <g class="nad-active">
                         <g transform="rotate(157.71)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -210,8 +210,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="21">
             <g id="21.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-221.12,-57.39 -98.72,-173.20"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-197.51,-79.73)">
+                <polyline class="nad-edge-path" points="-221.12,-57.39 -98.72,-173.20"/>
+                <g class="nad-edge-infos" transform="translate(-197.51,-79.73)">
                     <g class="nad-active">
                         <g transform="rotate(46.58)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -222,8 +222,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="21.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="23.68,-289.01 -98.72,-173.20"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(0.07,-266.68)">
+                <polyline class="nad-edge-path" points="23.68,-289.01 -98.72,-173.20"/>
+                <g class="nad-edge-infos" transform="translate(0.07,-266.68)">
                     <g class="nad-active">
                         <g transform="rotate(-133.42)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -236,8 +236,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="22">
             <g id="22.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-216.30,-26.59 -68.86,44.14"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-187.00,-12.53)">
+                <polyline class="nad-edge-path" points="-216.30,-26.59 -68.86,44.14"/>
+                <g class="nad-edge-infos" transform="translate(-187.00,-12.53)">
                     <g class="nad-active">
                         <g transform="rotate(115.63)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -248,8 +248,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="22.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="78.57,114.88 -68.86,44.14"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(49.27,100.82)">
+                <polyline class="nad-edge-path" points="78.57,114.88 -68.86,44.14"/>
+                <g class="nad-edge-infos" transform="translate(49.27,100.82)">
                     <g class="nad-active">
                         <g transform="rotate(-64.37)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -262,8 +262,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="23">
             <g id="23.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-352.77,-372.71 -168.13,-342.53"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-320.69,-367.47)">
+                <polyline class="nad-edge-path" points="-352.77,-372.71 -168.13,-342.53"/>
+                <g class="nad-edge-infos" transform="translate(-320.69,-367.47)">
                     <g class="nad-active">
                         <g transform="rotate(99.28)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -274,8 +274,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="23.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="16.51,-312.35 -168.13,-342.53"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-15.56,-317.59)">
+                <polyline class="nad-edge-path" points="16.51,-312.35 -168.13,-342.53"/>
+                <g class="nad-edge-infos" transform="translate(-15.56,-317.59)">
                     <g class="nad-active">
                         <g transform="rotate(-80.72)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -288,8 +288,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="24">
             <g id="24.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="47.40,-280.67 73.51,-90.57"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(51.82,-248.47)">
+                <polyline class="nad-edge-path" points="47.40,-280.67 73.51,-90.57"/>
+                <g class="nad-edge-infos" transform="translate(51.82,-248.47)">
                     <g class="nad-active">
                         <g transform="rotate(172.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -300,8 +300,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="24.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="99.63,99.53 73.51,-90.57"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(95.20,67.33)">
+                <polyline class="nad-edge-path" points="99.63,99.53 73.51,-90.57"/>
+                <g class="nad-edge-infos" transform="translate(95.20,67.33)">
                     <g class="nad-active">
                         <g transform="rotate(-7.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -314,8 +314,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="25">
             <g id="25.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="67.23,-293.76 217.88,-203.34"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(95.10,-277.04)">
+                <polyline class="nad-edge-path" points="67.23,-293.76 217.88,-203.34"/>
+                <g class="nad-edge-infos" transform="translate(95.10,-277.04)">
                     <g class="nad-active">
                         <g transform="rotate(120.97)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -326,15 +326,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="25.2" class="nad-vl0to30-line"></g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl120to180-line nad-winding" cx="235.03" cy="-193.04" r="20.00"/>
                 <circle class="nad-vl0to30-line nad-winding" cx="252.18" cy="-182.75" r="20.00"/>
             </g>
         </g>
         <g id="26">
             <g id="26.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="46.77,-335.24 66.19,-505.32"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(50.46,-367.53)">
+                <polyline class="nad-edge-path" points="46.77,-335.24 66.19,-505.32"/>
+                <g class="nad-edge-infos" transform="translate(50.46,-367.53)">
                     <g class="nad-active">
                         <g transform="rotate(6.51)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -345,15 +345,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="26.2" class="nad-vl0to30-line"></g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl120to180-line nad-winding" cx="68.46" cy="-525.19" r="20.00"/>
                 <circle class="nad-vl0to30-line nad-winding" cx="70.73" cy="-545.06" r="20.00"/>
             </g>
         </g>
         <g id="27">
             <g id="27.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="130.27,132.50 363.88,182.24"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(162.05,139.27)">
+                <polyline class="nad-edge-path" points="130.27,132.50 363.88,182.24"/>
+                <g class="nad-edge-infos" transform="translate(162.05,139.27)">
                     <g class="nad-active">
                         <g transform="rotate(102.02)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -364,15 +364,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="27.2" class="nad-vl0to30-line"></g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl120to180-line nad-winding" cx="383.44" cy="186.41" r="20.00"/>
                 <circle class="nad-vl0to30-line nad-winding" cx="403.00" cy="190.57" r="20.00"/>
             </g>
         </g>
         <g id="28">
             <g id="28.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="411.28,454.40 426.57,206.99"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(413.29,421.97)">
+                <polyline class="nad-edge-path" points="411.28,454.40 426.57,206.99"/>
+                <g class="nad-edge-infos" transform="translate(413.29,421.97)">
                     <g class="nad-active">
                         <g transform="rotate(3.54)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_nofilter.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_nofilter.svg
@@ -156,8 +156,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
     <g class="nad-branch-edges">
         <g id="28">
             <g id="28.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="391.72,-873.13 467.85,-719.67"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(406.17,-844.01)">
+                <polyline class="nad-edge-path" points="391.72,-873.13 467.85,-719.67"/>
+                <g class="nad-edge-infos" transform="translate(406.17,-844.01)">
                     <g class="nad-active">
                         <g transform="rotate(153.61)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -168,8 +168,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="28.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="543.99,-566.20 467.85,-719.67"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(529.54,-595.32)">
+                <polyline class="nad-edge-path" points="543.99,-566.20 467.85,-719.67"/>
+                <g class="nad-edge-infos" transform="translate(529.54,-595.32)">
                     <g class="nad-active">
                         <g transform="rotate(-26.39)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -182,8 +182,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="29">
             <g id="29.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="365.83,-873.91 277.59,-719.97"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(349.66,-845.71)">
+                <polyline class="nad-edge-path" points="365.83,-873.91 277.59,-719.97"/>
+                <g class="nad-edge-infos" transform="translate(349.66,-845.71)">
                     <g class="nad-active">
                         <g transform="rotate(-150.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -194,8 +194,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="29.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="189.36,-566.04 277.59,-719.97"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(205.52,-594.24)">
+                <polyline class="nad-edge-path" points="189.36,-566.04 277.59,-719.97"/>
+                <g class="nad-edge-infos" transform="translate(205.52,-594.24)">
                     <g class="nad-active">
                         <g transform="rotate(29.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -208,8 +208,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="30">
             <g id="30.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="60.59,339.44 -249.07,332.57"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(28.10,338.71)">
+                <polyline class="nad-edge-path" points="60.59,339.44 -249.07,332.57"/>
+                <g class="nad-edge-infos" transform="translate(28.10,338.71)">
                     <g class="nad-active">
                         <g transform="rotate(-88.73)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -220,8 +220,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="30.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-558.72,325.70 -249.07,332.57"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-526.23,326.42)">
+                <polyline class="nad-edge-path" points="-558.72,325.70 -249.07,332.57"/>
+                <g class="nad-edge-infos" transform="translate(-526.23,326.42)">
                     <g class="nad-active">
                         <g transform="rotate(91.27)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -234,8 +234,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="31">
             <g id="31.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-597.86,300.17 -683.85,116.23"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-611.62,270.73)">
+                <polyline class="nad-edge-path" points="-597.86,300.17 -683.85,116.23"/>
+                <g class="nad-edge-infos" transform="translate(-611.62,270.73)">
                     <g class="nad-active">
                         <g transform="rotate(-25.05)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -246,8 +246,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="31.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-769.84,-67.72 -683.85,116.23"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-756.08,-38.28)">
+                <polyline class="nad-edge-path" points="-769.84,-67.72 -683.85,116.23"/>
+                <g class="nad-edge-infos" transform="translate(-756.08,-38.28)">
                     <g class="nad-active">
                         <g transform="rotate(154.95)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -260,8 +260,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="32">
             <g id="32.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-426.49,-351.82 -592.88,-230.34"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-452.74,-332.66)">
+                <polyline class="nad-edge-path" points="-426.49,-351.82 -592.88,-230.34"/>
+                <g class="nad-edge-infos" transform="translate(-452.74,-332.66)">
                     <g class="nad-active">
                         <g transform="rotate(-126.13)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -272,8 +272,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="32.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-759.27,-108.85 -592.88,-230.34"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-733.03,-128.01)">
+                <polyline class="nad-edge-path" points="-759.27,-108.85 -592.88,-230.34"/>
+                <g class="nad-edge-infos" transform="translate(-733.03,-128.01)">
                     <g class="nad-active">
                         <g transform="rotate(53.87)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -286,8 +286,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="33">
             <g id="33.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-380.36,-354.47 -280.61,-297.89"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-352.09,-338.44)">
+                <polyline class="nad-edge-path" points="-380.36,-354.47 -280.61,-297.89"/>
+                <g class="nad-edge-infos" transform="translate(-352.09,-338.44)">
                     <g class="nad-active">
                         <g transform="rotate(119.56)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -298,8 +298,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="33.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-180.87,-241.31 -280.61,-297.89"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-209.13,-257.35)">
+                <polyline class="nad-edge-path" points="-180.87,-241.31 -280.61,-297.89"/>
+                <g class="nad-edge-infos" transform="translate(-209.13,-257.35)">
                     <g class="nad-active">
                         <g transform="rotate(-60.44)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -312,8 +312,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="34">
             <g id="34.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-168.74,-202.90 -228.44,-77.21"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-182.69,-173.54)">
+                <polyline class="nad-edge-path" points="-168.74,-202.90 -228.44,-77.21"/>
+                <g class="nad-edge-infos" transform="translate(-182.69,-173.54)">
                     <g class="nad-active">
                         <g transform="rotate(-154.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -324,8 +324,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="34.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-288.14,48.48 -228.44,-77.21"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-274.19,19.12)">
+                <polyline class="nad-edge-path" points="-288.14,48.48 -228.44,-77.21"/>
+                <g class="nad-edge-infos" transform="translate(-274.19,19.12)">
                     <g class="nad-active">
                         <g transform="rotate(25.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -338,8 +338,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="35">
             <g id="35.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-397.95,-341.28 -352.11,-147.36"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-390.47,-309.65)">
+                <polyline class="nad-edge-path" points="-397.95,-341.28 -352.11,-147.36"/>
+                <g class="nad-edge-infos" transform="translate(-390.47,-309.65)">
                     <g class="nad-active">
                         <g transform="rotate(166.70)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -350,8 +350,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="35.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-306.26,46.56 -352.11,-147.36"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-313.74,14.93)">
+                <polyline class="nad-edge-path" points="-306.26,46.56 -352.11,-147.36"/>
+                <g class="nad-edge-infos" transform="translate(-313.74,14.93)">
                     <g class="nad-active">
                         <g transform="rotate(-13.30)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -364,8 +364,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="36">
             <g id="36.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-294.50,100.28 -251.20,314.87"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-288.07,132.13)">
+                <polyline class="nad-edge-path" points="-294.50,100.28 -251.20,314.87"/>
+                <g class="nad-edge-infos" transform="translate(-288.07,132.13)">
                     <g class="nad-active">
                         <g transform="rotate(168.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -376,8 +376,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="36.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-207.91,529.46 -251.20,314.87"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-214.34,497.60)">
+                <polyline class="nad-edge-path" points="-207.91,529.46 -251.20,314.87"/>
+                <g class="nad-edge-infos" transform="translate(-214.34,497.60)">
                     <g class="nad-active">
                         <g transform="rotate(-11.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -390,8 +390,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="37">
             <g id="37.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="66.03,356.47 -57.19,448.23"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(39.96,375.88)">
+                <polyline class="nad-edge-path" points="66.03,356.47 -57.19,448.23"/>
+                <g class="nad-edge-infos" transform="translate(39.96,375.88)">
                     <g class="nad-active">
                         <g transform="rotate(-126.67)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -402,8 +402,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="37.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-180.42,539.99 -57.19,448.23"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-154.35,520.58)">
+                <polyline class="nad-edge-path" points="-180.42,539.99 -57.19,448.23"/>
+                <g class="nad-edge-infos" transform="translate(-154.35,520.58)">
                     <g class="nad-active">
                         <g transform="rotate(53.33)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -416,8 +416,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="38">
             <g id="38.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="577.50,-524.17 700.51,-423.67"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(602.67,-503.61)">
+                <polyline class="nad-edge-path" points="577.50,-524.17 700.51,-423.67"/>
+                <g class="nad-edge-infos" transform="translate(602.67,-503.61)">
                     <g class="nad-active">
                         <g transform="rotate(129.25)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -428,8 +428,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="38.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="823.51,-323.16 700.51,-423.67"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(798.34,-343.73)">
+                <polyline class="nad-edge-path" points="823.51,-323.16 700.51,-423.67"/>
+                <g class="nad-edge-infos" transform="translate(798.34,-343.73)">
                     <g class="nad-active">
                         <g transform="rotate(-50.75)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -442,8 +442,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="39">
             <g id="39.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="550.33,-514.70 508.07,-321.54"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(543.38,-482.96)">
+                <polyline class="nad-edge-path" points="550.33,-514.70 508.07,-321.54"/>
+                <g class="nad-edge-infos" transform="translate(543.38,-482.96)">
                     <g class="nad-active">
                         <g transform="rotate(-167.66)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -454,8 +454,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="39.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="465.80,-128.37 508.07,-321.54"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(472.75,-160.12)">
+                <polyline class="nad-edge-path" points="465.80,-128.37 508.07,-321.54"/>
+                <g class="nad-edge-infos" transform="translate(472.75,-160.12)">
                     <g class="nad-active">
                         <g transform="rotate(12.34)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -468,8 +468,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="40">
             <g id="40.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="528.71,-541.61 365.94,-541.88"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(496.21,-541.67)">
+                <polyline class="nad-edge-path" points="528.71,-541.61 365.94,-541.88"/>
+                <g class="nad-edge-infos" transform="translate(496.21,-541.67)">
                     <g class="nad-active">
                         <g transform="rotate(-89.91)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -480,8 +480,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="40.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="203.18,-542.14 365.94,-541.88"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(235.68,-542.09)">
+                <polyline class="nad-edge-path" points="203.18,-542.14 365.94,-541.88"/>
+                <g class="nad-edge-infos" transform="translate(235.68,-542.09)">
                     <g class="nad-active">
                         <g transform="rotate(90.09)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -494,8 +494,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="41">
             <g id="41.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="820.51,-292.87 652.36,-203.64"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(791.81,-277.64)">
+                <polyline class="nad-edge-path" points="820.51,-292.87 652.36,-203.64"/>
+                <g class="nad-edge-infos" transform="translate(791.81,-277.64)">
                     <g class="nad-active">
                         <g transform="rotate(-117.96)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -506,8 +506,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="41.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="484.22,-114.40 652.36,-203.64"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(512.92,-129.63)">
+                <polyline class="nad-edge-path" points="484.22,-114.40 652.36,-203.64"/>
+                <g class="nad-edge-infos" transform="translate(512.92,-129.63)">
                     <g class="nad-active">
                         <g transform="rotate(62.04)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -520,8 +520,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="42">
             <g id="42.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="445.02,-124.62 317.80,-321.85"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(427.40,-151.93)">
+                <polyline class="nad-edge-path" points="445.02,-124.62 317.80,-321.85"/>
+                <g class="nad-edge-infos" transform="translate(427.40,-151.93)">
                     <g class="nad-active">
                         <g transform="rotate(-32.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -532,8 +532,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="42.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="190.59,-519.08 317.80,-321.85"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(208.20,-491.76)">
+                <polyline class="nad-edge-path" points="190.59,-519.08 317.80,-321.85"/>
+                <g class="nad-edge-infos" transform="translate(208.20,-491.76)">
                     <g class="nad-active">
                         <g transform="rotate(147.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -546,8 +546,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="43">
             <g id="43.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="463.74,-74.27 489.26,107.81"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(468.25,-42.09)">
+                <polyline class="nad-edge-path" points="463.74,-74.27 489.26,107.81"/>
+                <g class="nad-edge-infos" transform="translate(468.25,-42.09)">
                     <g class="nad-active">
                         <g transform="rotate(172.02)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -558,8 +558,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="43.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="523.10,349.32 497.59,167.23"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(518.59,317.14)">
+                <polyline class="nad-edge-path" points="523.10,349.32 497.59,167.23"/>
+                <g class="nad-edge-infos" transform="translate(518.59,317.14)">
                     <g class="nad-active">
                         <g transform="rotate(-7.98)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -569,15 +569,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl120to180-line nad-winding" cx="492.04" cy="127.62" r="20.00"/>
                 <circle class="nad-vl0to30-line nad-winding" cx="494.81" cy="147.43" r="20.00"/>
             </g>
         </g>
         <g id="44">
             <g id="44.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="442.21,-80.47 293.33,96.32"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(421.28,-55.61)">
+                <polyline class="nad-edge-path" points="442.21,-80.47 293.33,96.32"/>
+                <g class="nad-edge-infos" transform="translate(421.28,-55.61)">
                     <g class="nad-active">
                         <g transform="rotate(-139.90)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -588,8 +588,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="44.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="105.80,319.01 254.68,142.22"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(126.73,294.15)">
+                <polyline class="nad-edge-path" points="105.80,319.01 254.68,142.22"/>
+                <g class="nad-edge-infos" transform="translate(126.73,294.15)">
                     <g class="nad-active">
                         <g transform="rotate(40.10)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -599,15 +599,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl120to180-line nad-winding" cx="280.45" cy="111.62" r="20.00"/>
                 <circle class="nad-vl0to30-line nad-winding" cx="267.56" cy="126.92" r="20.00"/>
             </g>
         </g>
         <g id="45">
             <g id="45.1" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="149.34,-534.28 -85.57,-463.74"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(118.22,-524.93)">
+                <polyline class="nad-edge-path" points="149.34,-534.28 -85.57,-463.74"/>
+                <g class="nad-edge-infos" transform="translate(118.22,-524.93)">
                     <g class="nad-active">
                         <g transform="rotate(-106.71)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -618,8 +618,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="45.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-377.94,-375.95 -143.03,-446.49"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-346.81,-385.30)">
+                <polyline class="nad-edge-path" points="-377.94,-375.95 -143.03,-446.49"/>
+                <g class="nad-edge-infos" transform="translate(-346.81,-385.30)">
                     <g class="nad-active">
                         <g transform="rotate(73.29)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -629,15 +629,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl120to180-line nad-winding" cx="-104.72" cy="-457.99" r="20.00"/>
                 <circle class="nad-vl0to30-line nad-winding" cx="-123.88" cy="-452.24" r="20.00"/>
             </g>
         </g>
         <g id="46">
             <g id="46.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="545.17,397.13 666.97,534.43"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(566.74,421.44)">
+                <polyline class="nad-edge-path" points="545.17,397.13 666.97,534.43"/>
+                <g class="nad-edge-infos" transform="translate(566.74,421.44)">
                     <g class="nad-active">
                         <g transform="rotate(138.42)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -648,8 +648,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="46.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="788.77,671.73 666.97,534.43"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(767.20,647.42)">
+                <polyline class="nad-edge-path" points="788.77,671.73 666.97,534.43"/>
+                <g class="nad-edge-infos" transform="translate(767.20,647.42)">
                     <g class="nad-active">
                         <g transform="rotate(-41.58)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -662,8 +662,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="47">
             <g id="47.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="499.52,374.28 307.50,358.30"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(467.13,371.58)">
+                <polyline class="nad-edge-path" points="499.52,374.28 307.50,358.30"/>
+                <g class="nad-edge-infos" transform="translate(467.13,371.58)">
                     <g class="nad-active">
                         <g transform="rotate(-85.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -674,8 +674,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="47.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="115.49,342.33 307.50,358.30"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(147.88,345.02)">
+                <polyline class="nad-edge-path" points="115.49,342.33 307.50,358.30"/>
+                <g class="nad-edge-infos" transform="translate(147.88,345.02)">
                     <g class="nad-active">
                         <g transform="rotate(94.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/IEEE_14_id_prefixed.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_id_prefixed.svg
@@ -106,8 +106,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="test_28">
             <desc>L1-2-1</desc>
             <g id="test_28.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="390.84,-874.92 467.85,-719.67"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(405.28,-845.81)">
+                <polyline class="nad-edge-path" points="390.84,-874.92 467.85,-719.67"/>
+                <g class="nad-edge-infos" transform="translate(405.28,-845.81)">
                     <g class="nad-active">
                         <g transform="rotate(153.61)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -118,8 +118,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="test_28.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="544.87,-564.41 467.85,-719.67"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(530.43,-593.53)">
+                <polyline class="nad-edge-path" points="544.87,-564.41 467.85,-719.67"/>
+                <g class="nad-edge-infos" transform="translate(530.43,-593.53)">
                     <g class="nad-active">
                         <g transform="rotate(-26.39)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -133,8 +133,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="test_29">
             <desc>L1-5-1</desc>
             <g id="test_29.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="366.82,-875.64 277.59,-719.97"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(350.66,-847.44)">
+                <polyline class="nad-edge-path" points="366.82,-875.64 277.59,-719.97"/>
+                <g class="nad-edge-infos" transform="translate(350.66,-847.44)">
                     <g class="nad-active">
                         <g transform="rotate(-150.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -145,8 +145,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="test_29.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="188.36,-564.31 277.59,-719.97"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(204.52,-592.50)">
+                <polyline class="nad-edge-path" points="188.36,-564.31 277.59,-719.97"/>
+                <g class="nad-edge-infos" transform="translate(204.52,-592.50)">
                     <g class="nad-active">
                         <g transform="rotate(29.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -160,8 +160,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="test_30">
             <desc>L9-10-1</desc>
             <g id="test_30.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="62.59,339.48 -249.07,332.57"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(30.10,338.76)">
+                <polyline class="nad-edge-path" points="62.59,339.48 -249.07,332.57"/>
+                <g class="nad-edge-infos" transform="translate(30.10,338.76)">
                     <g class="nad-active">
                         <g transform="rotate(-88.73)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -172,8 +172,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="test_30.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-560.72,325.65 -249.07,332.57"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-528.23,326.37)">
+                <polyline class="nad-edge-path" points="-560.72,325.65 -249.07,332.57"/>
+                <g class="nad-edge-infos" transform="translate(-528.23,326.37)">
                     <g class="nad-active">
                         <g transform="rotate(91.27)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -187,8 +187,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="test_31">
             <desc>L10-11-1</desc>
             <g id="test_31.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-597.01,301.99 -683.85,116.23"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-610.78,272.54)">
+                <polyline class="nad-edge-path" points="-597.01,301.99 -683.85,116.23"/>
+                <g class="nad-edge-infos" transform="translate(-610.78,272.54)">
                     <g class="nad-active">
                         <g transform="rotate(-25.05)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -199,8 +199,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="test_31.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-770.69,-69.53 -683.85,116.23"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-756.92,-40.09)">
+                <polyline class="nad-edge-path" points="-770.69,-69.53 -683.85,116.23"/>
+                <g class="nad-edge-infos" transform="translate(-756.92,-40.09)">
                     <g class="nad-active">
                         <g transform="rotate(154.95)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -214,8 +214,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="test_32">
             <desc>L6-11-1</desc>
             <g id="test_32.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-424.87,-353.00 -592.88,-230.34"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-451.12,-333.84)">
+                <polyline class="nad-edge-path" points="-424.87,-353.00 -592.88,-230.34"/>
+                <g class="nad-edge-infos" transform="translate(-451.12,-333.84)">
                     <g class="nad-active">
                         <g transform="rotate(-126.13)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -226,8 +226,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="test_32.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-760.89,-107.67 -592.88,-230.34"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-734.64,-126.83)">
+                <polyline class="nad-edge-path" points="-760.89,-107.67 -592.88,-230.34"/>
+                <g class="nad-edge-infos" transform="translate(-734.64,-126.83)">
                     <g class="nad-active">
                         <g transform="rotate(53.87)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -241,8 +241,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="test_33">
             <desc>L6-12-1</desc>
             <g id="test_33.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-382.10,-355.46 -280.61,-297.89"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-353.83,-339.42)">
+                <polyline class="nad-edge-path" points="-382.10,-355.46 -280.61,-297.89"/>
+                <g class="nad-edge-infos" transform="translate(-353.83,-339.42)">
                     <g class="nad-active">
                         <g transform="rotate(119.56)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -253,8 +253,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="test_33.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-179.13,-240.32 -280.61,-297.89"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-207.39,-256.36)">
+                <polyline class="nad-edge-path" points="-179.13,-240.32 -280.61,-297.89"/>
+                <g class="nad-edge-infos" transform="translate(-207.39,-256.36)">
                     <g class="nad-active">
                         <g transform="rotate(-60.44)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -268,8 +268,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="test_34">
             <desc>L12-13-1</desc>
             <g id="test_34.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-167.89,-204.71 -228.44,-77.21"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-181.83,-175.35)">
+                <polyline class="nad-edge-path" points="-167.89,-204.71 -228.44,-77.21"/>
+                <g class="nad-edge-infos" transform="translate(-181.83,-175.35)">
                     <g class="nad-active">
                         <g transform="rotate(-154.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -280,8 +280,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="test_34.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-289.00,50.28 -228.44,-77.21"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-275.05,20.93)">
+                <polyline class="nad-edge-path" points="-289.00,50.28 -228.44,-77.21"/>
+                <g class="nad-edge-infos" transform="translate(-275.05,20.93)">
                     <g class="nad-active">
                         <g transform="rotate(25.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -295,8 +295,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="test_35">
             <desc>L6-13-1</desc>
             <g id="test_35.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-398.41,-343.22 -352.11,-147.36"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-390.93,-311.60)">
+                <polyline class="nad-edge-path" points="-398.41,-343.22 -352.11,-147.36"/>
+                <g class="nad-edge-infos" transform="translate(-390.93,-311.60)">
                     <g class="nad-active">
                         <g transform="rotate(166.70)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -307,8 +307,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="test_35.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-305.80,48.50 -352.11,-147.36"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-313.28,16.87)">
+                <polyline class="nad-edge-path" points="-305.80,48.50 -352.11,-147.36"/>
+                <g class="nad-edge-infos" transform="translate(-313.28,16.87)">
                     <g class="nad-active">
                         <g transform="rotate(-13.30)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -322,8 +322,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="test_36">
             <desc>L13-14-1</desc>
             <g id="test_36.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-294.89,98.31 -251.20,314.87"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-288.47,130.17)">
+                <polyline class="nad-edge-path" points="-294.89,98.31 -251.20,314.87"/>
+                <g class="nad-edge-infos" transform="translate(-288.47,130.17)">
                     <g class="nad-active">
                         <g transform="rotate(168.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -334,8 +334,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="test_36.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-207.52,531.42 -251.20,314.87"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-213.94,499.56)">
+                <polyline class="nad-edge-path" points="-207.52,531.42 -251.20,314.87"/>
+                <g class="nad-edge-infos" transform="translate(-213.94,499.56)">
                     <g class="nad-active">
                         <g transform="rotate(-11.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -349,8 +349,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="test_37">
             <desc>L9-14-1</desc>
             <g id="test_37.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="67.63,355.28 -57.19,448.23"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(41.57,374.69)">
+                <polyline class="nad-edge-path" points="67.63,355.28 -57.19,448.23"/>
+                <g class="nad-edge-infos" transform="translate(41.57,374.69)">
                     <g class="nad-active">
                         <g transform="rotate(-126.67)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -361,8 +361,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="test_37.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-182.02,541.18 -57.19,448.23"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-155.95,521.77)">
+                <polyline class="nad-edge-path" points="-182.02,541.18 -57.19,448.23"/>
+                <g class="nad-edge-infos" transform="translate(-155.95,521.77)">
                     <g class="nad-active">
                         <g transform="rotate(53.33)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -376,8 +376,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="test_38">
             <desc>L2-3-1</desc>
             <g id="test_38.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="575.95,-525.43 700.51,-423.67"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(601.12,-504.87)">
+                <polyline class="nad-edge-path" points="575.95,-525.43 700.51,-423.67"/>
+                <g class="nad-edge-infos" transform="translate(601.12,-504.87)">
                     <g class="nad-active">
                         <g transform="rotate(129.25)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -388,8 +388,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="test_38.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="825.06,-321.90 700.51,-423.67"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(799.89,-342.46)">
+                <polyline class="nad-edge-path" points="825.06,-321.90 700.51,-423.67"/>
+                <g class="nad-edge-infos" transform="translate(799.89,-342.46)">
                     <g class="nad-active">
                         <g transform="rotate(-50.75)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -403,8 +403,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="test_39">
             <desc>L2-4-1</desc>
             <g id="test_39.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="550.76,-516.66 508.07,-321.54"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(543.81,-484.91)">
+                <polyline class="nad-edge-path" points="550.76,-516.66 508.07,-321.54"/>
+                <g class="nad-edge-infos" transform="translate(543.81,-484.91)">
                     <g class="nad-active">
                         <g transform="rotate(-167.66)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -415,8 +415,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="test_39.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="465.38,-126.42 508.07,-321.54"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(472.32,-158.17)">
+                <polyline class="nad-edge-path" points="465.38,-126.42 508.07,-321.54"/>
+                <g class="nad-edge-infos" transform="translate(472.32,-158.17)">
                     <g class="nad-active">
                         <g transform="rotate(12.34)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -430,8 +430,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="test_40">
             <desc>L2-5-1</desc>
             <g id="test_40.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="530.71,-541.61 365.94,-541.88"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(498.21,-541.66)">
+                <polyline class="nad-edge-path" points="530.71,-541.61 365.94,-541.88"/>
+                <g class="nad-edge-infos" transform="translate(498.21,-541.66)">
                     <g class="nad-active">
                         <g transform="rotate(-89.91)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -442,8 +442,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="test_40.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="201.18,-542.14 365.94,-541.88"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(233.68,-542.09)">
+                <polyline class="nad-edge-path" points="201.18,-542.14 365.94,-541.88"/>
+                <g class="nad-edge-infos" transform="translate(233.68,-542.09)">
                     <g class="nad-active">
                         <g transform="rotate(90.09)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -457,8 +457,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="test_41">
             <desc>L3-4-1</desc>
             <g id="test_41.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="822.28,-293.81 652.36,-203.64"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(793.57,-278.58)">
+                <polyline class="nad-edge-path" points="822.28,-293.81 652.36,-203.64"/>
+                <g class="nad-edge-infos" transform="translate(793.57,-278.58)">
                     <g class="nad-active">
                         <g transform="rotate(-117.96)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -469,8 +469,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="test_41.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="482.45,-113.46 652.36,-203.64"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(511.16,-128.70)">
+                <polyline class="nad-edge-path" points="482.45,-113.46 652.36,-203.64"/>
+                <g class="nad-edge-infos" transform="translate(511.16,-128.70)">
                     <g class="nad-active">
                         <g transform="rotate(62.04)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -484,8 +484,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="test_42">
             <desc>L4-5-1</desc>
             <g id="test_42.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="446.10,-122.94 317.80,-321.85"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(428.49,-150.25)">
+                <polyline class="nad-edge-path" points="446.10,-122.94 317.80,-321.85"/>
+                <g class="nad-edge-infos" transform="translate(428.49,-150.25)">
                     <g class="nad-active">
                         <g transform="rotate(-32.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -496,8 +496,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="test_42.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="189.50,-520.76 317.80,-321.85"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(207.12,-493.44)">
+                <polyline class="nad-edge-path" points="189.50,-520.76 317.80,-321.85"/>
+                <g class="nad-edge-infos" transform="translate(207.12,-493.44)">
                     <g class="nad-active">
                         <g transform="rotate(147.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -511,8 +511,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="test_43">
             <desc>T4-7-1</desc>
             <g id="test_43.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="463.46,-76.25 489.26,107.81"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(467.97,-44.07)">
+                <polyline class="nad-edge-path" points="463.46,-76.25 489.26,107.81"/>
+                <g class="nad-edge-infos" transform="translate(467.97,-44.07)">
                     <g class="nad-active">
                         <g transform="rotate(172.02)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -523,8 +523,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="test_43.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="523.38,351.30 497.59,167.23"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(518.87,319.12)">
+                <polyline class="nad-edge-path" points="523.38,351.30 497.59,167.23"/>
+                <g class="nad-edge-infos" transform="translate(518.87,319.12)">
                     <g class="nad-active">
                         <g transform="rotate(-7.98)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -534,7 +534,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl120to180 nad-winding" cx="492.04" cy="127.62" r="20.00"/>
                 <circle class="nad-vl0to30 nad-winding" cx="494.81" cy="147.43" r="20.00"/>
             </g>
@@ -542,8 +542,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="test_44">
             <desc>T4-9-1</desc>
             <g id="test_44.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="443.50,-82.00 293.33,96.32"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(422.56,-57.14)">
+                <polyline class="nad-edge-path" points="443.50,-82.00 293.33,96.32"/>
+                <g class="nad-edge-infos" transform="translate(422.56,-57.14)">
                     <g class="nad-active">
                         <g transform="rotate(-139.90)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -554,8 +554,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="test_44.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="104.51,320.54 254.68,142.22"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(125.44,295.68)">
+                <polyline class="nad-edge-path" points="104.51,320.54 254.68,142.22"/>
+                <g class="nad-edge-infos" transform="translate(125.44,295.68)">
                     <g class="nad-active">
                         <g transform="rotate(40.10)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -565,7 +565,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl120to180 nad-winding" cx="280.45" cy="111.62" r="20.00"/>
                 <circle class="nad-vl0to30 nad-winding" cx="267.56" cy="126.92" r="20.00"/>
             </g>
@@ -573,8 +573,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="test_45">
             <desc>T5-6-1</desc>
             <g id="test_45.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="151.26,-534.85 -85.57,-463.74"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(120.13,-525.50)">
+                <polyline class="nad-edge-path" points="151.26,-534.85 -85.57,-463.74"/>
+                <g class="nad-edge-infos" transform="translate(120.13,-525.50)">
                     <g class="nad-active">
                         <g transform="rotate(-106.71)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -585,8 +585,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="test_45.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-379.86,-375.37 -143.03,-446.49"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-348.73,-384.72)">
+                <polyline class="nad-edge-path" points="-379.86,-375.37 -143.03,-446.49"/>
+                <g class="nad-edge-infos" transform="translate(-348.73,-384.72)">
                     <g class="nad-active">
                         <g transform="rotate(73.29)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -596,7 +596,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl120to180 nad-winding" cx="-104.72" cy="-457.99" r="20.00"/>
                 <circle class="nad-vl0to30 nad-winding" cx="-123.88" cy="-452.24" r="20.00"/>
             </g>
@@ -604,8 +604,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="test_46">
             <desc>L7-8-1</desc>
             <g id="test_46.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="543.84,395.63 666.97,534.43"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(565.41,419.94)">
+                <polyline class="nad-edge-path" points="543.84,395.63 666.97,534.43"/>
+                <g class="nad-edge-infos" transform="translate(565.41,419.94)">
                     <g class="nad-active">
                         <g transform="rotate(138.42)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -616,8 +616,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="test_46.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="790.10,673.23 666.97,534.43"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(768.53,648.91)">
+                <polyline class="nad-edge-path" points="790.10,673.23 666.97,534.43"/>
+                <g class="nad-edge-infos" transform="translate(768.53,648.91)">
                     <g class="nad-active">
                         <g transform="rotate(-41.58)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -631,8 +631,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="test_47">
             <desc>L7-9-1</desc>
             <g id="test_47.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="501.51,374.44 307.50,358.30"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(469.12,371.75)">
+                <polyline class="nad-edge-path" points="501.51,374.44 307.50,358.30"/>
+                <g class="nad-edge-infos" transform="translate(469.12,371.75)">
                     <g class="nad-active">
                         <g transform="rotate(-85.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -643,8 +643,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="test_47.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="113.50,342.16 307.50,358.30"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(145.88,344.85)">
+                <polyline class="nad-edge-path" points="113.50,342.16 307.50,358.30"/>
+                <g class="nad-edge-infos" transform="translate(145.88,344.85)">
                     <g class="nad-active">
                         <g transform="rotate(94.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/IEEE_24_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_24_bus.svg
@@ -146,8 +146,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="48">
             <desc>L-1-2-1 </desc>
             <g id="48.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-940.19,-172.23 -989.86,66.22"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-946.82,-140.42)">
+                <polyline class="nad-edge-path" points="-940.19,-172.23 -989.86,66.22"/>
+                <g class="nad-edge-infos" transform="translate(-946.82,-140.42)">
                     <g class="nad-active">
                         <g transform="rotate(-168.23)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -158,8 +158,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="48.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1039.52,304.68 -989.86,66.22"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1032.90,272.86)">
+                <polyline class="nad-edge-path" points="-1039.52,304.68 -989.86,66.22"/>
+                <g class="nad-edge-infos" transform="translate(-1032.90,272.86)">
                     <g class="nad-active">
                         <g transform="rotate(11.77)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -173,8 +173,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="49">
             <desc>L-3-1-1 </desc>
             <g id="49.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-315.54,-478.90 -613.66,-343.33"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-345.12,-465.45)">
+                <polyline class="nad-edge-path" points="-315.54,-478.90 -613.66,-343.33"/>
+                <g class="nad-edge-infos" transform="translate(-345.12,-465.45)">
                     <g class="nad-active">
                         <g transform="rotate(-114.45)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -185,8 +185,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="49.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-911.78,-207.75 -613.66,-343.33"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-882.20,-221.21)">
+                <polyline class="nad-edge-path" points="-911.78,-207.75 -613.66,-343.33"/>
+                <g class="nad-edge-infos" transform="translate(-882.20,-221.21)">
                     <g class="nad-active">
                         <g transform="rotate(65.55)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -200,8 +200,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="50">
             <desc>L-1-5-1 </desc>
             <g id="50.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-959.31,-189.52 -1089.70,-148.35"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-990.30,-179.73)">
+                <polyline class="nad-edge-path" points="-959.31,-189.52 -1089.70,-148.35"/>
+                <g class="nad-edge-infos" transform="translate(-990.30,-179.73)">
                     <g class="nad-active">
                         <g transform="rotate(-107.52)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -212,8 +212,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="50.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1220.09,-107.19 -1089.70,-148.35"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1189.10,-116.97)">
+                <polyline class="nad-edge-path" points="-1220.09,-107.19 -1089.70,-148.35"/>
+                <g class="nad-edge-infos" transform="translate(-1189.10,-116.97)">
                     <g class="nad-active">
                         <g transform="rotate(72.48)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -227,8 +227,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="51">
             <desc>L-10-6-1 </desc>
             <g id="51.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-751.50,146.16 -1004.38,311.59"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-778.69,163.95)">
+                <polyline class="nad-edge-path" points="-751.50,146.16 -1004.38,311.59"/>
+                <g class="nad-edge-infos" transform="translate(-778.69,163.95)">
                     <g class="nad-active">
                         <g transform="rotate(-123.19)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -239,8 +239,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="51.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1257.27,477.01 -1004.38,311.59"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1230.07,459.22)">
+                <polyline class="nad-edge-path" points="-1257.27,477.01 -1004.38,311.59"/>
+                <g class="nad-edge-infos" transform="translate(-1230.07,459.22)">
                     <g class="nad-active">
                         <g transform="rotate(56.81)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -254,8 +254,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="52">
             <desc>L-8-10-1 </desc>
             <g id="52.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-687.06,-398.21 -707.58,-145.72"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-689.69,-365.82)">
+                <polyline class="nad-edge-path" points="-687.06,-398.21 -707.58,-145.72"/>
+                <g class="nad-edge-infos" transform="translate(-689.69,-365.82)">
                     <g class="nad-active">
                         <g transform="rotate(-175.35)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -266,8 +266,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="52.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-728.09,106.78 -707.58,-145.72"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-725.46,74.39)">
+                <polyline class="nad-edge-path" points="-728.09,106.78 -707.58,-145.72"/>
+                <g class="nad-edge-infos" transform="translate(-725.46,74.39)">
                     <g class="nad-active">
                         <g transform="rotate(4.65)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -281,8 +281,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="53">
             <desc>T-5-10-1 </desc>
             <g id="53.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1221.16,-89.03 -1014.63,4.02"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1191.52,-75.68)">
+                <polyline class="nad-edge-path" points="-1221.16,-89.03 -1014.63,4.02"/>
+                <g class="nad-edge-infos" transform="translate(-1191.52,-75.68)">
                     <g class="nad-active">
                         <g transform="rotate(114.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -293,8 +293,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="53.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-753.41,121.72 -959.93,28.67"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-783.04,108.37)">
+                <polyline class="nad-edge-path" points="-753.41,121.72 -959.93,28.67"/>
+                <g class="nad-edge-infos" transform="translate(-783.04,108.37)">
                     <g class="nad-active">
                         <g transform="rotate(-65.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -304,7 +304,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl120to180 nad-winding" cx="-996.40" cy="12.24" r="20.00"/>
                 <circle class="nad-vl120to180 nad-winding" cx="-978.16" cy="20.45" r="20.00"/>
             </g>
@@ -312,8 +312,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="54">
             <desc>T-11-10-1 </desc>
             <g id="54.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-114.16,141.27 -379.41,137.36"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-146.65,140.79)">
+                <polyline class="nad-edge-path" points="-114.16,141.27 -379.41,137.36"/>
+                <g class="nad-edge-infos" transform="translate(-146.65,140.79)">
                     <g class="nad-active">
                         <g transform="rotate(-89.16)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -324,8 +324,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="54.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-704.66,132.57 -439.41,136.48"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-672.16,133.05)">
+                <polyline class="nad-edge-path" points="-704.66,132.57 -439.41,136.48"/>
+                <g class="nad-edge-infos" transform="translate(-672.16,133.05)">
                     <g class="nad-active">
                         <g transform="rotate(90.84)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -335,7 +335,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl180to300 nad-winding" cx="-399.41" cy="137.07" r="20.00"/>
                 <circle class="nad-vl120to180 nad-winding" cx="-419.41" cy="136.78" r="20.00"/>
             </g>
@@ -343,8 +343,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="55">
             <desc>T-12-10-1 </desc>
             <g id="55.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-286.33,446.48 -473.36,314.05"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-312.86,427.70)">
+                <polyline class="nad-edge-path" points="-286.33,446.48 -473.36,314.05"/>
+                <g class="nad-edge-infos" transform="translate(-312.86,427.70)">
                     <g class="nad-active">
                         <g transform="rotate(-54.70)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -355,8 +355,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="55.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-709.35,146.94 -522.32,279.37"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-682.82,165.72)">
+                <polyline class="nad-edge-path" points="-709.35,146.94 -522.32,279.37"/>
+                <g class="nad-edge-infos" transform="translate(-682.82,165.72)">
                     <g class="nad-active">
                         <g transform="rotate(125.30)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -366,7 +366,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl180to300 nad-winding" cx="-489.68" cy="302.49" r="20.00"/>
                 <circle class="nad-vl120to180 nad-winding" cx="-506.00" cy="290.93" r="20.00"/>
             </g>
@@ -374,8 +374,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="56">
             <desc>L-11-13-1 </desc>
             <g id="56.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-85.50,166.95 -56.31,400.53"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-81.47,199.20)">
+                <polyline class="nad-edge-path" points="-85.50,166.95 -56.31,400.53"/>
+                <g class="nad-edge-infos" transform="translate(-81.47,199.20)">
                     <g class="nad-active">
                         <g transform="rotate(172.88)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -386,8 +386,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="56.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-27.11,634.11 -56.31,400.53"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-31.14,601.86)">
+                <polyline class="nad-edge-path" points="-27.11,634.11 -56.31,400.53"/>
+                <g class="nad-edge-infos" transform="translate(-31.14,601.86)">
                     <g class="nad-active">
                         <g transform="rotate(-7.12)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -401,8 +401,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="57">
             <desc>L-11-14-1 </desc>
             <g id="57.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-67.34,127.65 131.36,-2.75"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-40.17,109.82)">
+                <polyline class="nad-edge-path" points="-67.34,127.65 131.36,-2.75"/>
+                <g class="nad-edge-infos" transform="translate(-40.17,109.82)">
                     <g class="nad-active">
                         <g transform="rotate(56.72)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -413,8 +413,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="57.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="330.07,-133.16 131.36,-2.75"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(302.90,-115.33)">
+                <polyline class="nad-edge-path" points="330.07,-133.16 131.36,-2.75"/>
+                <g class="nad-edge-infos" transform="translate(302.90,-115.33)">
                     <g class="nad-active">
                         <g transform="rotate(-123.28)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -428,8 +428,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="58">
             <desc>T-11-9-1 </desc>
             <g id="58.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-111.89,131.12 -217.54,83.24"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-141.49,117.71)">
+                <polyline class="nad-edge-path" points="-111.89,131.12 -217.54,83.24"/>
+                <g class="nad-edge-infos" transform="translate(-141.49,117.71)">
                     <g class="nad-active">
                         <g transform="rotate(-65.62)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -440,8 +440,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="58.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-377.85,10.59 -272.19,58.47"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-348.25,24.01)">
+                <polyline class="nad-edge-path" points="-377.85,10.59 -272.19,58.47"/>
+                <g class="nad-edge-infos" transform="translate(-348.25,24.01)">
                     <g class="nad-active">
                         <g transform="rotate(114.38)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -451,7 +451,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl180to300 nad-winding" cx="-235.76" cy="74.98" r="20.00"/>
                 <circle class="nad-vl120to180 nad-winding" cx="-253.98" cy="66.73" r="20.00"/>
             </g>
@@ -459,8 +459,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="59">
             <desc>L-12-13-1 </desc>
             <g id="59.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-245.81,477.39 -144.74,560.32"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-220.68,498.01)">
+                <polyline class="nad-edge-path" points="-245.81,477.39 -144.74,560.32"/>
+                <g class="nad-edge-infos" transform="translate(-220.68,498.01)">
                     <g class="nad-active">
                         <g transform="rotate(129.37)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -471,8 +471,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="59.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-43.67,643.24 -144.74,560.32"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-68.79,622.62)">
+                <polyline class="nad-edge-path" points="-43.67,643.24 -144.74,560.32"/>
+                <g class="nad-edge-infos" transform="translate(-68.79,622.62)">
                     <g class="nad-active">
                         <g transform="rotate(-50.63)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -486,8 +486,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="60">
             <desc>L-12-23-1 </desc>
             <g id="60.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-242.31,471.77 7.77,585.44"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-212.72,485.22)">
+                <polyline class="nad-edge-path" points="-242.31,471.77 7.77,585.44"/>
+                <g class="nad-edge-infos" transform="translate(-212.72,485.22)">
                     <g class="nad-active">
                         <g transform="rotate(114.44)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -498,8 +498,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="60.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="257.86,699.10 7.77,585.44"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(228.27,685.65)">
+                <polyline class="nad-edge-path" points="257.86,699.10 7.77,585.44"/>
+                <g class="nad-edge-infos" transform="translate(228.27,685.65)">
                     <g class="nad-active">
                         <g transform="rotate(-65.56)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -513,8 +513,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="61">
             <desc>T-9-12-1 </desc>
             <g id="61.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-393.88,24.53 -341.76,201.86"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-384.72,55.71)">
+                <polyline class="nad-edge-path" points="-393.88,24.53 -341.76,201.86"/>
+                <g class="nad-edge-infos" transform="translate(-384.72,55.71)">
                     <g class="nad-active">
                         <g transform="rotate(163.62)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -525,8 +525,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="61.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-272.72,436.75 -324.84,259.43"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-281.88,405.57)">
+                <polyline class="nad-edge-path" points="-272.72,436.75 -324.84,259.43"/>
+                <g class="nad-edge-infos" transform="translate(-281.88,405.57)">
                     <g class="nad-active">
                         <g transform="rotate(-16.38)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -536,7 +536,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl120to180 nad-winding" cx="-336.12" cy="221.05" r="20.00"/>
                 <circle class="nad-vl180to300 nad-winding" cx="-330.48" cy="240.24" r="20.00"/>
             </g>
@@ -544,8 +544,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="62">
             <desc>L-23-13-1 </desc>
             <g id="62.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="255.91,705.51 128.56,684.53"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(223.84,700.22)">
+                <polyline class="nad-edge-path" points="255.91,705.51 128.56,684.53"/>
+                <g class="nad-edge-infos" transform="translate(223.84,700.22)">
                     <g class="nad-active">
                         <g transform="rotate(-80.65)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -556,8 +556,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="62.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1.21,663.56 128.56,684.53"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(33.28,668.84)">
+                <polyline class="nad-edge-path" points="1.21,663.56 128.56,684.53"/>
+                <g class="nad-edge-infos" transform="translate(33.28,668.84)">
                     <g class="nad-active">
                         <g transform="rotate(99.35)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -571,8 +571,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="63">
             <desc>L-14-16-1 </desc>
             <g id="63.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="375.96,-153.98 583.78,-211.71"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(407.27,-162.68)">
+                <polyline class="nad-edge-path" points="375.96,-153.98 583.78,-211.71"/>
+                <g class="nad-edge-infos" transform="translate(407.27,-162.68)">
                     <g class="nad-active">
                         <g transform="rotate(74.48)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -583,8 +583,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="63.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="791.59,-269.44 583.78,-211.71"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(760.28,-260.74)">
+                <polyline class="nad-edge-path" points="791.59,-269.44 583.78,-211.71"/>
+                <g class="nad-edge-infos" transform="translate(760.28,-260.74)">
                     <g class="nad-active">
                         <g transform="rotate(-105.52)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -598,8 +598,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="64">
             <desc>L-16-15-1 </desc>
             <g id="64.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="815.78,-301.76 812.72,-506.88"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(815.30,-334.26)">
+                <polyline class="nad-edge-path" points="815.78,-301.76 812.72,-506.88"/>
+                <g class="nad-edge-infos" transform="translate(815.30,-334.26)">
                     <g class="nad-active">
                         <g transform="rotate(-0.86)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -610,8 +610,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="64.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="809.65,-712.00 812.72,-506.88"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(810.14,-679.50)">
+                <polyline class="nad-edge-path" points="809.65,-712.00 812.72,-506.88"/>
+                <g class="nad-edge-infos" transform="translate(810.14,-679.50)">
                     <g class="nad-active">
                         <g transform="rotate(179.14)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -625,8 +625,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="65">
             <desc>L-15-21-1 </desc>
             <g id="65.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="827.80,-719.97 867.39,-682.52 1068.14,-634.65"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(896.57,-675.56)">
+                <polyline class="nad-edge-path" points="827.80,-719.97 867.39,-682.52 1068.14,-634.65"/>
+                <g class="nad-edge-infos" transform="translate(896.57,-675.56)">
                     <g class="nad-active">
                         <g transform="rotate(103.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -637,8 +637,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="65.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1321.13,-602.34 1268.90,-586.78 1068.14,-634.65"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1239.72,-593.74)">
+                <polyline class="nad-edge-path" points="1321.13,-602.34 1268.90,-586.78 1068.14,-634.65"/>
+                <g class="nad-edge-infos" transform="translate(1239.72,-593.74)">
                     <g class="nad-active">
                         <g transform="rotate(-76.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -652,8 +652,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="66">
             <desc>L-21-15-2 </desc>
             <g id="66.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1327.05,-627.14 1287.46,-664.60 1086.70,-712.47"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1258.27,-671.55)">
+                <polyline class="nad-edge-path" points="1327.05,-627.14 1287.46,-664.60 1086.70,-712.47"/>
+                <g class="nad-edge-infos" transform="translate(1258.27,-671.55)">
                     <g class="nad-active">
                         <g transform="rotate(-76.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -664,8 +664,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="66.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="833.71,-744.78 885.94,-760.34 1086.70,-712.47"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(915.13,-753.38)">
+                <polyline class="nad-edge-path" points="833.71,-744.78 885.94,-760.34 1086.70,-712.47"/>
+                <g class="nad-edge-infos" transform="translate(915.13,-753.38)">
                     <g class="nad-active">
                         <g transform="rotate(103.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -679,8 +679,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="67">
             <desc>L-15-24-1 </desc>
             <g id="67.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="784.00,-740.88 525.92,-775.46"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(751.79,-745.20)">
+                <polyline class="nad-edge-path" points="784.00,-740.88 525.92,-775.46"/>
+                <g class="nad-edge-infos" transform="translate(751.79,-745.20)">
                     <g class="nad-active">
                         <g transform="rotate(-82.37)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -691,8 +691,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="67.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="267.84,-810.04 525.92,-775.46"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(300.06,-805.73)">
+                <polyline class="nad-edge-path" points="267.84,-810.04 525.92,-775.46"/>
+                <g class="nad-edge-infos" transform="translate(300.06,-805.73)">
                     <g class="nad-active">
                         <g transform="rotate(97.63)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -706,8 +706,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="68">
             <desc>L-16-17-1 </desc>
             <g id="68.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="841.49,-273.27 1053.44,-248.22"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(873.76,-269.46)">
+                <polyline class="nad-edge-path" points="841.49,-273.27 1053.44,-248.22"/>
+                <g class="nad-edge-infos" transform="translate(873.76,-269.46)">
                     <g class="nad-active">
                         <g transform="rotate(96.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -718,8 +718,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="68.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1265.39,-223.17 1053.44,-248.22"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1233.11,-226.99)">
+                <polyline class="nad-edge-path" points="1265.39,-223.17 1053.44,-248.22"/>
+                <g class="nad-edge-infos" transform="translate(1233.11,-226.99)">
                     <g class="nad-active">
                         <g transform="rotate(-83.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -733,8 +733,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="69">
             <desc>L-16-19-1 </desc>
             <g id="69.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="817.31,-250.79 826.45,-48.04"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(818.78,-218.32)">
+                <polyline class="nad-edge-path" points="817.31,-250.79 826.45,-48.04"/>
+                <g class="nad-edge-infos" transform="translate(818.78,-218.32)">
                     <g class="nad-active">
                         <g transform="rotate(177.42)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -745,8 +745,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="69.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="835.59,154.70 826.45,-48.04"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(834.13,122.24)">
+                <polyline class="nad-edge-path" points="835.59,154.70 826.45,-48.04"/>
+                <g class="nad-edge-infos" transform="translate(834.13,122.24)">
                     <g class="nad-active">
                         <g transform="rotate(-2.58)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -760,8 +760,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="70">
             <desc>L-17-18-1 </desc>
             <g id="70.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1314.24,-210.36 1436.34,-159.39"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1344.24,-197.84)">
+                <polyline class="nad-edge-path" points="1314.24,-210.36 1436.34,-159.39"/>
+                <g class="nad-edge-infos" transform="translate(1344.24,-197.84)">
                     <g class="nad-active">
                         <g transform="rotate(112.66)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -772,8 +772,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="70.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1558.43,-108.42 1436.34,-159.39"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1528.44,-120.94)">
+                <polyline class="nad-edge-path" points="1558.43,-108.42 1436.34,-159.39"/>
+                <g class="nad-edge-infos" transform="translate(1528.44,-120.94)">
                     <g class="nad-active">
                         <g transform="rotate(-67.34)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -787,8 +787,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="71">
             <desc>L-17-22-1 </desc>
             <g id="71.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1311.74,-234.61 1479.18,-349.52"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1338.53,-253.00)">
+                <polyline class="nad-edge-path" points="1311.74,-234.61 1479.18,-349.52"/>
+                <g class="nad-edge-infos" transform="translate(1338.53,-253.00)">
                     <g class="nad-active">
                         <g transform="rotate(55.54)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -799,8 +799,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="71.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1646.63,-464.43 1479.18,-349.52"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1619.83,-446.04)">
+                <polyline class="nad-edge-path" points="1646.63,-464.43 1479.18,-349.52"/>
+                <g class="nad-edge-infos" transform="translate(1619.83,-446.04)">
                     <g class="nad-active">
                         <g transform="rotate(-124.46)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -814,8 +814,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="72">
             <desc>L-18-21-1 </desc>
             <g id="72.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1584.27,-124.00 1589.18,-178.28 1500.07,-370.90"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1576.59,-205.50)">
+                <polyline class="nad-edge-path" points="1584.27,-124.00 1589.18,-178.28 1500.07,-370.90"/>
+                <g class="nad-edge-infos" transform="translate(1576.59,-205.50)">
                     <g class="nad-active">
                         <g transform="rotate(-24.83)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -826,8 +826,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="72.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1366.41,-594.93 1410.96,-563.53 1500.07,-370.90"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1423.56,-536.30)">
+                <polyline class="nad-edge-path" points="1366.41,-594.93 1410.96,-563.53 1500.07,-370.90"/>
+                <g class="nad-edge-infos" transform="translate(1423.56,-536.30)">
                     <g class="nad-active">
                         <g transform="rotate(155.17)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -841,8 +841,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="73">
             <desc>L-18-21-2 </desc>
             <g id="73.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1561.12,-113.29 1516.57,-144.69 1427.46,-337.32"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1503.98,-171.92)">
+                <polyline class="nad-edge-path" points="1561.12,-113.29 1516.57,-144.69 1427.46,-337.32"/>
+                <g class="nad-edge-infos" transform="translate(1503.98,-171.92)">
                     <g class="nad-active">
                         <g transform="rotate(-24.83)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -853,8 +853,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="73.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1343.27,-584.22 1338.36,-529.94 1427.46,-337.32"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1350.95,-502.72)">
+                <polyline class="nad-edge-path" points="1343.27,-584.22 1338.36,-529.94 1427.46,-337.32"/>
+                <g class="nad-edge-infos" transform="translate(1350.95,-502.72)">
                     <g class="nad-active">
                         <g transform="rotate(155.17)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -868,8 +868,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="74">
             <desc>L-19-20-1 </desc>
             <g id="74.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="817.68,197.12 776.95,233.33 732.14,368.37"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(767.50,261.81)">
+                <polyline class="nad-edge-path" points="817.68,197.12 776.95,233.33 732.14,368.37"/>
+                <g class="nad-edge-infos" transform="translate(767.50,261.81)">
                     <g class="nad-active">
                         <g transform="rotate(-161.64)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -880,8 +880,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="74.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="698.32,556.79 687.32,503.41 732.14,368.37"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(696.77,474.94)">
+                <polyline class="nad-edge-path" points="698.32,556.79 687.32,503.41 732.14,368.37"/>
+                <g class="nad-edge-infos" transform="translate(696.77,474.94)">
                     <g class="nad-active">
                         <g transform="rotate(18.36)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -895,8 +895,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="75">
             <desc>L-19-20-2 </desc>
             <g id="75.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="841.88,205.15 852.88,258.53 808.07,393.57"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(843.43,287.01)">
+                <polyline class="nad-edge-path" points="841.88,205.15 852.88,258.53 808.07,393.57"/>
+                <g class="nad-edge-infos" transform="translate(843.43,287.01)">
                     <g class="nad-active">
                         <g transform="rotate(-161.64)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -907,8 +907,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="75.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="722.52,564.82 763.25,528.61 808.07,393.57"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(772.70,500.14)">
+                <polyline class="nad-edge-path" points="722.52,564.82 763.25,528.61 808.07,393.57"/>
+                <g class="nad-edge-infos" transform="translate(772.70,500.14)">
                     <g class="nad-active">
                         <g transform="rotate(18.36)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -922,8 +922,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="76">
             <desc>L-2-4-1 </desc>
             <g id="76.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1023.17,343.27 -879.56,434.02"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-995.69,360.63)">
+                <polyline class="nad-edge-path" points="-1023.17,343.27 -879.56,434.02"/>
+                <g class="nad-edge-infos" transform="translate(-995.69,360.63)">
                     <g class="nad-active">
                         <g transform="rotate(122.29)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -934,8 +934,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="76.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-735.95,524.78 -879.56,434.02"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-763.43,507.42)">
+                <polyline class="nad-edge-path" points="-735.95,524.78 -879.56,434.02"/>
+                <g class="nad-edge-infos" transform="translate(-763.43,507.42)">
                     <g class="nad-active">
                         <g transform="rotate(-57.71)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -949,8 +949,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="77">
             <desc>L-2-6-1 </desc>
             <g id="77.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1065.71,344.12 -1161.66,410.31"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1092.47,362.58)">
+                <polyline class="nad-edge-path" points="-1065.71,344.12 -1161.66,410.31"/>
+                <g class="nad-edge-infos" transform="translate(-1092.47,362.58)">
                     <g class="nad-active">
                         <g transform="rotate(-124.60)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -961,8 +961,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="77.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1257.61,476.49 -1161.66,410.31"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1230.86,458.04)">
+                <polyline class="nad-edge-path" points="-1257.61,476.49 -1161.66,410.31"/>
+                <g class="nad-edge-infos" transform="translate(-1230.86,458.04)">
                     <g class="nad-active">
                         <g transform="rotate(55.40)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -976,8 +976,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="78">
             <desc>L-20-23-1 </desc>
             <g id="78.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="678.64,575.96 625.57,563.56 480.68,607.43"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(596.85,572.25)">
+                <polyline class="nad-edge-path" points="678.64,575.96 625.57,563.56 480.68,607.43"/>
+                <g class="nad-edge-infos" transform="translate(596.85,572.25)">
                     <g class="nad-active">
                         <g transform="rotate(-106.84)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -988,8 +988,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="78.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="298.52,691.05 335.79,651.29 480.68,607.43"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(364.51,642.60)">
+                <polyline class="nad-edge-path" points="298.52,691.05 335.79,651.29 480.68,607.43"/>
+                <g class="nad-edge-infos" transform="translate(364.51,642.60)">
                     <g class="nad-active">
                         <g transform="rotate(73.16)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1003,8 +1003,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="79">
             <desc>L-20-23-2 </desc>
             <g id="79.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="686.03,600.37 648.75,640.13 503.86,683.99"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(620.04,648.82)">
+                <polyline class="nad-edge-path" points="686.03,600.37 648.75,640.13 503.86,683.99"/>
+                <g class="nad-edge-infos" transform="translate(620.04,648.82)">
                     <g class="nad-active">
                         <g transform="rotate(-106.84)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1015,8 +1015,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="79.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="305.90,715.45 358.97,727.86 503.86,683.99"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(387.69,719.17)">
+                <polyline class="nad-edge-path" points="305.90,715.45 358.97,727.86 503.86,683.99"/>
+                <g class="nad-edge-infos" transform="translate(387.69,719.17)">
                     <g class="nad-active">
                         <g transform="rotate(73.16)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1030,8 +1030,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="80">
             <desc>L-21-22-1 </desc>
             <g id="80.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1369.20,-600.03 1506.61,-544.24"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1399.31,-587.80)">
+                <polyline class="nad-edge-path" points="1369.20,-600.03 1506.61,-544.24"/>
+                <g class="nad-edge-infos" transform="translate(1399.31,-587.80)">
                     <g class="nad-active">
                         <g transform="rotate(112.10)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1042,8 +1042,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="80.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1644.02,-488.45 1506.61,-544.24"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1613.91,-500.68)">
+                <polyline class="nad-edge-path" points="1644.02,-488.45 1506.61,-544.24"/>
+                <g class="nad-edge-infos" transform="translate(1613.91,-500.68)">
                     <g class="nad-active">
                         <g transform="rotate(-67.90)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1057,8 +1057,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="81">
             <desc>T-24-3-1 </desc>
             <g id="81.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="220.76,-800.22 0.78,-666.98"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(192.96,-783.38)">
+                <polyline class="nad-edge-path" points="220.76,-800.22 0.78,-666.98"/>
+                <g class="nad-edge-infos" transform="translate(192.96,-783.38)">
                     <g class="nad-active">
                         <g transform="rotate(-121.20)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1069,8 +1069,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="81.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-270.51,-502.67 -50.54,-635.90"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-242.71,-519.50)">
+                <polyline class="nad-edge-path" points="-270.51,-502.67 -50.54,-635.90"/>
+                <g class="nad-edge-infos" transform="translate(-242.71,-519.50)">
                     <g class="nad-active">
                         <g transform="rotate(58.80)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1080,7 +1080,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl180to300 nad-winding" cx="-16.32" cy="-656.62" r="20.00"/>
                 <circle class="nad-vl120to180 nad-winding" cx="-33.43" cy="-646.26" r="20.00"/>
             </g>
@@ -1088,8 +1088,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="82">
             <desc>L-3-9-1 </desc>
             <g id="82.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-297.85,-464.56 -346.70,-244.69"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-304.90,-432.84)">
+                <polyline class="nad-edge-path" points="-297.85,-464.56 -346.70,-244.69"/>
+                <g class="nad-edge-infos" transform="translate(-304.90,-432.84)">
                     <g class="nad-active">
                         <g transform="rotate(-167.47)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1100,8 +1100,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="82.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-395.54,-24.83 -346.70,-244.69"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-388.50,-56.55)">
+                <polyline class="nad-edge-path" points="-395.54,-24.83 -346.70,-244.69"/>
+                <g class="nad-edge-infos" transform="translate(-388.50,-56.55)">
                     <g class="nad-active">
                         <g transform="rotate(12.53)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1115,8 +1115,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="83">
             <desc>L-4-9-1 </desc>
             <g id="83.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-701.57,516.37 -557.74,269.24"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-685.22,488.28)">
+                <polyline class="nad-edge-path" points="-701.57,516.37 -557.74,269.24"/>
+                <g class="nad-edge-infos" transform="translate(-685.22,488.28)">
                     <g class="nad-active">
                         <g transform="rotate(30.20)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1127,8 +1127,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="83.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-413.90,22.11 -557.74,269.24"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-430.25,50.20)">
+                <polyline class="nad-edge-path" points="-413.90,22.11 -557.74,269.24"/>
+                <g class="nad-edge-infos" transform="translate(-430.25,50.20)">
                     <g class="nad-active">
                         <g transform="rotate(-149.80)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1142,8 +1142,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="84">
             <desc>L-7-8-1 </desc>
             <g id="84.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-855.68,-860.25 -774.98,-653.81"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-843.85,-829.98)">
+                <polyline class="nad-edge-path" points="-855.68,-860.25 -774.98,-653.81"/>
+                <g class="nad-edge-infos" transform="translate(-843.85,-829.98)">
                     <g class="nad-active">
                         <g transform="rotate(158.65)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1154,8 +1154,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="84.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-694.28,-447.38 -774.98,-653.81"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-706.11,-477.65)">
+                <polyline class="nad-edge-path" points="-694.28,-447.38 -774.98,-653.81"/>
+                <g class="nad-edge-infos" transform="translate(-706.11,-477.65)">
                     <g class="nad-active">
                         <g transform="rotate(-21.35)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1169,8 +1169,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="85">
             <desc>L-8-9-1 </desc>
             <g id="85.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-670.80,-402.45 -543.03,-211.78"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-652.71,-375.45)">
+                <polyline class="nad-edge-path" points="-670.80,-402.45 -543.03,-211.78"/>
+                <g class="nad-edge-infos" transform="translate(-652.71,-375.45)">
                     <g class="nad-active">
                         <g transform="rotate(146.17)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1181,8 +1181,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="85.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-415.27,-21.12 -543.03,-211.78"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-433.36,-48.12)">
+                <polyline class="nad-edge-path" points="-415.27,-21.12 -543.03,-211.78"/>
+                <g class="nad-edge-infos" transform="translate(-433.36,-48.12)">
                     <g class="nad-active">
                         <g transform="rotate(-33.83)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/IEEE_30_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_30_bus.svg
@@ -170,8 +170,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="60">
             <desc>L1-2-1</desc>
             <g id="60.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="519.68,-890.97 406.11,-579.20"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(508.56,-860.43)">
+                <polyline class="nad-edge-path" points="519.68,-890.97 406.11,-579.20"/>
+                <g class="nad-edge-infos" transform="translate(508.56,-860.43)">
                     <g class="nad-active">
                         <g transform="rotate(-159.98)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -182,8 +182,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="60.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="292.54,-267.43 406.11,-579.20"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(303.66,-297.97)">
+                <polyline class="nad-edge-path" points="292.54,-267.43 406.11,-579.20"/>
+                <g class="nad-edge-infos" transform="translate(303.66,-297.97)">
                     <g class="nad-active">
                         <g transform="rotate(20.02)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -197,8 +197,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="61">
             <desc>L1-3-1</desc>
             <g id="61.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="553.51,-910.43 705.17,-883.27"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(585.50,-904.70)">
+                <polyline class="nad-edge-path" points="553.51,-910.43 705.17,-883.27"/>
+                <g class="nad-edge-infos" transform="translate(585.50,-904.70)">
                     <g class="nad-active">
                         <g transform="rotate(100.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -209,8 +209,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="61.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="856.84,-856.11 705.17,-883.27"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(824.85,-861.84)">
+                <polyline class="nad-edge-path" points="856.84,-856.11 705.17,-883.27"/>
+                <g class="nad-edge-infos" transform="translate(824.85,-861.84)">
                     <g class="nad-active">
                         <g transform="rotate(-79.85)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -224,8 +224,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="62">
             <desc>L9-10-1</desc>
             <g id="62.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="156.18,554.72 99.49,215.65"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(150.82,522.66)">
+                <polyline class="nad-edge-path" points="156.18,554.72 99.49,215.65"/>
+                <g class="nad-edge-infos" transform="translate(150.82,522.66)">
                     <g class="nad-active">
                         <g transform="rotate(-9.49)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -236,8 +236,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="62.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="42.81,-123.42 99.49,215.65"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(48.17,-91.37)">
+                <polyline class="nad-edge-path" points="42.81,-123.42 99.49,215.65"/>
+                <g class="nad-edge-infos" transform="translate(48.17,-91.37)">
                     <g class="nad-active">
                         <g transform="rotate(170.51)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -251,8 +251,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="63">
             <desc>L10-20-1</desc>
             <g id="63.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="28.33,-171.91 -136.09,-545.16"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(15.23,-201.65)">
+                <polyline class="nad-edge-path" points="28.33,-171.91 -136.09,-545.16"/>
+                <g class="nad-edge-infos" transform="translate(15.23,-201.65)">
                     <g class="nad-active">
                         <g transform="rotate(-23.77)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -263,8 +263,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="63.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-300.51,-918.41 -136.09,-545.16"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-287.41,-888.67)">
+                <polyline class="nad-edge-path" points="-300.51,-918.41 -136.09,-545.16"/>
+                <g class="nad-edge-infos" transform="translate(-287.41,-888.67)">
                     <g class="nad-active">
                         <g transform="rotate(156.23)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -278,8 +278,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="64">
             <desc>L10-17-1</desc>
             <g id="64.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="62.68,-156.99 458.06,-295.29"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(93.36,-167.72)">
+                <polyline class="nad-edge-path" points="62.68,-156.99 458.06,-295.29"/>
+                <g class="nad-edge-infos" transform="translate(93.36,-167.72)">
                     <g class="nad-active">
                         <g transform="rotate(70.72)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -290,8 +290,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="64.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="853.44,-433.58 458.06,-295.29"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(822.76,-422.85)">
+                <polyline class="nad-edge-path" points="853.44,-433.58 458.06,-295.29"/>
+                <g class="nad-edge-infos" transform="translate(822.76,-422.85)">
                     <g class="nad-active">
                         <g transform="rotate(-109.28)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -305,8 +305,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="65">
             <desc>L10-21-1</desc>
             <g id="65.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="13.39,-152.38 -115.22,-171.81"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-18.74,-157.24)">
+                <polyline class="nad-edge-path" points="13.39,-152.38 -115.22,-171.81"/>
+                <g class="nad-edge-infos" transform="translate(-18.74,-157.24)">
                     <g class="nad-active">
                         <g transform="rotate(-81.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -317,8 +317,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="65.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-243.83,-191.24 -115.22,-171.81"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-211.70,-186.38)">
+                <polyline class="nad-edge-path" points="-243.83,-191.24 -115.22,-171.81"/>
+                <g class="nad-edge-infos" transform="translate(-211.70,-186.38)">
                     <g class="nad-active">
                         <g transform="rotate(98.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -332,8 +332,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="66">
             <desc>L10-22-1</desc>
             <g id="66.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="15.50,-159.35 -217.50,-267.99"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-13.96,-173.08)">
+                <polyline class="nad-edge-path" points="15.50,-159.35 -217.50,-267.99"/>
+                <g class="nad-edge-infos" transform="translate(-13.96,-173.08)">
                     <g class="nad-active">
                         <g transform="rotate(-65.00)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -344,8 +344,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="66.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-450.50,-376.62 -217.50,-267.99"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-421.04,-362.89)">
+                <polyline class="nad-edge-path" points="-450.50,-376.62 -217.50,-267.99"/>
+                <g class="nad-edge-infos" transform="translate(-421.04,-362.89)">
                     <g class="nad-active">
                         <g transform="rotate(115.00)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -359,8 +359,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="67">
             <desc>T6-10-1</desc>
             <g id="67.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="174.33,264.79 119.81,98.73"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(164.20,233.92)">
+                <polyline class="nad-edge-path" points="174.33,264.79 119.81,98.73"/>
+                <g class="nad-edge-infos" transform="translate(164.20,233.92)">
                     <g class="nad-active">
                         <g transform="rotate(-18.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -371,8 +371,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="67.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="46.56,-124.35 101.09,41.72"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(56.70,-93.47)">
+                <polyline class="nad-edge-path" points="46.56,-124.35 101.09,41.72"/>
+                <g class="nad-edge-infos" transform="translate(56.70,-93.47)">
                     <g class="nad-active">
                         <g transform="rotate(161.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -382,7 +382,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl120to180 nad-winding" cx="113.57" cy="79.72" r="20.00"/>
                 <circle class="nad-vl30to50 nad-winding" cx="107.33" cy="60.72" r="20.00"/>
             </g>
@@ -390,8 +390,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="68">
             <desc>L9-11-1</desc>
             <g id="68.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="160.46,605.37 161.34,891.89"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(160.56,637.87)">
+                <polyline class="nad-edge-path" points="160.46,605.37 161.34,891.89"/>
+                <g class="nad-edge-infos" transform="translate(160.56,637.87)">
                     <g class="nad-active">
                         <g transform="rotate(179.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -402,8 +402,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="68.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="162.23,1178.42 161.34,891.89"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(162.13,1145.92)">
+                <polyline class="nad-edge-path" points="162.23,1178.42 161.34,891.89"/>
+                <g class="nad-edge-infos" transform="translate(162.13,1145.92)">
                     <g class="nad-active">
                         <g transform="rotate(-0.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -417,8 +417,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="69">
             <desc>L12-13-1</desc>
             <g id="69.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1178.76,-209.21 1374.29,-84.27"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1206.15,-191.71)">
+                <polyline class="nad-edge-path" points="1178.76,-209.21 1374.29,-84.27"/>
+                <g class="nad-edge-infos" transform="translate(1206.15,-191.71)">
                     <g class="nad-active">
                         <g transform="rotate(122.58)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -429,8 +429,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="69.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1569.81,40.67 1374.29,-84.27"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1542.42,23.17)">
+                <polyline class="nad-edge-path" points="1569.81,40.67 1374.29,-84.27"/>
+                <g class="nad-edge-infos" transform="translate(1542.42,23.17)">
                     <g class="nad-active">
                         <g transform="rotate(-57.42)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -444,8 +444,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="70">
             <desc>L12-14-1</desc>
             <g id="70.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1140.19,-204.01 1054.59,-109.13"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1118.42,-179.88)">
+                <polyline class="nad-edge-path" points="1140.19,-204.01 1054.59,-109.13"/>
+                <g class="nad-edge-infos" transform="translate(1118.42,-179.88)">
                     <g class="nad-active">
                         <g transform="rotate(-137.94)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -456,8 +456,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="70.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="968.98,-14.25 1054.59,-109.13"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(990.75,-38.38)">
+                <polyline class="nad-edge-path" points="968.98,-14.25 1054.59,-109.13"/>
+                <g class="nad-edge-infos" transform="translate(990.75,-38.38)">
                     <g class="nad-active">
                         <g transform="rotate(42.06)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -471,8 +471,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="71">
             <desc>L12-15-1</desc>
             <g id="71.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1135.25,-235.79 847.67,-403.65"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1107.18,-252.18)">
+                <polyline class="nad-edge-path" points="1135.25,-235.79 847.67,-403.65"/>
+                <g class="nad-edge-infos" transform="translate(1107.18,-252.18)">
                     <g class="nad-active">
                         <g transform="rotate(-59.73)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -483,8 +483,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="71.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="560.08,-571.51 847.67,-403.65"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(588.15,-555.13)">
+                <polyline class="nad-edge-path" points="560.08,-571.51 847.67,-403.65"/>
+                <g class="nad-edge-infos" transform="translate(588.15,-555.13)">
                     <g class="nad-active">
                         <g transform="rotate(120.27)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -498,8 +498,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="72">
             <desc>L12-16-1</desc>
             <g id="72.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1172.00,-243.76 1264.93,-375.15"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1190.77,-270.29)">
+                <polyline class="nad-edge-path" points="1172.00,-243.76 1264.93,-375.15"/>
+                <g class="nad-edge-infos" transform="translate(1190.77,-270.29)">
                     <g class="nad-active">
                         <g transform="rotate(35.27)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -510,8 +510,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="72.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1357.85,-506.55 1264.93,-375.15"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1339.09,-480.01)">
+                <polyline class="nad-edge-path" points="1357.85,-506.55 1264.93,-375.15"/>
+                <g class="nad-edge-infos" transform="translate(1339.09,-480.01)">
                     <g class="nad-active">
                         <g transform="rotate(-144.73)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -525,8 +525,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="73">
             <desc>T4-12-1</desc>
             <g id="73.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="668.03,-172.38 870.13,-193.27"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(700.35,-175.72)">
+                <polyline class="nad-edge-path" points="668.03,-172.38 870.13,-193.27"/>
+                <g class="nad-edge-infos" transform="translate(700.35,-175.72)">
                     <g class="nad-active">
                         <g transform="rotate(84.10)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -537,8 +537,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="73.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1131.91,-220.32 929.81,-199.43"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1099.58,-216.98)">
+                <polyline class="nad-edge-path" points="1131.91,-220.32 929.81,-199.43"/>
+                <g class="nad-edge-infos" transform="translate(1099.58,-216.98)">
                     <g class="nad-active">
                         <g transform="rotate(-95.90)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -548,7 +548,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl120to180 nad-winding" cx="890.02" cy="-195.32" r="20.00"/>
                 <circle class="nad-vl30to50 nad-winding" cx="909.92" cy="-197.38" r="20.00"/>
             </g>
@@ -556,8 +556,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="74">
             <desc>L14-15-1</desc>
             <g id="74.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="937.24,-16.18 744.98,-289.84"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(918.55,-42.77)">
+                <polyline class="nad-edge-path" points="937.24,-16.18 744.98,-289.84"/>
+                <g class="nad-edge-infos" transform="translate(918.55,-42.77)">
                     <g class="nad-active">
                         <g transform="rotate(-35.09)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -568,8 +568,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="74.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="552.72,-563.50 744.98,-289.84"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(571.40,-536.91)">
+                <polyline class="nad-edge-path" points="552.72,-563.50 744.98,-289.84"/>
+                <g class="nad-edge-infos" transform="translate(571.40,-536.91)">
                     <g class="nad-active">
                         <g transform="rotate(144.91)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -583,8 +583,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="75">
             <desc>L15-18-1</desc>
             <g id="75.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="526.85,-607.27 378.63,-910.28"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(512.57,-636.47)">
+                <polyline class="nad-edge-path" points="526.85,-607.27 378.63,-910.28"/>
+                <g class="nad-edge-infos" transform="translate(512.57,-636.47)">
                     <g class="nad-active">
                         <g transform="rotate(-26.07)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -595,8 +595,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="75.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="230.40,-1213.29 378.63,-910.28"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(244.68,-1184.09)">
+                <polyline class="nad-edge-path" points="230.40,-1213.29 378.63,-910.28"/>
+                <g class="nad-edge-infos" transform="translate(244.68,-1184.09)">
                     <g class="nad-active">
                         <g transform="rotate(153.93)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -610,8 +610,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="76">
             <desc>L15-23-1</desc>
             <g id="76.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="512.72,-587.24 213.91,-621.15"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(480.43,-590.90)">
+                <polyline class="nad-edge-path" points="512.72,-587.24 213.91,-621.15"/>
+                <g class="nad-edge-infos" transform="translate(480.43,-590.90)">
                     <g class="nad-active">
                         <g transform="rotate(-83.53)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -622,8 +622,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="76.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-84.89,-655.05 213.91,-621.15"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-52.60,-651.39)">
+                <polyline class="nad-edge-path" points="-84.89,-655.05 213.91,-621.15"/>
+                <g class="nad-edge-infos" transform="translate(-52.60,-651.39)">
                     <g class="nad-active">
                         <g transform="rotate(96.47)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -637,8 +637,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="77">
             <desc>L16-17-1</desc>
             <g id="77.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1347.45,-523.03 1125.05,-484.68"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1315.42,-517.51)">
+                <polyline class="nad-edge-path" points="1347.45,-523.03 1125.05,-484.68"/>
+                <g class="nad-edge-infos" transform="translate(1315.42,-517.51)">
                     <g class="nad-active">
                         <g transform="rotate(-99.78)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -649,8 +649,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="77.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="902.64,-446.33 1125.05,-484.68"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(934.67,-451.85)">
+                <polyline class="nad-edge-path" points="902.64,-446.33 1125.05,-484.68"/>
+                <g class="nad-edge-infos" transform="translate(934.67,-451.85)">
                     <g class="nad-active">
                         <g transform="rotate(80.22)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -664,8 +664,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="78">
             <desc>L18-19-1</desc>
             <g id="78.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="194.95,-1244.10 9.23,-1304.67"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(164.06,-1254.18)">
+                <polyline class="nad-edge-path" points="194.95,-1244.10 9.23,-1304.67"/>
+                <g class="nad-edge-infos" transform="translate(164.06,-1254.18)">
                     <g class="nad-active">
                         <g transform="rotate(-71.94)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -676,8 +676,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="78.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-176.50,-1365.25 9.23,-1304.67"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-145.60,-1355.17)">
+                <polyline class="nad-edge-path" points="-176.50,-1365.25 9.23,-1304.67"/>
+                <g class="nad-edge-infos" transform="translate(-145.60,-1355.17)">
                     <g class="nad-active">
                         <g transform="rotate(108.06)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -691,8 +691,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="79">
             <desc>L19-20-1</desc>
             <g id="79.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-207.04,-1348.44 -255.76,-1157.45"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-215.08,-1316.95)">
+                <polyline class="nad-edge-path" points="-207.04,-1348.44 -255.76,-1157.45"/>
+                <g class="nad-edge-infos" transform="translate(-215.08,-1316.95)">
                     <g class="nad-active">
                         <g transform="rotate(-165.69)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -703,8 +703,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="79.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-304.48,-966.45 -255.76,-1157.45"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-296.45,-997.95)">
+                <polyline class="nad-edge-path" points="-304.48,-966.45 -255.76,-1157.45"/>
+                <g class="nad-edge-infos" transform="translate(-296.45,-997.95)">
                     <g class="nad-active">
                         <g transform="rotate(14.31)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -718,8 +718,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="80">
             <desc>L2-4-1</desc>
             <g id="80.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="308.79,-238.34 463.24,-206.62"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(340.62,-231.80)">
+                <polyline class="nad-edge-path" points="308.79,-238.34 463.24,-206.62"/>
+                <g class="nad-edge-infos" transform="translate(340.62,-231.80)">
                     <g class="nad-active">
                         <g transform="rotate(101.61)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -730,8 +730,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="80.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="617.68,-174.89 463.24,-206.62"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(585.85,-181.43)">
+                <polyline class="nad-edge-path" points="617.68,-174.89 463.24,-206.62"/>
+                <g class="nad-edge-infos" transform="translate(585.85,-181.43)">
                     <g class="nad-active">
                         <g transform="rotate(-78.39)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -745,8 +745,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="81">
             <desc>L2-5-1</desc>
             <g id="81.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="261.43,-231.26 -44.53,-64.26"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(232.90,-215.69)">
+                <polyline class="nad-edge-path" points="261.43,-231.26 -44.53,-64.26"/>
+                <g class="nad-edge-infos" transform="translate(232.90,-215.69)">
                     <g class="nad-active">
                         <g transform="rotate(-118.63)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -757,8 +757,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="81.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-350.49,102.74 -44.53,-64.26"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-321.96,87.17)">
+                <polyline class="nad-edge-path" points="-350.49,102.74 -44.53,-64.26"/>
+                <g class="nad-edge-infos" transform="translate(-321.96,87.17)">
                     <g class="nad-active">
                         <g transform="rotate(61.37)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -772,8 +772,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="82">
             <desc>L2-6-1</desc>
             <g id="82.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="279.03,-218.42 233.05,22.77"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(272.95,-186.50)">
+                <polyline class="nad-edge-path" points="279.03,-218.42 233.05,22.77"/>
+                <g class="nad-edge-infos" transform="translate(272.95,-186.50)">
                     <g class="nad-active">
                         <g transform="rotate(-169.21)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -784,8 +784,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="82.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="187.07,263.97 233.05,22.77"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(193.15,232.05)">
+                <polyline class="nad-edge-path" points="187.07,263.97 233.05,22.77"/>
+                <g class="nad-edge-infos" transform="translate(193.15,232.05)">
                     <g class="nad-active">
                         <g transform="rotate(10.79)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -799,8 +799,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="83">
             <desc>L21-22-1</desc>
             <g id="83.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-287.62,-212.52 -371.33,-291.22"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-311.30,-234.78)">
+                <polyline class="nad-edge-path" points="-287.62,-212.52 -371.33,-291.22"/>
+                <g class="nad-edge-infos" transform="translate(-311.30,-234.78)">
                     <g class="nad-active">
                         <g transform="rotate(-46.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -811,8 +811,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="83.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-455.03,-369.93 -371.33,-291.22"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-431.35,-347.67)">
+                <polyline class="nad-edge-path" points="-455.03,-369.93 -371.33,-291.22"/>
+                <g class="nad-edge-infos" transform="translate(-431.35,-347.67)">
                     <g class="nad-active">
                         <g transform="rotate(133.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -826,8 +826,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="84">
             <desc>L22-24-1</desc>
             <g id="84.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-499.05,-389.13 -637.01,-398.52"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-531.47,-391.34)">
+                <polyline class="nad-edge-path" points="-499.05,-389.13 -637.01,-398.52"/>
+                <g class="nad-edge-infos" transform="translate(-531.47,-391.34)">
                     <g class="nad-active">
                         <g transform="rotate(-86.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -838,8 +838,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="84.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-774.97,-407.91 -637.01,-398.52"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-742.54,-405.70)">
+                <polyline class="nad-edge-path" points="-774.97,-407.91 -637.01,-398.52"/>
+                <g class="nad-edge-infos" transform="translate(-742.54,-405.70)">
                     <g class="nad-active">
                         <g transform="rotate(93.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -853,8 +853,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="85">
             <desc>L23-24-1</desc>
             <g id="85.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-134.23,-649.30 -455.32,-533.78"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-164.81,-638.29)">
+                <polyline class="nad-edge-path" points="-134.23,-649.30 -455.32,-533.78"/>
+                <g class="nad-edge-infos" transform="translate(-164.81,-638.29)">
                     <g class="nad-active">
                         <g transform="rotate(-109.79)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -865,8 +865,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="85.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-776.42,-418.27 -455.32,-533.78"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-745.83,-429.27)">
+                <polyline class="nad-edge-path" points="-776.42,-418.27 -455.32,-533.78"/>
+                <g class="nad-edge-infos" transform="translate(-745.83,-429.27)">
                     <g class="nad-active">
                         <g transform="rotate(70.21)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -880,8 +880,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="86">
             <desc>L24-25-1</desc>
             <g id="86.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-813.90,-388.00 -965.61,-144.59"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-831.09,-360.42)">
+                <polyline class="nad-edge-path" points="-813.90,-388.00 -965.61,-144.59"/>
+                <g class="nad-edge-infos" transform="translate(-831.09,-360.42)">
                     <g class="nad-active">
                         <g transform="rotate(-148.06)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -892,8 +892,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="86.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1117.32,98.81 -965.61,-144.59"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1100.13,71.23)">
+                <polyline class="nad-edge-path" points="-1117.32,98.81 -965.61,-144.59"/>
+                <g class="nad-edge-infos" transform="translate(-1100.13,71.23)">
                     <g class="nad-active">
                         <g transform="rotate(31.94)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -907,8 +907,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="87">
             <desc>L25-26-1</desc>
             <g id="87.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1154.29,110.49 -1331.28,35.41"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1184.21,97.80)">
+                <polyline class="nad-edge-path" points="-1154.29,110.49 -1331.28,35.41"/>
+                <g class="nad-edge-infos" transform="translate(-1184.21,97.80)">
                     <g class="nad-active">
                         <g transform="rotate(-67.01)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -919,8 +919,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="87.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1508.28,-39.68 -1331.28,35.41"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1478.36,-26.99)">
+                <polyline class="nad-edge-path" points="-1508.28,-39.68 -1331.28,35.41"/>
+                <g class="nad-edge-infos" transform="translate(-1478.36,-26.99)">
                     <g class="nad-active">
                         <g transform="rotate(112.99)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -934,8 +934,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="88">
             <desc>L25-27-1</desc>
             <g id="88.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1122.01,144.38 -1012.99,440.57"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1110.78,174.88)">
+                <polyline class="nad-edge-path" points="-1122.01,144.38 -1012.99,440.57"/>
+                <g class="nad-edge-infos" transform="translate(-1110.78,174.88)">
                     <g class="nad-active">
                         <g transform="rotate(159.79)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -946,8 +946,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="88.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-903.98,736.76 -1012.99,440.57"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-915.21,706.26)">
+                <polyline class="nad-edge-path" points="-903.98,736.76 -1012.99,440.57"/>
+                <g class="nad-edge-infos" transform="translate(-915.21,706.26)">
                     <g class="nad-active">
                         <g transform="rotate(-20.21)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -961,8 +961,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="89">
             <desc>L27-29-1</desc>
             <g id="89.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-915.78,775.71 -1066.71,885.77"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-942.04,794.86)">
+                <polyline class="nad-edge-path" points="-915.78,775.71 -1066.71,885.77"/>
+                <g class="nad-edge-infos" transform="translate(-942.04,794.86)">
                     <g class="nad-active">
                         <g transform="rotate(-126.10)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -973,8 +973,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="89.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1217.64,995.83 -1066.71,885.77"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1191.38,976.68)">
+                <polyline class="nad-edge-path" points="-1217.64,995.83 -1066.71,885.77"/>
+                <g class="nad-edge-infos" transform="translate(-1191.38,976.68)">
                     <g class="nad-active">
                         <g transform="rotate(53.90)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -988,8 +988,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="90">
             <desc>L27-30-1</desc>
             <g id="90.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-899.42,785.83 -931.91,978.24"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-904.83,817.88)">
+                <polyline class="nad-edge-path" points="-899.42,785.83 -931.91,978.24"/>
+                <g class="nad-edge-infos" transform="translate(-904.83,817.88)">
                     <g class="nad-active">
                         <g transform="rotate(-170.42)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1000,8 +1000,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="90.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-964.40,1170.65 -931.91,978.24"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-958.98,1138.60)">
+                <polyline class="nad-edge-path" points="-964.40,1170.65 -931.91,978.24"/>
+                <g class="nad-edge-infos" transform="translate(-958.98,1138.60)">
                     <g class="nad-active">
                         <g transform="rotate(9.58)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1015,8 +1015,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="91">
             <desc>T28-27-1</desc>
             <g id="91.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-247.48,808.27 -528.69,787.61"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-279.89,805.89)">
+                <polyline class="nad-edge-path" points="-247.48,808.27 -528.69,787.61"/>
+                <g class="nad-edge-infos" transform="translate(-279.89,805.89)">
                     <g class="nad-active">
                         <g transform="rotate(-85.80)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1027,8 +1027,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="91.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-869.74,762.55 -588.53,783.21"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-837.33,764.94)">
+                <polyline class="nad-edge-path" points="-869.74,762.55 -588.53,783.21"/>
+                <g class="nad-edge-infos" transform="translate(-837.33,764.94)">
                     <g class="nad-active">
                         <g transform="rotate(94.20)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1038,7 +1038,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl120to180 nad-winding" cx="-548.64" cy="786.14" r="20.00"/>
                 <circle class="nad-vl30to50 nad-winding" cx="-568.58" cy="784.68" r="20.00"/>
             </g>
@@ -1046,8 +1046,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="92">
             <desc>L8-28-1</desc>
             <g id="92.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="277.94,834.73 40.68,823.06"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(245.48,833.13)">
+                <polyline class="nad-edge-path" points="277.94,834.73 40.68,823.06"/>
+                <g class="nad-edge-infos" transform="translate(245.48,833.13)">
                     <g class="nad-active">
                         <g transform="rotate(-87.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1058,8 +1058,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="92.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-196.58,811.39 40.68,823.06"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-164.12,812.99)">
+                <polyline class="nad-edge-path" points="-196.58,811.39 40.68,823.06"/>
+                <g class="nad-edge-infos" transform="translate(-164.12,812.99)">
                     <g class="nad-active">
                         <g transform="rotate(92.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1073,8 +1073,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="93">
             <desc>L6-28-1</desc>
             <g id="93.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="166.66,309.17 -19.88,549.58"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(146.73,334.85)">
+                <polyline class="nad-edge-path" points="166.66,309.17 -19.88,549.58"/>
+                <g class="nad-edge-infos" transform="translate(146.73,334.85)">
                     <g class="nad-active">
                         <g transform="rotate(-142.19)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1085,8 +1085,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="93.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-206.42,789.99 -19.88,549.58"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-186.49,764.31)">
+                <polyline class="nad-edge-path" points="-206.42,789.99 -19.88,549.58"/>
+                <g class="nad-edge-infos" transform="translate(-186.49,764.31)">
                     <g class="nad-active">
                         <g transform="rotate(37.81)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1100,8 +1100,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="94">
             <desc>L29-30-1</desc>
             <g id="94.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1217.21,1025.28 -1103.44,1103.32"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1190.41,1043.67)">
+                <polyline class="nad-edge-path" points="-1217.21,1025.28 -1103.44,1103.32"/>
+                <g class="nad-edge-infos" transform="translate(-1190.41,1043.67)">
                     <g class="nad-active">
                         <g transform="rotate(124.45)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1112,8 +1112,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="94.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-989.67,1181.37 -1103.44,1103.32"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1016.47,1162.98)">
+                <polyline class="nad-edge-path" points="-989.67,1181.37 -1103.44,1103.32"/>
+                <g class="nad-edge-infos" transform="translate(-1016.47,1162.98)">
                     <g class="nad-active">
                         <g transform="rotate(-55.55)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1127,8 +1127,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="95">
             <desc>L3-4-1</desc>
             <g id="95.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="873.49,-827.55 762.30,-510.69"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(862.73,-796.89)">
+                <polyline class="nad-edge-path" points="873.49,-827.55 762.30,-510.69"/>
+                <g class="nad-edge-infos" transform="translate(862.73,-796.89)">
                     <g class="nad-active">
                         <g transform="rotate(-160.66)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1139,8 +1139,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="95.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="651.11,-193.82 762.30,-510.69"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(661.87,-224.49)">
+                <polyline class="nad-edge-path" points="651.11,-193.82 762.30,-510.69"/>
+                <g class="nad-edge-infos" transform="translate(661.87,-224.49)">
                     <g class="nad-active">
                         <g transform="rotate(19.34)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1154,8 +1154,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="96">
             <desc>L4-6-1</desc>
             <g id="96.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="624.60,-151.76 412.48,59.63"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(601.58,-128.82)">
+                <polyline class="nad-edge-path" points="624.60,-151.76 412.48,59.63"/>
+                <g class="nad-edge-infos" transform="translate(601.58,-128.82)">
                     <g class="nad-active">
                         <g transform="rotate(-134.90)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1166,8 +1166,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="96.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="200.35,271.02 412.48,59.63"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(223.37,248.08)">
+                <polyline class="nad-edge-path" points="200.35,271.02 412.48,59.63"/>
+                <g class="nad-edge-infos" transform="translate(223.37,248.08)">
                     <g class="nad-active">
                         <g transform="rotate(45.10)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1181,8 +1181,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="97">
             <desc>L5-7-1</desc>
             <g id="97.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-365.49,139.37 -327.73,264.27"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-356.09,170.48)">
+                <polyline class="nad-edge-path" points="-365.49,139.37 -327.73,264.27"/>
+                <g class="nad-edge-infos" transform="translate(-356.09,170.48)">
                     <g class="nad-active">
                         <g transform="rotate(163.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1193,8 +1193,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="97.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-289.97,389.17 -327.73,264.27"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-299.38,358.06)">
+                <polyline class="nad-edge-path" points="-289.97,389.17 -327.73,264.27"/>
+                <g class="nad-edge-infos" transform="translate(-299.38,358.06)">
                     <g class="nad-active">
                         <g transform="rotate(-16.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1208,8 +1208,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="98">
             <desc>L6-7-1</desc>
             <g id="98.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="157.66,295.62 -50.15,351.30"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(126.27,304.03)">
+                <polyline class="nad-edge-path" points="157.66,295.62 -50.15,351.30"/>
+                <g class="nad-edge-infos" transform="translate(126.27,304.03)">
                     <g class="nad-active">
                         <g transform="rotate(-105.00)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1220,8 +1220,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="98.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-257.96,406.98 -50.15,351.30"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-226.57,398.57)">
+                <polyline class="nad-edge-path" points="-257.96,406.98 -50.15,351.30"/>
+                <g class="nad-edge-infos" transform="translate(-226.57,398.57)">
                     <g class="nad-active">
                         <g transform="rotate(75.00)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1235,8 +1235,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="99">
             <desc>L6-8-1</desc>
             <g id="99.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="187.80,313.92 242.85,562.50"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(194.83,345.65)">
+                <polyline class="nad-edge-path" points="187.80,313.92 242.85,562.50"/>
+                <g class="nad-edge-infos" transform="translate(194.83,345.65)">
                     <g class="nad-active">
                         <g transform="rotate(167.51)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1247,8 +1247,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="99.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="297.90,811.09 242.85,562.50"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(290.87,779.35)">
+                <polyline class="nad-edge-path" points="297.90,811.09 242.85,562.50"/>
+                <g class="nad-edge-infos" transform="translate(290.87,779.35)">
                     <g class="nad-active">
                         <g transform="rotate(-12.49)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1262,8 +1262,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="100">
             <desc>T6-9-1</desc>
             <g id="100.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="180.37,314.45 173.59,404.53"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(177.93,346.86)">
+                <polyline class="nad-edge-path" points="180.37,314.45 173.59,404.53"/>
+                <g class="nad-edge-infos" transform="translate(177.93,346.86)">
                     <g class="nad-active">
                         <g transform="rotate(-175.69)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1274,8 +1274,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="100.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="162.30,554.44 169.08,464.36"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(164.74,522.03)">
+                <polyline class="nad-edge-path" points="162.30,554.44 169.08,464.36"/>
+                <g class="nad-edge-infos" transform="translate(164.74,522.03)">
                     <g class="nad-active">
                         <g transform="rotate(4.31)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1285,7 +1285,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl120to180 nad-winding" cx="172.09" cy="424.47" r="20.00"/>
                 <circle class="nad-vl0to30 nad-winding" cx="170.58" cy="444.42" r="20.00"/>
             </g>

--- a/network-area-diagram/src/test/resources/IEEE_57_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_57_bus.svg
@@ -298,8 +298,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="99">
             <desc>L1-2-1</desc>
             <g id="99.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-182.94,-779.94 -368.54,-714.50"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-213.59,-769.13)">
+                <polyline class="nad-edge-path" points="-182.94,-779.94 -368.54,-714.50"/>
+                <g class="nad-edge-infos" transform="translate(-213.59,-769.13)">
                     <g class="nad-active">
                         <g transform="rotate(-109.42)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -310,8 +310,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="99.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-554.15,-649.06 -368.54,-714.50"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-523.50,-659.86)">
+                <polyline class="nad-edge-path" points="-554.15,-649.06 -368.54,-714.50"/>
+                <g class="nad-edge-infos" transform="translate(-523.50,-659.86)">
                     <g class="nad-active">
                         <g transform="rotate(70.58)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -325,8 +325,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="100">
             <desc>L1-15-1</desc>
             <g id="100.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-153.54,-761.81 -123.84,-527.96"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-149.45,-729.57)">
+                <polyline class="nad-edge-path" points="-153.54,-761.81 -123.84,-527.96"/>
+                <g class="nad-edge-infos" transform="translate(-149.45,-729.57)">
                     <g class="nad-active">
                         <g transform="rotate(172.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -337,8 +337,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="100.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-94.13,-294.12 -123.84,-527.96"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-98.22,-326.36)">
+                <polyline class="nad-edge-path" points="-94.13,-294.12 -123.84,-527.96"/>
+                <g class="nad-edge-infos" transform="translate(-98.22,-326.36)">
                     <g class="nad-active">
                         <g transform="rotate(-7.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -352,8 +352,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="101">
             <desc>L1-16-1</desc>
             <g id="101.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-135.99,-806.82 32.80,-949.20"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-111.14,-827.77)">
+                <polyline class="nad-edge-path" points="-135.99,-806.82 32.80,-949.20"/>
+                <g class="nad-edge-infos" transform="translate(-111.14,-827.77)">
                     <g class="nad-active">
                         <g transform="rotate(49.85)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -364,8 +364,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="101.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="201.59,-1091.57 32.80,-949.20"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(176.74,-1070.62)">
+                <polyline class="nad-edge-path" points="201.59,-1091.57 32.80,-949.20"/>
+                <g class="nad-edge-infos" transform="translate(176.74,-1070.62)">
                     <g class="nad-active">
                         <g transform="rotate(-130.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -379,8 +379,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="102">
             <desc>L1-17-1</desc>
             <g id="102.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-129.54,-790.43 26.08,-798.07"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-97.08,-792.03)">
+                <polyline class="nad-edge-path" points="-129.54,-790.43 26.08,-798.07"/>
+                <g class="nad-edge-infos" transform="translate(-97.08,-792.03)">
                     <g class="nad-active">
                         <g transform="rotate(87.19)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -391,8 +391,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="102.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="181.71,-805.70 26.08,-798.07"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(149.25,-804.11)">
+                <polyline class="nad-edge-path" points="181.71,-805.70 26.08,-798.07"/>
+                <g class="nad-edge-infos" transform="translate(149.25,-804.11)">
                     <g class="nad-active">
                         <g transform="rotate(-92.81)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -406,8 +406,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="103">
             <desc>L9-10-1</desc>
             <g id="103.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="833.92,51.27 852.22,-136.12"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(837.08,18.93)">
+                <polyline class="nad-edge-path" points="833.92,51.27 852.22,-136.12"/>
+                <g class="nad-edge-infos" transform="translate(837.08,18.93)">
                     <g class="nad-active">
                         <g transform="rotate(5.58)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -418,8 +418,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="103.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="870.52,-323.50 852.22,-136.12"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(867.36,-291.16)">
+                <polyline class="nad-edge-path" points="870.52,-323.50 852.22,-136.12"/>
+                <g class="nad-edge-infos" transform="translate(867.36,-291.16)">
                     <g class="nad-active">
                         <g transform="rotate(-174.42)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -433,8 +433,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="104">
             <desc>L10-12-1</desc>
             <g id="104.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="829.39,-414.25 704.81,-503.64"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(802.98,-433.20)">
+                <polyline class="nad-edge-path" points="829.39,-414.25 704.81,-503.64"/>
+                <g class="nad-edge-infos" transform="translate(802.98,-433.20)">
                     <g class="nad-active">
                         <g transform="rotate(-54.34)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -445,8 +445,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="104.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="580.24,-593.02 704.81,-503.64"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(606.64,-574.07)">
+                <polyline class="nad-edge-path" points="580.24,-593.02 704.81,-503.64"/>
+                <g class="nad-edge-infos" transform="translate(606.64,-574.07)">
                     <g class="nad-active">
                         <g transform="rotate(125.66)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -460,8 +460,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="105">
             <desc>L50-51-1</desc>
             <g id="105.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="611.30,-335.30 730.15,-355.69"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(643.33,-340.80)">
+                <polyline class="nad-edge-path" points="611.30,-335.30 730.15,-355.69"/>
+                <g class="nad-edge-infos" transform="translate(643.33,-340.80)">
                     <g class="nad-active">
                         <g transform="rotate(80.27)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -472,8 +472,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="105.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="849.00,-376.08 730.15,-355.69"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(787.40,-365.51)">
+                <polyline class="nad-edge-path" points="849.00,-376.08 730.15,-355.69"/>
+                <g class="nad-edge-infos" transform="translate(787.40,-365.51)">
                     <g class="nad-active">
                         <g transform="rotate(-99.73)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -510,7 +510,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl0to30-line nad-winding" cx="981.27" cy="-439.38" r="20.00"/>
                 <circle class="nad-vl0to30-line nad-winding" cx="989.53" cy="-421.16" r="20.00"/>
             </g>
@@ -518,8 +518,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="107">
             <desc>L9-11-1</desc>
             <g id="107.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="884.41,95.78 1065.15,54.78"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(916.10,88.59)">
+                <polyline class="nad-edge-path" points="884.41,95.78 1065.15,54.78"/>
+                <g class="nad-edge-infos" transform="translate(916.10,88.59)">
                     <g class="nad-active">
                         <g transform="rotate(77.22)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -530,8 +530,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="107.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1245.89,13.79 1065.15,54.78"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1194.69,25.40)">
+                <polyline class="nad-edge-path" points="1245.89,13.79 1065.15,54.78"/>
+                <g class="nad-edge-infos" transform="translate(1194.69,25.40)">
                     <g class="nad-active">
                         <g transform="rotate(-102.78)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -545,8 +545,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="108">
             <desc>L11-13-1</desc>
             <g id="108.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1245.00,3.82 934.63,-9.98"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1192.55,1.49)">
+                <polyline class="nad-edge-path" points="1245.00,3.82 934.63,-9.98"/>
+                <g class="nad-edge-infos" transform="translate(1192.55,1.49)">
                     <g class="nad-active">
                         <g transform="rotate(-87.45)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -557,8 +557,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="108.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="624.26,-23.79 934.63,-9.98"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(656.73,-22.35)">
+                <polyline class="nad-edge-path" points="624.26,-23.79 934.63,-9.98"/>
+                <g class="nad-edge-infos" transform="translate(656.73,-22.35)">
                     <g class="nad-active">
                         <g transform="rotate(92.55)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -572,8 +572,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="109">
             <desc>L41-42-1</desc>
             <g id="109.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1339.96,6.13 1528.04,8.21"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1372.46,6.49)">
+                <polyline class="nad-edge-path" points="1339.96,6.13 1528.04,8.21"/>
+                <g class="nad-edge-infos" transform="translate(1372.46,6.49)">
                     <g class="nad-active">
                         <g transform="rotate(90.63)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -584,8 +584,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="109.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1716.13,10.29 1528.04,8.21"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1683.63,9.93)">
+                <polyline class="nad-edge-path" points="1716.13,10.29 1528.04,8.21"/>
+                <g class="nad-edge-infos" transform="translate(1683.63,9.93)">
                     <g class="nad-active">
                         <g transform="rotate(-89.37)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -626,8 +626,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="111">
             <desc>L56-41-1</desc>
             <g id="111.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1566.39,-348.28 1442.42,-193.82"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1546.05,-322.93)">
+                <polyline class="nad-edge-path" points="1566.39,-348.28 1442.42,-193.82"/>
+                <g class="nad-edge-infos" transform="translate(1546.05,-322.93)">
                     <g class="nad-active">
                         <g transform="rotate(-141.25)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -638,8 +638,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="111.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1318.45,-39.35 1442.42,-193.82"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1338.80,-64.70)">
+                <polyline class="nad-edge-path" points="1318.45,-39.35 1442.42,-193.82"/>
+                <g class="nad-edge-infos" transform="translate(1338.80,-64.70)">
                     <g class="nad-active">
                         <g transform="rotate(38.75)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -676,7 +676,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl0to30-line nad-winding" cx="1227.93" cy="112.85" r="20.00"/>
                 <circle class="nad-vl0to30-line nad-winding" cx="1210.91" cy="102.34" r="20.00"/>
             </g>
@@ -707,7 +707,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl0to30-line nad-winding" cx="1223.87" cy="-99.71" r="20.00"/>
                 <circle class="nad-vl0to30-line nad-winding" cx="1242.09" cy="-107.96" r="20.00"/>
             </g>
@@ -715,8 +715,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="114">
             <desc>L9-12-1</desc>
             <g id="114.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="808.06,54.70 687.82,-264.31"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(796.59,24.28)">
+                <polyline class="nad-edge-path" points="808.06,54.70 687.82,-264.31"/>
+                <g class="nad-edge-infos" transform="translate(796.59,24.28)">
                     <g class="nad-active">
                         <g transform="rotate(-20.65)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -727,8 +727,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="114.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="567.59,-583.32 687.82,-264.31"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(579.06,-552.91)">
+                <polyline class="nad-edge-path" points="567.59,-583.32 687.82,-264.31"/>
+                <g class="nad-edge-infos" transform="translate(579.06,-552.91)">
                     <g class="nad-active">
                         <g transform="rotate(159.35)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -742,8 +742,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="115">
             <desc>L12-13-1</desc>
             <g id="115.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="558.32,-581.55 562.13,-332.70"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(558.81,-549.06)">
+                <polyline class="nad-edge-path" points="558.32,-581.55 562.13,-332.70"/>
+                <g class="nad-edge-infos" transform="translate(558.81,-549.06)">
                     <g class="nad-active">
                         <g transform="rotate(179.12)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -754,8 +754,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="115.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="565.94,-83.84 562.13,-332.70"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(565.44,-116.33)">
+                <polyline class="nad-edge-path" points="565.94,-83.84 562.13,-332.70"/>
+                <g class="nad-edge-infos" transform="translate(565.44,-116.33)">
                     <g class="nad-active">
                         <g transform="rotate(-0.88)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -769,8 +769,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="116">
             <desc>L12-16-1</desc>
             <g id="116.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="542.58,-631.89 390.25,-859.18"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(524.49,-658.89)">
+                <polyline class="nad-edge-path" points="542.58,-631.89 390.25,-859.18"/>
+                <g class="nad-edge-infos" transform="translate(524.49,-658.89)">
                     <g class="nad-active">
                         <g transform="rotate(-33.83)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -781,8 +781,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="116.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="237.92,-1086.46 390.25,-859.18"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(256.01,-1059.47)">
+                <polyline class="nad-edge-path" points="237.92,-1086.46 390.25,-859.18"/>
+                <g class="nad-edge-infos" transform="translate(256.01,-1059.47)">
                     <g class="nad-active">
                         <g transform="rotate(146.17)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -796,8 +796,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="117">
             <desc>L12-17-1</desc>
             <g id="117.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="533.98,-622.63 383.53,-708.05"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(505.72,-638.68)">
+                <polyline class="nad-edge-path" points="533.98,-622.63 383.53,-708.05"/>
+                <g class="nad-edge-infos" transform="translate(505.72,-638.68)">
                     <g class="nad-active">
                         <g transform="rotate(-60.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -808,8 +808,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="117.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="233.09,-793.47 383.53,-708.05"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(261.35,-777.42)">
+                <polyline class="nad-edge-path" points="233.09,-793.47 383.53,-708.05"/>
+                <g class="nad-edge-infos" transform="translate(261.35,-777.42)">
                     <g class="nad-active">
                         <g transform="rotate(119.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -823,8 +823,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="118">
             <desc>L9-13-1</desc>
             <g id="118.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="777.23,82.15 697.57,41.08"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(748.34,67.26)">
+                <polyline class="nad-edge-path" points="777.23,82.15 697.57,41.08"/>
+                <g class="nad-edge-infos" transform="translate(748.34,67.26)">
                     <g class="nad-active">
                         <g transform="rotate(-62.72)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -835,8 +835,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="118.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="617.92,0.01 697.57,41.08"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(646.81,14.90)">
+                <polyline class="nad-edge-path" points="617.92,0.01 697.57,41.08"/>
+                <g class="nad-edge-infos" transform="translate(646.81,14.90)">
                     <g class="nad-active">
                         <g transform="rotate(117.28)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -850,8 +850,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="119">
             <desc>L13-14-1</desc>
             <g id="119.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="522.04,9.74 379.87,124.31"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(496.74,30.13)">
+                <polyline class="nad-edge-path" points="522.04,9.74 379.87,124.31"/>
+                <g class="nad-edge-infos" transform="translate(496.74,30.13)">
                     <g class="nad-active">
                         <g transform="rotate(-128.86)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -862,8 +862,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="119.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="237.70,238.87 379.87,124.31"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(263.01,218.48)">
+                <polyline class="nad-edge-path" points="237.70,238.87 379.87,124.31"/>
+                <g class="nad-edge-infos" transform="translate(263.01,218.48)">
                     <g class="nad-active">
                         <g transform="rotate(51.14)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -877,8 +877,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="120">
             <desc>L13-15-1</desc>
             <g id="120.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="512.09,-43.99 239.97,-131.71"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(481.16,-53.96)">
+                <polyline class="nad-edge-path" points="512.09,-43.99 239.97,-131.71"/>
+                <g class="nad-edge-infos" transform="translate(481.16,-53.96)">
                     <g class="nad-active">
                         <g transform="rotate(-72.13)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -889,8 +889,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="120.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-32.16,-219.43 239.97,-131.71"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1.22,-209.46)">
+                <polyline class="nad-edge-path" points="-32.16,-219.43 239.97,-131.71"/>
+                <g class="nad-edge-infos" transform="translate(-1.22,-209.46)">
                     <g class="nad-active">
                         <g transform="rotate(107.87)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -904,8 +904,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="121">
             <desc>L48-49-1</desc>
             <g id="121.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="724.32,476.54 649.68,238.22"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(714.61,445.52)">
+                <polyline class="nad-edge-path" points="724.32,476.54 649.68,238.22"/>
+                <g class="nad-edge-infos" transform="translate(714.61,445.52)">
                     <g class="nad-active">
                         <g transform="rotate(-17.39)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -916,8 +916,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="121.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="575.03,-0.10 649.68,238.22"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(593.72,59.54)">
+                <polyline class="nad-edge-path" points="575.03,-0.10 649.68,238.22"/>
+                <g class="nad-edge-infos" transform="translate(593.72,59.54)">
                     <g class="nad-active">
                         <g transform="rotate(162.61)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -931,8 +931,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="122">
             <desc>L49-50-1</desc>
             <g id="122.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="568.38,-53.80 575.50,-178.50"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(571.95,-116.20)">
+                <polyline class="nad-edge-path" points="568.38,-53.80 575.50,-178.50"/>
+                <g class="nad-edge-infos" transform="translate(571.95,-116.20)">
                     <g class="nad-active">
                         <g transform="rotate(3.27)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -943,8 +943,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="122.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="582.62,-303.20 575.50,-178.50"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(580.77,-270.75)">
+                <polyline class="nad-edge-path" points="582.62,-303.20 575.50,-178.50"/>
+                <g class="nad-edge-infos" transform="translate(580.77,-270.75)">
                     <g class="nad-active">
                         <g transform="rotate(-176.73)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -958,8 +958,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="123">
             <desc>L38-49-1</desc>
             <g id="123.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="490.68,245.27 525.04,122.70"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(499.45,213.98)">
+                <polyline class="nad-edge-path" points="490.68,245.27 525.04,122.70"/>
+                <g class="nad-edge-infos" transform="translate(499.45,213.98)">
                     <g class="nad-active">
                         <g transform="rotate(15.66)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -970,8 +970,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="123.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="559.39,0.13 525.04,122.70"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(542.52,60.32)">
+                <polyline class="nad-edge-path" points="559.39,0.13 525.04,122.70"/>
+                <g class="nad-edge-infos" transform="translate(542.52,60.32)">
                     <g class="nad-active">
                         <g transform="rotate(-164.34)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1008,7 +1008,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl0to30-line nad-winding" cx="649.16" cy="-114.20" r="20.00"/>
                 <circle class="nad-vl0to30-line nad-winding" cx="662.57" cy="-99.36" r="20.00"/>
             </g>
@@ -1016,8 +1016,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="125">
             <desc>L14-15-1</desc>
             <g id="125.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="165.36,224.50 53.03,18.94"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(149.77,195.98)">
+                <polyline class="nad-edge-path" points="165.36,224.50 53.03,18.94"/>
+                <g class="nad-edge-infos" transform="translate(149.77,195.98)">
                     <g class="nad-active">
                         <g transform="rotate(-28.66)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1028,8 +1028,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="125.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-59.31,-186.62 53.03,18.94"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-43.72,-158.10)">
+                <polyline class="nad-edge-path" points="-59.31,-186.62 53.03,18.94"/>
+                <g class="nad-edge-infos" transform="translate(-43.72,-158.10)">
                     <g class="nad-active">
                         <g transform="rotate(151.34)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1043,8 +1043,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="126">
             <desc>L46-47-1</desc>
             <g id="126.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="206.25,299.01 319.80,504.11"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(236.52,353.69)">
+                <polyline class="nad-edge-path" points="206.25,299.01 319.80,504.11"/>
+                <g class="nad-edge-infos" transform="translate(236.52,353.69)">
                     <g class="nad-active">
                         <g transform="rotate(151.03)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1055,8 +1055,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="126.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="433.34,709.20 319.80,504.11"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(417.60,680.77)">
+                <polyline class="nad-edge-path" points="433.34,709.20 319.80,504.11"/>
+                <g class="nad-edge-infos" transform="translate(417.60,680.77)">
                     <g class="nad-active">
                         <g transform="rotate(-28.97)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1093,7 +1093,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl0to30-line nad-winding" cx="92.61" cy="341.55" r="20.00"/>
                 <circle class="nad-vl0to30-line nad-winding" cx="82.97" cy="324.03" r="20.00"/>
             </g>
@@ -1101,8 +1101,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="128">
             <desc>L3-15-1</desc>
             <g id="128.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-614.50,-165.10 -379.18,-197.20"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-582.30,-169.50)">
+                <polyline class="nad-edge-path" points="-614.50,-165.10 -379.18,-197.20"/>
+                <g class="nad-edge-infos" transform="translate(-582.30,-169.50)">
                     <g class="nad-active">
                         <g transform="rotate(82.23)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1113,8 +1113,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="128.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-143.86,-229.30 -379.18,-197.20"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-176.06,-224.91)">
+                <polyline class="nad-edge-path" points="-143.86,-229.30 -379.18,-197.20"/>
+                <g class="nad-edge-infos" transform="translate(-176.06,-224.91)">
                     <g class="nad-active">
                         <g transform="rotate(-97.77)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1128,8 +1128,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="129">
             <desc>L44-45-1</desc>
             <g id="129.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="98.79,-56.02 15.80,-136.95"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(75.52,-78.71)">
+                <polyline class="nad-edge-path" points="98.79,-56.02 15.80,-136.95"/>
+                <g class="nad-edge-infos" transform="translate(75.52,-78.71)">
                     <g class="nad-active">
                         <g transform="rotate(-45.72)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1140,8 +1140,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="129.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-67.19,-217.88 15.80,-136.95"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-22.45,-174.24)">
+                <polyline class="nad-edge-path" points="-67.19,-217.88 15.80,-136.95"/>
+                <g class="nad-edge-infos" transform="translate(-22.45,-174.24)">
                     <g class="nad-active">
                         <g transform="rotate(134.28)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1178,7 +1178,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl0to30-line nad-winding" cx="-0.92" cy="-321.40" r="20.00"/>
                 <circle class="nad-vl0to30-line nad-winding" cx="11.85" cy="-306.01" r="20.00"/>
             </g>
@@ -1186,8 +1186,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="131">
             <desc>L18-19-1</desc>
             <g id="131.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1056.49,536.69 -1062.70,861.06"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1057.69,599.18)">
+                <polyline class="nad-edge-path" points="-1056.49,536.69 -1062.70,861.06"/>
+                <g class="nad-edge-infos" transform="translate(-1057.69,599.18)">
                     <g class="nad-active">
                         <g transform="rotate(-178.90)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1198,8 +1198,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="131.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1068.90,1185.43 -1062.70,861.06"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1068.28,1152.94)">
+                <polyline class="nad-edge-path" points="-1068.90,1185.43 -1062.70,861.06"/>
+                <g class="nad-edge-infos" transform="translate(-1068.28,1152.94)">
                     <g class="nad-active">
                         <g transform="rotate(1.10)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1213,8 +1213,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="132">
             <desc>L19-20-1</desc>
             <g id="132.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1044.70,1224.97 -870.40,1309.85"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1015.48,1239.20)">
+                <polyline class="nad-edge-path" points="-1044.70,1224.97 -870.40,1309.85"/>
+                <g class="nad-edge-infos" transform="translate(-1015.48,1239.20)">
                     <g class="nad-active">
                         <g transform="rotate(115.97)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1225,8 +1225,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="132.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-696.09,1394.74 -870.40,1309.85"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-752.28,1367.37)">
+                <polyline class="nad-edge-path" points="-696.09,1394.74 -870.40,1309.85"/>
+                <g class="nad-edge-infos" transform="translate(-752.28,1367.37)">
                     <g class="nad-active">
                         <g transform="rotate(-64.03)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1240,8 +1240,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="133">
             <desc>L2-3-1</desc>
             <g id="133.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-583.60,-612.64 -610.92,-400.65"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-587.75,-580.40)">
+                <polyline class="nad-edge-path" points="-583.60,-612.64 -610.92,-400.65"/>
+                <g class="nad-edge-infos" transform="translate(-587.75,-580.40)">
                     <g class="nad-active">
                         <g transform="rotate(-172.66)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1252,8 +1252,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="133.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-638.23,-188.66 -610.92,-400.65"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-634.08,-220.89)">
+                <polyline class="nad-edge-path" points="-638.23,-188.66 -610.92,-400.65"/>
+                <g class="nad-edge-infos" transform="translate(-634.08,-220.89)">
                     <g class="nad-active">
                         <g transform="rotate(7.34)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1267,8 +1267,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="134">
             <desc>L21-22-1</desc>
             <g id="134.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-634.52,1362.64 -492.64,1192.68"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-613.69,1337.69)">
+                <polyline class="nad-edge-path" points="-634.52,1362.64 -492.64,1192.68"/>
+                <g class="nad-edge-infos" transform="translate(-613.69,1337.69)">
                     <g class="nad-active">
                         <g transform="rotate(39.85)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1279,8 +1279,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="134.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-350.77,1022.73 -492.64,1192.68"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-371.60,1047.68)">
+                <polyline class="nad-edge-path" points="-350.77,1022.73 -492.64,1192.68"/>
+                <g class="nad-edge-infos" transform="translate(-371.60,1047.68)">
                     <g class="nad-active">
                         <g transform="rotate(-140.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1317,7 +1317,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl0to30-line nad-winding" cx="-636.45" cy="1522.02" r="20.00"/>
                 <circle class="nad-vl0to30-line nad-winding" cx="-656.01" cy="1526.21" r="20.00"/>
             </g>
@@ -1325,8 +1325,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="136">
             <desc>L22-23-1</desc>
             <g id="136.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-359.59,994.05 -649.69,910.99"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-390.83,985.10)">
+                <polyline class="nad-edge-path" points="-359.59,994.05 -649.69,910.99"/>
+                <g class="nad-edge-infos" transform="translate(-390.83,985.10)">
                     <g class="nad-active">
                         <g transform="rotate(-74.02)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1337,8 +1337,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="136.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-939.80,827.93 -649.69,910.99"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-908.55,836.87)">
+                <polyline class="nad-edge-path" points="-939.80,827.93 -649.69,910.99"/>
+                <g class="nad-edge-infos" transform="translate(-908.55,836.87)">
                     <g class="nad-active">
                         <g transform="rotate(105.98)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1352,8 +1352,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="137">
             <desc>L22-38-1</desc>
             <g id="137.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-312.65,983.29 75.05,636.69"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-288.42,961.63)">
+                <polyline class="nad-edge-path" points="-312.65,983.29 75.05,636.69"/>
+                <g class="nad-edge-infos" transform="translate(-288.42,961.63)">
                     <g class="nad-active">
                         <g transform="rotate(48.20)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1364,8 +1364,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="137.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="462.76,290.08 75.05,636.69"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(438.53,311.74)">
+                <polyline class="nad-edge-path" points="462.76,290.08 75.05,636.69"/>
+                <g class="nad-edge-infos" transform="translate(438.53,311.74)">
                     <g class="nad-active">
                         <g transform="rotate(-131.80)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1379,8 +1379,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="138">
             <desc>L23-24-1</desc>
             <g id="138.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-979.96,796.53 -1176.10,456.01"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-996.18,768.37)">
+                <polyline class="nad-edge-path" points="-979.96,796.53 -1176.10,456.01"/>
+                <g class="nad-edge-infos" transform="translate(-996.18,768.37)">
                     <g class="nad-active">
                         <g transform="rotate(-29.94)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1391,8 +1391,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="138.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1372.23,115.50 -1176.10,456.01"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1356.01,143.66)">
+                <polyline class="nad-edge-path" points="-1372.23,115.50 -1176.10,456.01"/>
+                <g class="nad-edge-infos" transform="translate(-1356.01,143.66)">
                     <g class="nad-active">
                         <g transform="rotate(150.06)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1406,8 +1406,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="139">
             <desc>L25-30-1</desc>
             <g id="139.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1395.96,28.51 -1347.79,-331.66"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1389.00,-23.53)">
+                <polyline class="nad-edge-path" points="-1395.96,28.51 -1347.79,-331.66"/>
+                <g class="nad-edge-infos" transform="translate(-1389.00,-23.53)">
                     <g class="nad-active">
                         <g transform="rotate(7.62)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1418,8 +1418,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="139.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1299.62,-691.83 -1347.79,-331.66"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1303.93,-659.61)">
+                <polyline class="nad-edge-path" points="-1299.62,-691.83 -1347.79,-331.66"/>
+                <g class="nad-edge-infos" transform="translate(-1303.93,-659.61)">
                     <g class="nad-active">
                         <g transform="rotate(-172.38)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1433,8 +1433,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="140">
             <desc>L26-27-1</desc>
             <g id="140.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1407.31,49.38 -1450.94,-62.11"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1433.73,-18.14)">
+                <polyline class="nad-edge-path" points="-1407.31,49.38 -1450.94,-62.11"/>
+                <g class="nad-edge-infos" transform="translate(-1433.73,-18.14)">
                     <g class="nad-active">
                         <g transform="rotate(-21.37)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1445,8 +1445,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="140.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1494.58,-173.59 -1450.94,-62.11"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1482.73,-143.33)">
+                <polyline class="nad-edge-path" points="-1494.58,-173.59 -1450.94,-62.11"/>
+                <g class="nad-edge-infos" transform="translate(-1482.73,-143.33)">
                     <g class="nad-active">
                         <g transform="rotate(158.63)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1483,7 +1483,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl0to30-line nad-winding" cx="-1438.44" cy="180.10" r="20.00"/>
                 <circle class="nad-vl0to30-line nad-winding" cx="-1456.87" cy="172.31" r="20.00"/>
             </g>
@@ -1514,7 +1514,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl0to30-line nad-winding" cx="-1519.13" cy="42.68" r="20.00"/>
                 <circle class="nad-vl0to30-line nad-winding" cx="-1513.70" cy="23.44" r="20.00"/>
             </g>
@@ -1545,7 +1545,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl0to30-line nad-winding" cx="-1285.14" cy="32.63" r="20.00"/>
                 <circle class="nad-vl0to30-line nad-winding" cx="-1281.27" cy="52.25" r="20.00"/>
             </g>
@@ -1553,8 +1553,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="144">
             <desc>L27-28-1</desc>
             <g id="144.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1481.09,-184.94 -1257.95,-49.53"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1453.30,-168.08)">
+                <polyline class="nad-edge-path" points="-1481.09,-184.94 -1257.95,-49.53"/>
+                <g class="nad-edge-infos" transform="translate(-1453.30,-168.08)">
                     <g class="nad-active">
                         <g transform="rotate(121.25)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1565,8 +1565,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="144.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1034.82,85.87 -1257.95,-49.53"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1062.60,69.01)">
+                <polyline class="nad-edge-path" points="-1034.82,85.87 -1257.95,-49.53"/>
+                <g class="nad-edge-infos" transform="translate(-1062.60,69.01)">
                     <g class="nad-active">
                         <g transform="rotate(-58.75)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1580,8 +1580,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="145">
             <desc>L28-29-1</desc>
             <g id="145.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-990.93,118.60 -725.50,359.03"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-966.84,140.42)">
+                <polyline class="nad-edge-path" points="-990.93,118.60 -725.50,359.03"/>
+                <g class="nad-edge-infos" transform="translate(-966.84,140.42)">
                     <g class="nad-active">
                         <g transform="rotate(132.17)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1592,8 +1592,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="145.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-460.06,599.46 -725.50,359.03"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-484.15,577.64)">
+                <polyline class="nad-edge-path" points="-460.06,599.46 -725.50,359.03"/>
+                <g class="nad-edge-infos" transform="translate(-484.15,577.64)">
                     <g class="nad-active">
                         <g transform="rotate(-47.83)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1607,8 +1607,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="146">
             <desc>L3-4-1</desc>
             <g id="146.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-656.20,-137.99 -840.97,161.14"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-673.28,-110.34)">
+                <polyline class="nad-edge-path" points="-656.20,-137.99 -840.97,161.14"/>
+                <g class="nad-edge-infos" transform="translate(-673.28,-110.34)">
                     <g class="nad-active">
                         <g transform="rotate(-148.30)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1619,8 +1619,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="146.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1025.75,460.27 -840.97,161.14"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1008.67,432.62)">
+                <polyline class="nad-edge-path" points="-1025.75,460.27 -840.97,161.14"/>
+                <g class="nad-edge-infos" transform="translate(-1008.67,432.62)">
                     <g class="nad-active">
                         <g transform="rotate(31.70)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1634,8 +1634,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="147">
             <desc>L30-31-1</desc>
             <g id="147.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1279.76,-741.29 -1093.84,-995.83"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1260.59,-767.53)">
+                <polyline class="nad-edge-path" points="-1279.76,-741.29 -1093.84,-995.83"/>
+                <g class="nad-edge-infos" transform="translate(-1260.59,-767.53)">
                     <g class="nad-active">
                         <g transform="rotate(36.14)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1646,8 +1646,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="147.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-907.92,-1250.38 -1093.84,-995.83"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-927.09,-1224.13)">
+                <polyline class="nad-edge-path" points="-907.92,-1250.38 -1093.84,-995.83"/>
+                <g class="nad-edge-infos" transform="translate(-927.09,-1224.13)">
                     <g class="nad-active">
                         <g transform="rotate(-143.86)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1661,8 +1661,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="148">
             <desc>L31-32-1</desc>
             <g id="148.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-867.29,-1285.25 -581.82,-1433.40"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-838.44,-1300.22)">
+                <polyline class="nad-edge-path" points="-867.29,-1285.25 -581.82,-1433.40"/>
+                <g class="nad-edge-infos" transform="translate(-838.44,-1300.22)">
                     <g class="nad-active">
                         <g transform="rotate(62.57)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1673,8 +1673,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="148.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-296.36,-1581.54 -581.82,-1433.40"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-325.21,-1566.57)">
+                <polyline class="nad-edge-path" points="-296.36,-1581.54 -581.82,-1433.40"/>
+                <g class="nad-edge-infos" transform="translate(-325.21,-1566.57)">
                     <g class="nad-active">
                         <g transform="rotate(-117.43)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1688,8 +1688,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="149">
             <desc>L32-33-1</desc>
             <g id="149.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-275.51,-1656.96 -361.81,-1796.84"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-292.58,-1684.62)">
+                <polyline class="nad-edge-path" points="-275.51,-1656.96 -361.81,-1796.84"/>
+                <g class="nad-edge-infos" transform="translate(-292.58,-1684.62)">
                     <g class="nad-active">
                         <g transform="rotate(-31.67)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1700,8 +1700,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="149.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-448.11,-1936.71 -361.81,-1796.84"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-431.04,-1909.05)">
+                <polyline class="nad-edge-path" points="-448.11,-1936.71 -361.81,-1796.84"/>
+                <g class="nad-edge-infos" transform="translate(-431.04,-1909.05)">
                     <g class="nad-active">
                         <g transform="rotate(148.33)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1715,8 +1715,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="150">
             <desc>L34-35-1</desc>
             <g id="150.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-218.08,-1604.26 164.07,-1551.52"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-156.17,-1595.72)">
+                <polyline class="nad-edge-path" points="-218.08,-1604.26 164.07,-1551.52"/>
+                <g class="nad-edge-infos" transform="translate(-156.17,-1595.72)">
                     <g class="nad-active">
                         <g transform="rotate(97.86)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1727,8 +1727,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="150.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="546.23,-1498.77 164.07,-1551.52"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(514.03,-1503.21)">
+                <polyline class="nad-edge-path" points="546.23,-1498.77 164.07,-1551.52"/>
+                <g class="nad-edge-infos" transform="translate(514.03,-1503.21)">
                     <g class="nad-active">
                         <g transform="rotate(-82.14)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1765,7 +1765,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl0to30-line nad-winding" cx="-215.07" cy="-1491.47" r="20.00"/>
                 <circle class="nad-vl0to30-line nad-winding" cx="-234.78" cy="-1488.07" r="20.00"/>
             </g>
@@ -1773,8 +1773,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="152">
             <desc>L35-36-1</desc>
             <g id="152.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="594.84,-1477.71 887.07,-1241.25"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(620.11,-1457.27)">
+                <polyline class="nad-edge-path" points="594.84,-1477.71 887.07,-1241.25"/>
+                <g class="nad-edge-infos" transform="translate(620.11,-1457.27)">
                     <g class="nad-active">
                         <g transform="rotate(128.98)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1785,8 +1785,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="152.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1179.30,-1004.79 887.07,-1241.25"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1154.03,-1025.23)">
+                <polyline class="nad-edge-path" points="1179.30,-1004.79 887.07,-1241.25"/>
+                <g class="nad-edge-infos" transform="translate(1154.03,-1025.23)">
                     <g class="nad-active">
                         <g transform="rotate(-51.02)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1800,8 +1800,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="153">
             <desc>L36-37-1</desc>
             <g id="153.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1201.85,-960.01 1210.54,-756.50"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1203.24,-927.54)">
+                <polyline class="nad-edge-path" points="1201.85,-960.01 1210.54,-756.50"/>
+                <g class="nad-edge-infos" transform="translate(1203.24,-927.54)">
                     <g class="nad-active">
                         <g transform="rotate(177.56)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1812,8 +1812,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="153.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1219.22,-552.99 1210.54,-756.50"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1217.84,-585.46)">
+                <polyline class="nad-edge-path" points="1219.22,-552.99 1210.54,-756.50"/>
+                <g class="nad-edge-infos" transform="translate(1217.84,-585.46)">
                     <g class="nad-active">
                         <g transform="rotate(-2.44)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1827,8 +1827,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="154">
             <desc>L36-40-1</desc>
             <g id="154.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1216.08,-964.70 1401.53,-690.31"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1234.27,-937.78)">
+                <polyline class="nad-edge-path" points="1216.08,-964.70 1401.53,-690.31"/>
+                <g class="nad-edge-infos" transform="translate(1234.27,-937.78)">
                     <g class="nad-active">
                         <g transform="rotate(145.95)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1839,8 +1839,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="154.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1586.98,-415.91 1401.53,-690.31"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1551.98,-467.69)">
+                <polyline class="nad-edge-path" points="1586.98,-415.91 1401.53,-690.31"/>
+                <g class="nad-edge-infos" transform="translate(1551.98,-467.69)">
                     <g class="nad-active">
                         <g transform="rotate(-34.05)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1854,8 +1854,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="155">
             <desc>L37-38-1</desc>
             <g id="155.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1201.73,-505.33 851.83,-126.88"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1179.66,-481.46)">
+                <polyline class="nad-edge-path" points="1201.73,-505.33 851.83,-126.88"/>
+                <g class="nad-edge-infos" transform="translate(1179.66,-481.46)">
                     <g class="nad-active">
                         <g transform="rotate(-137.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1866,8 +1866,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="155.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="501.93,251.56 851.83,-126.88"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(523.99,227.70)">
+                <polyline class="nad-edge-path" points="501.93,251.56 851.83,-126.88"/>
+                <g class="nad-edge-infos" transform="translate(523.99,227.70)">
                     <g class="nad-active">
                         <g transform="rotate(42.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1881,8 +1881,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="156">
             <desc>L37-39-1</desc>
             <g id="156.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1246.27,-534.83 1470.19,-615.45"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1276.85,-545.84)">
+                <polyline class="nad-edge-path" points="1246.27,-534.83 1470.19,-615.45"/>
+                <g class="nad-edge-infos" transform="translate(1276.85,-545.84)">
                     <g class="nad-active">
                         <g transform="rotate(70.20)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1893,8 +1893,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="156.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1694.12,-696.07 1470.19,-615.45"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1635.31,-674.90)">
+                <polyline class="nad-edge-path" points="1694.12,-696.07 1470.19,-615.45"/>
+                <g class="nad-edge-infos" transform="translate(1635.31,-674.90)">
                     <g class="nad-active">
                         <g transform="rotate(-109.80)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1908,8 +1908,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="157">
             <desc>L38-44-1</desc>
             <g id="157.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="462.26,253.99 300.87,117.47"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(437.45,233.00)">
+                <polyline class="nad-edge-path" points="462.26,253.99 300.87,117.47"/>
+                <g class="nad-edge-infos" transform="translate(437.45,233.00)">
                     <g class="nad-active">
                         <g transform="rotate(-49.77)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1920,8 +1920,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="157.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="139.47,-19.06 300.87,117.47"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(164.29,1.93)">
+                <polyline class="nad-edge-path" points="139.47,-19.06 300.87,117.47"/>
+                <g class="nad-edge-infos" transform="translate(164.29,1.93)">
                     <g class="nad-active">
                         <g transform="rotate(130.23)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1935,8 +1935,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="158">
             <desc>L38-48-1</desc>
             <g id="158.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="503.43,290.45 607.90,387.27"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(527.27,312.54)">
+                <polyline class="nad-edge-path" points="503.43,290.45 607.90,387.27"/>
+                <g class="nad-edge-infos" transform="translate(527.27,312.54)">
                     <g class="nad-active">
                         <g transform="rotate(132.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1947,8 +1947,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="158.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="712.37,484.09 607.90,387.27"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(688.53,462.00)">
+                <polyline class="nad-edge-path" points="712.37,484.09 607.90,387.27"/>
+                <g class="nad-edge-infos" transform="translate(688.53,462.00)">
                     <g class="nad-active">
                         <g transform="rotate(-47.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1962,8 +1962,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="159">
             <desc>L57-56-1</desc>
             <g id="159.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1699.72,-651.58 1661.19,-549.25"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1688.27,-621.16)">
+                <polyline class="nad-edge-path" points="1699.72,-651.58 1661.19,-549.25"/>
+                <g class="nad-edge-infos" transform="translate(1688.27,-621.16)">
                     <g class="nad-active">
                         <g transform="rotate(-159.36)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -1974,8 +1974,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="159.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1622.65,-446.93 1661.19,-549.25"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1634.10,-477.35)">
+                <polyline class="nad-edge-path" points="1622.65,-446.93 1661.19,-549.25"/>
+                <g class="nad-edge-infos" transform="translate(1634.10,-477.35)">
                     <g class="nad-active">
                         <g transform="rotate(20.64)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2012,7 +2012,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl0to30-line nad-winding" cx="1798.44" cy="-796.74" r="20.00"/>
                 <circle class="nad-vl0to30-line nad-winding" cx="1812.48" cy="-782.49" r="20.00"/>
             </g>
@@ -2020,8 +2020,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="161">
             <desc>L4-5-1</desc>
             <g id="161.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1105.69,538.07 -1214.79,601.41"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1133.80,554.38)">
+                <polyline class="nad-edge-path" points="-1105.69,538.07 -1214.79,601.41"/>
+                <g class="nad-edge-infos" transform="translate(-1133.80,554.38)">
                     <g class="nad-active">
                         <g transform="rotate(-120.14)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2032,8 +2032,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="161.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1323.88,664.76 -1214.79,601.41"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1295.78,648.44)">
+                <polyline class="nad-edge-path" points="-1323.88,664.76 -1214.79,601.41"/>
+                <g class="nad-edge-infos" transform="translate(-1295.78,648.44)">
                     <g class="nad-active">
                         <g transform="rotate(59.86)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2047,8 +2047,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="162">
             <desc>L4-6-1</desc>
             <g id="162.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-998.81,515.49 -877.13,528.91"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-966.51,519.05)">
+                <polyline class="nad-edge-path" points="-998.81,515.49 -877.13,528.91"/>
+                <g class="nad-edge-infos" transform="translate(-966.51,519.05)">
                     <g class="nad-active">
                         <g transform="rotate(96.29)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2059,8 +2059,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="162.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-755.44,542.32 -877.13,528.91"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-787.74,538.76)">
+                <polyline class="nad-edge-path" points="-755.44,542.32 -877.13,528.91"/>
+                <g class="nad-edge-infos" transform="translate(-787.74,538.76)">
                     <g class="nad-active">
                         <g transform="rotate(-83.71)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2097,7 +2097,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl0to30-line nad-winding" cx="-969.24" cy="592.73" r="20.00"/>
                 <circle class="nad-vl0to30-line nad-winding" cx="-984.27" cy="605.94" r="20.00"/>
             </g>
@@ -2128,7 +2128,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl0to30-line nad-winding" cx="-1146.82" cy="430.16" r="20.00"/>
                 <circle class="nad-vl0to30-line nad-winding" cx="-1132.49" cy="416.22" r="20.00"/>
             </g>
@@ -2136,8 +2136,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="165">
             <desc>L56-42-1</desc>
             <g id="165.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1621.37,-338.85 1677.96,-177.11"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1632.10,-308.17)">
+                <polyline class="nad-edge-path" points="1621.37,-338.85 1677.96,-177.11"/>
+                <g class="nad-edge-infos" transform="translate(1632.10,-308.17)">
                     <g class="nad-active">
                         <g transform="rotate(160.72)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2148,8 +2148,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="165.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1734.54,-15.37 1677.96,-177.11"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1723.81,-46.04)">
+                <polyline class="nad-edge-path" points="1734.54,-15.37 1677.96,-177.11"/>
+                <g class="nad-edge-infos" transform="translate(1723.81,-46.04)">
                     <g class="nad-active">
                         <g transform="rotate(-19.28)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2186,7 +2186,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl0to30-line nad-winding" cx="1722.49" cy="-401.70" r="20.00"/>
                 <circle class="nad-vl0to30-line nad-winding" cx="1722.25" cy="-381.70" r="20.00"/>
             </g>
@@ -2194,8 +2194,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="167">
             <desc>L47-48-1</desc>
             <g id="167.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="468.07,716.00 589.60,618.02"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(493.37,695.60)">
+                <polyline class="nad-edge-path" points="468.07,716.00 589.60,618.02"/>
+                <g class="nad-edge-infos" transform="translate(493.37,695.60)">
                     <g class="nad-active">
                         <g transform="rotate(51.12)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2206,8 +2206,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="167.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="711.13,520.04 589.60,618.02"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(685.83,540.44)">
+                <polyline class="nad-edge-path" points="711.13,520.04 589.60,618.02"/>
+                <g class="nad-edge-infos" transform="translate(685.83,540.44)">
                     <g class="nad-active">
                         <g transform="rotate(-128.88)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2221,8 +2221,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="168">
             <desc>L5-6-1</desc>
             <g id="168.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1320.78,672.79 -1037.88,611.95"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1289.00,665.95)">
+                <polyline class="nad-edge-path" points="-1320.78,672.79 -1037.88,611.95"/>
+                <g class="nad-edge-infos" transform="translate(-1289.00,665.95)">
                     <g class="nad-active">
                         <g transform="rotate(77.86)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2233,8 +2233,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="168.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-754.99,551.12 -1037.88,611.95"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-786.77,557.95)">
+                <polyline class="nad-edge-path" points="-754.99,551.12 -1037.88,611.95"/>
+                <g class="nad-edge-infos" transform="translate(-786.77,557.95)">
                     <g class="nad-active">
                         <g transform="rotate(-102.14)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2248,8 +2248,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="169">
             <desc>L29-52-1</desc>
             <g id="169.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-377.22,679.15 -126.10,935.66"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-354.49,702.38)">
+                <polyline class="nad-edge-path" points="-377.22,679.15 -126.10,935.66"/>
+                <g class="nad-edge-infos" transform="translate(-354.49,702.38)">
                     <g class="nad-active">
                         <g transform="rotate(135.61)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2260,8 +2260,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="169.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="125.02,1192.17 -126.10,935.66"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(102.29,1168.95)">
+                <polyline class="nad-edge-path" points="125.02,1192.17 -126.10,935.66"/>
+                <g class="nad-edge-infos" transform="translate(102.29,1168.95)">
                     <g class="nad-active">
                         <g transform="rotate(-44.39)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2275,8 +2275,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="170">
             <desc>L52-53-1</desc>
             <g id="170.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="171.44,1216.00 416.30,1253.64"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(203.57,1220.94)">
+                <polyline class="nad-edge-path" points="171.44,1216.00 416.30,1253.64"/>
+                <g class="nad-edge-infos" transform="translate(203.57,1220.94)">
                     <g class="nad-active">
                         <g transform="rotate(98.74)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2287,8 +2287,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="170.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="661.16,1291.29 416.30,1253.64"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(629.03,1286.35)">
+                <polyline class="nad-edge-path" points="661.16,1291.29 416.30,1253.64"/>
+                <g class="nad-edge-infos" transform="translate(629.03,1286.35)">
                     <g class="nad-active">
                         <g transform="rotate(-81.26)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2302,8 +2302,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="171">
             <desc>L53-54-1</desc>
             <g id="171.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="705.14,1273.69 851.77,1083.65"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(724.99,1247.96)">
+                <polyline class="nad-edge-path" points="705.14,1273.69 851.77,1083.65"/>
+                <g class="nad-edge-infos" transform="translate(724.99,1247.96)">
                     <g class="nad-active">
                         <g transform="rotate(37.65)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2314,8 +2314,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="171.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="998.41,893.60 851.77,1083.65"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(978.55,919.33)">
+                <polyline class="nad-edge-path" points="998.41,893.60 851.77,1083.65"/>
+                <g class="nad-edge-infos" transform="translate(978.55,919.33)">
                     <g class="nad-active">
                         <g transform="rotate(-142.35)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2329,8 +2329,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="172">
             <desc>L54-55-1</desc>
             <g id="172.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1008.67,845.11 921.77,490.16"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1000.94,813.55)">
+                <polyline class="nad-edge-path" points="1008.67,845.11 921.77,490.16"/>
+                <g class="nad-edge-infos" transform="translate(1000.94,813.55)">
                     <g class="nad-active">
                         <g transform="rotate(-13.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2341,8 +2341,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="172.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="834.87,135.21 921.77,490.16"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(849.74,195.92)">
+                <polyline class="nad-edge-path" points="834.87,135.21 921.77,490.16"/>
+                <g class="nad-edge-infos" transform="translate(849.74,195.92)">
                     <g class="nad-active">
                         <g transform="rotate(166.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2356,8 +2356,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="173">
             <desc>L6-7-1</desc>
             <g id="173.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-701.75,553.20 -572.78,591.70"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-670.61,562.50)">
+                <polyline class="nad-edge-path" points="-701.75,553.20 -572.78,591.70"/>
+                <g class="nad-edge-infos" transform="translate(-670.61,562.50)">
                     <g class="nad-active">
                         <g transform="rotate(106.62)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2368,8 +2368,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="173.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-443.80,630.20 -572.78,591.70"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-503.69,612.32)">
+                <polyline class="nad-edge-path" points="-443.80,630.20 -572.78,591.70"/>
+                <g class="nad-edge-infos" transform="translate(-503.69,612.32)">
                     <g class="nad-active">
                         <g transform="rotate(-73.38)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2383,8 +2383,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="174">
             <desc>L6-8-1</desc>
             <g id="174.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-700.80,542.10 -417.43,508.53"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-668.52,538.28)">
+                <polyline class="nad-edge-path" points="-700.80,542.10 -417.43,508.53"/>
+                <g class="nad-edge-infos" transform="translate(-668.52,538.28)">
                     <g class="nad-active">
                         <g transform="rotate(83.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2395,8 +2395,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="174.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-134.06,474.96 -417.43,508.53"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-166.33,478.79)">
+                <polyline class="nad-edge-path" points="-134.06,474.96 -417.43,508.53"/>
+                <g class="nad-edge-infos" transform="translate(-166.33,478.79)">
                     <g class="nad-active">
                         <g transform="rotate(-96.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2410,8 +2410,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="175">
             <desc>L7-8-1</desc>
             <g id="175.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-393.20,625.09 -262.10,554.90"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-338.10,595.59)">
+                <polyline class="nad-edge-path" points="-393.20,625.09 -262.10,554.90"/>
+                <g class="nad-edge-infos" transform="translate(-338.10,595.59)">
                     <g class="nad-active">
                         <g transform="rotate(61.84)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2422,8 +2422,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="175.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-130.99,484.71 -262.10,554.90"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-159.64,500.05)">
+                <polyline class="nad-edge-path" points="-130.99,484.71 -262.10,554.90"/>
+                <g class="nad-edge-infos" transform="translate(-159.64,500.05)">
                     <g class="nad-active">
                         <g transform="rotate(-118.16)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2460,7 +2460,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl0to30-line nad-winding" cx="-470.90" cy="745.97" r="20.00"/>
                 <circle class="nad-vl0to30-line nad-winding" cx="-488.02" cy="735.63" r="20.00"/>
             </g>
@@ -2468,8 +2468,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="177">
             <desc>L8-9-1</desc>
             <g id="177.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-81.11,461.77 346.81,295.55"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-50.82,450.00)">
+                <polyline class="nad-edge-path" points="-81.11,461.77 346.81,295.55"/>
+                <g class="nad-edge-infos" transform="translate(-50.82,450.00)">
                     <g class="nad-active">
                         <g transform="rotate(68.77)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2480,8 +2480,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="177.2" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="774.74,129.32 346.81,295.55"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(744.44,141.09)">
+                <polyline class="nad-edge-path" points="774.74,129.32 346.81,295.55"/>
+                <g class="nad-edge-infos" transform="translate(744.44,141.09)">
                     <g class="nad-active">
                         <g transform="rotate(-111.23)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -2518,7 +2518,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl0to30-line nad-winding" cx="935.66" cy="163.11" r="20.00"/>
                 <circle class="nad-vl0to30-line nad-winding" cx="925.14" cy="180.12" r="20.00"/>
             </g>

--- a/network-area-diagram/src/test/resources/current_limits.svg
+++ b/network-area-diagram/src/test/resources/current_limits.svg
@@ -58,8 +58,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
     <g class="nad-branch-edges">
         <g id="4" class="nad-overload">
             <g id="4.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-69.22,-294.55 -143.24,-158.76"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-84.78,-266.02)">
+                <polyline class="nad-edge-path" points="-69.22,-294.55 -143.24,-158.76"/>
+                <g class="nad-edge-infos" transform="translate(-84.78,-266.02)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-151.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -70,8 +70,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="4.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-217.26,-22.97 -143.24,-158.76"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-201.70,-51.50)">
+                <polyline class="nad-edge-path" points="-217.26,-22.97 -143.24,-158.76"/>
+                <g class="nad-edge-infos" transform="translate(-201.70,-51.50)">
                     <g class="nad-active">
                         <g transform="rotate(28.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -84,8 +84,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="7" class="nad-dangling-line-edge">
             <g id="7.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-216.73,25.03 -139.77,159.16"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-200.56,53.22)">
+                <polyline class="nad-edge-path" points="-216.73,25.03 -139.77,159.16"/>
+                <g class="nad-edge-infos" transform="translate(-200.56,53.22)">
                     <g class="nad-active">
                         <g transform="rotate(150.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -96,7 +96,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="7.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-62.80,293.29 -139.77,159.16"/>
+                <polyline class="nad-edge-path" points="-62.80,293.29 -139.77,159.16"/>
             </g>
         </g>
     </g>

--- a/network-area-diagram/src/test/resources/dangling_line_connected.svg
+++ b/network-area-diagram/src/test/resources/dangling_line_connected.svg
@@ -63,8 +63,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
     <g class="nad-branch-edges">
         <g id="8">
             <g id="8.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-107.19,-205.38 -158.52,-194.37 -199.91,-156.95"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-180.78,-174.25)">
+                <polyline class="nad-edge-path" points="-107.19,-205.38 -158.52,-194.37 -199.91,-156.95"/>
+                <g class="nad-edge-infos" transform="translate(-180.78,-174.25)">
                     <g class="nad-active">
                         <g transform="rotate(-132.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -75,8 +75,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="8.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-257.43,-69.57 -241.30,-119.53 -199.91,-156.95"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-219.05,-139.65)">
+                <polyline class="nad-edge-path" points="-257.43,-69.57 -241.30,-119.53 -199.91,-156.95"/>
+                <g class="nad-edge-infos" transform="translate(-219.05,-139.65)">
                     <g class="nad-active">
                         <g transform="rotate(47.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -89,8 +89,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="9">
             <g id="9.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-97.96,-156.43 -104.87,-135.02 -146.26,-97.60"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-127.13,-114.90)">
+                <polyline class="nad-edge-path" points="-97.96,-156.43 -104.87,-135.02 -146.26,-97.60"/>
+                <g class="nad-edge-infos" transform="translate(-127.13,-114.90)">
                     <g class="nad-active">
                         <g transform="rotate(-132.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -101,8 +101,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="9.2" class="nad-disconnected nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-238.99,-49.17 -187.65,-60.19 -146.26,-97.60"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-165.40,-80.31)">
+                <polyline class="nad-edge-path" points="-238.99,-49.17 -187.65,-60.19 -146.26,-97.60"/>
+                <g class="nad-edge-infos" transform="translate(-165.40,-80.31)">
                     <g class="nad-active">
                         <g transform="rotate(47.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -115,8 +115,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="10">
             <g id="10.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-71.33,-154.36 -52.41,-34.52"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-66.26,-122.26)">
+                <polyline class="nad-edge-path" points="-71.33,-154.36 -52.41,-34.52"/>
+                <g class="nad-edge-infos" transform="translate(-66.26,-122.26)">
                     <g class="nad-active">
                         <g transform="rotate(171.03)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -127,8 +127,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="10.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-24.12,144.59 -43.05,24.75"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-33.87,82.85)">
+                <polyline class="nad-edge-path" points="-24.12,144.59 -43.05,24.75"/>
+                <g class="nad-edge-infos" transform="translate(-33.87,82.85)">
                     <g class="nad-active">
                         <g transform="rotate(-8.97)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -138,15 +138,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500 nad-winding" cx="-49.29" cy="-14.76" r="20.00"/>
                 <circle class="nad-vl180to300 nad-winding" cx="-46.17" cy="4.99" r="20.00"/>
             </g>
         </g>
         <g id="11">
             <g id="11.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-245.17,-25.30 -176.73,34.55"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-220.71,-3.90)">
+                <polyline class="nad-edge-path" points="-245.17,-25.30 -176.73,34.55"/>
+                <g class="nad-edge-infos" transform="translate(-220.71,-3.90)">
                     <g class="nad-active">
                         <g transform="rotate(131.17)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -157,8 +157,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="11.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-63.12,133.90 -131.56,74.05"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-87.58,112.51)">
+                <polyline class="nad-edge-path" points="-63.12,133.90 -131.56,74.05"/>
+                <g class="nad-edge-infos" transform="translate(-87.58,112.51)">
                     <g class="nad-active">
                         <g transform="rotate(-48.83)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -168,15 +168,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500 nad-winding" cx="-161.67" cy="47.72" r="20.00"/>
                 <circle class="nad-vl180to300 nad-winding" cx="-146.62" cy="60.88" r="20.00"/>
             </g>
         </g>
         <g id="14" class="nad-dangling-line-edge">
             <g id="14.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-242.83,-58.42 -27.76,-198.60"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-215.61,-76.16)">
+                <polyline class="nad-edge-path" points="-242.83,-58.42 -27.76,-198.60"/>
+                <g class="nad-edge-infos" transform="translate(-215.61,-76.16)">
                     <g class="nad-active">
                         <g transform="rotate(56.90)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -187,7 +187,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="14.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="187.32,-338.78 -27.76,-198.60"/>
+                <polyline class="nad-edge-path" points="187.32,-338.78 -27.76,-198.60"/>
             </g>
         </g>
     </g>

--- a/network-area-diagram/src/test/resources/dangling_line_disconnected.svg
+++ b/network-area-diagram/src/test/resources/dangling_line_disconnected.svg
@@ -63,8 +63,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
     <g class="nad-branch-edges">
         <g id="8">
             <g id="8.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-107.19,-205.38 -158.52,-194.37 -199.91,-156.95"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-180.78,-174.25)">
+                <polyline class="nad-edge-path" points="-107.19,-205.38 -158.52,-194.37 -199.91,-156.95"/>
+                <g class="nad-edge-infos" transform="translate(-180.78,-174.25)">
                     <g class="nad-active">
                         <g transform="rotate(-132.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -75,8 +75,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="8.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-257.43,-69.57 -241.30,-119.53 -199.91,-156.95"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-219.05,-139.65)">
+                <polyline class="nad-edge-path" points="-257.43,-69.57 -241.30,-119.53 -199.91,-156.95"/>
+                <g class="nad-edge-infos" transform="translate(-219.05,-139.65)">
                     <g class="nad-active">
                         <g transform="rotate(47.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -89,8 +89,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="9">
             <g id="9.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-97.96,-156.43 -104.87,-135.02 -146.26,-97.60"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-127.13,-114.90)">
+                <polyline class="nad-edge-path" points="-97.96,-156.43 -104.87,-135.02 -146.26,-97.60"/>
+                <g class="nad-edge-infos" transform="translate(-127.13,-114.90)">
                     <g class="nad-active">
                         <g transform="rotate(-132.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -101,8 +101,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="9.2" class="nad-disconnected nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-238.99,-49.17 -187.65,-60.19 -146.26,-97.60"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-165.40,-80.31)">
+                <polyline class="nad-edge-path" points="-238.99,-49.17 -187.65,-60.19 -146.26,-97.60"/>
+                <g class="nad-edge-infos" transform="translate(-165.40,-80.31)">
                     <g class="nad-active">
                         <g transform="rotate(47.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -115,8 +115,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="10">
             <g id="10.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-71.33,-154.36 -52.41,-34.52"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-66.26,-122.26)">
+                <polyline class="nad-edge-path" points="-71.33,-154.36 -52.41,-34.52"/>
+                <g class="nad-edge-infos" transform="translate(-66.26,-122.26)">
                     <g class="nad-active">
                         <g transform="rotate(171.03)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -127,8 +127,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="10.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-24.12,144.59 -43.05,24.75"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-33.87,82.85)">
+                <polyline class="nad-edge-path" points="-24.12,144.59 -43.05,24.75"/>
+                <g class="nad-edge-infos" transform="translate(-33.87,82.85)">
                     <g class="nad-active">
                         <g transform="rotate(-8.97)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -138,15 +138,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500 nad-winding" cx="-49.29" cy="-14.76" r="20.00"/>
                 <circle class="nad-vl180to300 nad-winding" cx="-46.17" cy="4.99" r="20.00"/>
             </g>
         </g>
         <g id="11">
             <g id="11.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-245.17,-25.30 -176.73,34.55"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-220.71,-3.90)">
+                <polyline class="nad-edge-path" points="-245.17,-25.30 -176.73,34.55"/>
+                <g class="nad-edge-infos" transform="translate(-220.71,-3.90)">
                     <g class="nad-active">
                         <g transform="rotate(131.17)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -157,8 +157,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="11.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-63.12,133.90 -131.56,74.05"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-87.58,112.51)">
+                <polyline class="nad-edge-path" points="-63.12,133.90 -131.56,74.05"/>
+                <g class="nad-edge-infos" transform="translate(-87.58,112.51)">
                     <g class="nad-active">
                         <g transform="rotate(-48.83)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -168,15 +168,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500 nad-winding" cx="-161.67" cy="47.72" r="20.00"/>
                 <circle class="nad-vl180to300 nad-winding" cx="-146.62" cy="60.88" r="20.00"/>
             </g>
         </g>
         <g id="14" class="nad-disconnected nad-dangling-line-edge">
             <g id="14.1" class="nad-disconnected nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-242.83,-58.42 -27.76,-198.60"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-215.61,-76.16)">
+                <polyline class="nad-edge-path" points="-242.83,-58.42 -27.76,-198.60"/>
+                <g class="nad-edge-infos" transform="translate(-215.61,-76.16)">
                     <g class="nad-active">
                         <g transform="rotate(56.90)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -187,7 +187,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="14.2" class="nad-disconnected nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="187.32,-338.78 -27.76,-198.60"/>
+                <polyline class="nad-edge-path" points="187.32,-338.78 -27.76,-198.60"/>
             </g>
         </g>
     </g>

--- a/network-area-diagram/src/test/resources/detailed_text_node.svg
+++ b/network-area-diagram/src/test/resources/detailed_text_node.svg
@@ -123,8 +123,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
     <g class="nad-branch-edges">
         <g id="4">
             <g id="4.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-69.22,-294.55 -143.24,-158.76"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-84.78,-266.02)">
+                <polyline class="nad-edge-path" points="-69.22,-294.55 -143.24,-158.76"/>
+                <g class="nad-edge-infos" transform="translate(-84.78,-266.02)">
                     <g class="nad-active">
                         <g transform="rotate(-151.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -135,8 +135,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="4.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-217.26,-22.97 -143.24,-158.76"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-201.70,-51.50)">
+                <polyline class="nad-edge-path" points="-217.26,-22.97 -143.24,-158.76"/>
+                <g class="nad-edge-infos" transform="translate(-201.70,-51.50)">
                     <g class="nad-active">
                         <g transform="rotate(28.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -149,8 +149,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="7" class="nad-dangling-line-edge">
             <g id="7.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-216.73,25.03 -139.77,159.16"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-200.56,53.22)">
+                <polyline class="nad-edge-path" points="-216.73,25.03 -139.77,159.16"/>
+                <g class="nad-edge-infos" transform="translate(-200.56,53.22)">
                     <g class="nad-active">
                         <g transform="rotate(150.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -161,7 +161,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="7.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-62.80,293.29 -139.77,159.16"/>
+                <polyline class="nad-edge-path" points="-62.80,293.29 -139.77,159.16"/>
             </g>
         </g>
     </g>

--- a/network-area-diagram/src/test/resources/detailed_text_node_no_legend.svg
+++ b/network-area-diagram/src/test/resources/detailed_text_node_no_legend.svg
@@ -123,8 +123,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
     <g class="nad-branch-edges">
         <g id="4">
             <g id="4.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-69.22,-294.55 -143.24,-158.76"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-84.78,-266.02)">
+                <polyline class="nad-edge-path" points="-69.22,-294.55 -143.24,-158.76"/>
+                <g class="nad-edge-infos" transform="translate(-84.78,-266.02)">
                     <g class="nad-active">
                         <g transform="rotate(-151.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -135,8 +135,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="4.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-217.26,-22.97 -143.24,-158.76"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-201.70,-51.50)">
+                <polyline class="nad-edge-path" points="-217.26,-22.97 -143.24,-158.76"/>
+                <g class="nad-edge-infos" transform="translate(-201.70,-51.50)">
                     <g class="nad-active">
                         <g transform="rotate(28.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -149,8 +149,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="7" class="nad-dangling-line-edge">
             <g id="7.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-216.73,25.03 -139.77,159.16"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-200.56,53.22)">
+                <polyline class="nad-edge-path" points="-216.73,25.03 -139.77,159.16"/>
+                <g class="nad-edge-infos" transform="translate(-200.56,53.22)">
                     <g class="nad-active">
                         <g transform="rotate(150.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -161,7 +161,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="7.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-62.80,293.29 -139.77,159.16"/>
+                <polyline class="nad-edge-path" points="-62.80,293.29 -139.77,159.16"/>
             </g>
         </g>
     </g>

--- a/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.0.svg
+++ b/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.0.svg
@@ -94,8 +94,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
     <g class="nad-branch-edges">
         <g id="30">
             <g id="30.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-645.74,790.21 -446.72,831.53"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-613.91,796.82)">
+                <polyline class="nad-edge-path" points="-645.74,790.21 -446.72,831.53"/>
+                <g class="nad-edge-infos" transform="translate(-613.91,796.82)">
                     <g class="nad-active">
                         <g transform="rotate(101.73)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -106,8 +106,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="30.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-247.71,872.84 -446.72,831.53"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-279.53,866.24)">
+                <polyline class="nad-edge-path" points="-247.71,872.84 -446.72,831.53"/>
+                <g class="nad-edge-infos" transform="translate(-279.53,866.24)">
                     <g class="nad-active">
                         <g transform="rotate(-78.27)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -120,8 +120,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="31">
             <g id="31.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1014.87,625.82 -883.45,686.81"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-985.39,639.50)">
+                <polyline class="nad-edge-path" points="-1014.87,625.82 -883.45,686.81"/>
+                <g class="nad-edge-infos" transform="translate(-985.39,639.50)">
                     <g class="nad-active">
                         <g transform="rotate(114.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -132,8 +132,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="31.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-697.61,773.05 -829.03,712.06"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-727.09,759.37)">
+                <polyline class="nad-edge-path" points="-697.61,773.05 -829.03,712.06"/>
+                <g class="nad-edge-infos" transform="translate(-727.09,759.37)">
                     <g class="nad-active">
                         <g transform="rotate(-65.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -143,15 +143,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500 nad-winding" cx="-865.31" cy="695.23" r="20.00"/>
                 <circle class="nad-vl180to300 nad-winding" cx="-847.17" cy="703.65" r="20.00"/>
             </g>
         </g>
         <g id="32">
             <g id="32.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-193.50,874.95 23.70,847.26"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-161.26,870.84)">
+                <polyline class="nad-edge-path" points="-193.50,874.95 23.70,847.26"/>
+                <g class="nad-edge-infos" transform="translate(-161.26,870.84)">
                     <g class="nad-active">
                         <g transform="rotate(82.73)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -162,8 +162,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="32.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="240.90,819.56 23.70,847.26"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(208.66,823.67)">
+                <polyline class="nad-edge-path" points="240.90,819.56 23.70,847.26"/>
+                <g class="nad-edge-infos" transform="translate(208.66,823.67)">
                     <g class="nad-active">
                         <g transform="rotate(-97.27)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -176,8 +176,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="33">
             <g id="33.1" class="nad-vl50to70">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="742.07,547.61 892.02,566.63"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(774.32,551.70)">
+                <polyline class="nad-edge-path" points="742.07,547.61 892.02,566.63"/>
+                <g class="nad-edge-infos" transform="translate(774.32,551.70)">
                     <g class="nad-active">
                         <g transform="rotate(97.23)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -188,8 +188,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="33.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1101.49,593.20 951.54,574.18"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1069.25,589.11)">
+                <polyline class="nad-edge-path" points="1101.49,593.20 951.54,574.18"/>
+                <g class="nad-edge-infos" transform="translate(1069.25,589.11)">
                     <g class="nad-active">
                         <g transform="rotate(-82.77)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -199,15 +199,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl50to70 nad-winding" cx="911.86" cy="569.14" r="20.00"/>
                 <circle class="nad-vl0to30 nad-winding" cx="931.70" cy="571.66" r="20.00"/>
             </g>
         </g>
         <g id="34">
             <g id="34.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="291.66,801.78 465.86,695.72"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(319.42,784.88)">
+                <polyline class="nad-edge-path" points="291.66,801.78 465.86,695.72"/>
+                <g class="nad-edge-infos" transform="translate(319.42,784.88)">
                     <g class="nad-active">
                         <g transform="rotate(58.66)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -218,8 +218,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="34.2" class="nad-vl50to70">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="691.30,558.45 517.11,664.51"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(663.55,575.35)">
+                <polyline class="nad-edge-path" points="691.30,558.45 517.11,664.51"/>
+                <g class="nad-edge-infos" transform="translate(663.55,575.35)">
                     <g class="nad-active">
                         <g transform="rotate(-121.34)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -229,15 +229,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl180to300 nad-winding" cx="482.94" cy="685.32" r="20.00"/>
                 <circle class="nad-vl50to70 nad-winding" cx="500.03" cy="674.92" r="20.00"/>
             </g>
         </g>
         <g id="35">
             <g id="35.1" class="nad-vl50to70">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="714.86,516.65 715.38,299.37"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(714.94,484.15)">
+                <polyline class="nad-edge-path" points="714.86,516.65 715.38,299.37"/>
+                <g class="nad-edge-infos" transform="translate(714.94,484.15)">
                     <g class="nad-active">
                         <g transform="rotate(0.14)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -248,8 +248,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="35.2" class="nad-vl50to70">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="715.90,82.10 715.38,299.37"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(715.83,114.60)">
+                <polyline class="nad-edge-path" points="715.90,82.10 715.38,299.37"/>
+                <g class="nad-edge-infos" transform="translate(715.83,114.60)">
                     <g class="nad-active">
                         <g transform="rotate(-179.86)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -262,8 +262,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="36">
             <g id="36.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="361.26,-377.98 393.68,-585.50"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(366.28,-410.09)">
+                <polyline class="nad-edge-path" points="361.26,-377.98 393.68,-585.50"/>
+                <g class="nad-edge-infos" transform="translate(366.28,-410.09)">
                     <g class="nad-active">
                         <g transform="rotate(8.88)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -274,8 +274,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="36.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="426.10,-793.01 393.68,-585.50"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(421.08,-760.90)">
+                <polyline class="nad-edge-path" points="426.10,-793.01 393.68,-585.50"/>
+                <g class="nad-edge-infos" transform="translate(421.08,-760.90)">
                     <g class="nad-active">
                         <g transform="rotate(-171.12)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -288,8 +288,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="37">
             <g id="37.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-297.46,-540.89 16.57,-449.68"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-266.25,-531.82)">
+                <polyline class="nad-edge-path" points="-297.46,-540.89 16.57,-449.68"/>
+                <g class="nad-edge-infos" transform="translate(-266.25,-531.82)">
                     <g class="nad-active">
                         <g transform="rotate(106.19)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -300,8 +300,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="37.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="330.61,-358.48 16.57,-449.68"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(299.40,-367.54)">
+                <polyline class="nad-edge-path" points="330.61,-358.48 16.57,-449.68"/>
+                <g class="nad-edge-infos" transform="translate(299.40,-367.54)">
                     <g class="nad-active">
                         <g transform="rotate(-73.81)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -314,8 +314,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="38">
             <g id="38.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="204.78,-23.24 275.10,-174.56"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(218.48,-52.71)">
+                <polyline class="nad-edge-path" points="204.78,-23.24 275.10,-174.56"/>
+                <g class="nad-edge-infos" transform="translate(218.48,-52.71)">
                     <g class="nad-active">
                         <g transform="rotate(24.93)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -326,8 +326,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="38.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="345.42,-325.87 275.10,-174.56"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(331.73,-296.40)">
+                <polyline class="nad-edge-path" points="345.42,-325.87 275.10,-174.56"/>
+                <g class="nad-edge-infos" transform="translate(331.73,-296.40)">
                     <g class="nad-active">
                         <g transform="rotate(-155.07)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -340,8 +340,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="39">
             <g id="39.1" class="nad-vl50to70">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="697.74,34.01 556.38,-125.65"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(676.19,9.67)">
+                <polyline class="nad-edge-path" points="697.74,34.01 556.38,-125.65"/>
+                <g class="nad-edge-infos" transform="translate(676.19,9.67)">
                     <g class="nad-active">
                         <g transform="rotate(-41.52)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -352,8 +352,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="39.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="375.24,-330.22 516.60,-170.57"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(396.79,-305.89)">
+                <polyline class="nad-edge-path" points="375.24,-330.22 516.60,-170.57"/>
+                <g class="nad-edge-infos" transform="translate(396.79,-305.89)">
                     <g class="nad-active">
                         <g transform="rotate(138.48)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -363,15 +363,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl50to70 nad-winding" cx="543.12" cy="-140.62" r="20.00"/>
                 <circle class="nad-vl0to30 nad-winding" cx="529.86" cy="-155.59" r="20.00"/>
             </g>
         </g>
         <g id="40">
             <g id="40.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="404.60,-829.84 226.99,-896.48"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(374.17,-841.26)">
+                <polyline class="nad-edge-path" points="404.60,-829.84 226.99,-896.48"/>
+                <g class="nad-edge-infos" transform="translate(374.17,-841.26)">
                     <g class="nad-active">
                         <g transform="rotate(-69.43)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -382,8 +382,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="40.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="49.39,-963.13 226.99,-896.48"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(79.82,-951.71)">
+                <polyline class="nad-edge-path" points="49.39,-963.13 226.99,-896.48"/>
+                <g class="nad-edge-infos" transform="translate(79.82,-951.71)">
                     <g class="nad-active">
                         <g transform="rotate(110.57)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -396,8 +396,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="41">
             <g id="41.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-3.78,-970.77 -190.55,-957.03"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-36.19,-968.38)">
+                <polyline class="nad-edge-path" points="-3.78,-970.77 -190.55,-957.03"/>
+                <g class="nad-edge-infos" transform="translate(-36.19,-968.38)">
                     <g class="nad-active">
                         <g transform="rotate(-94.21)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -408,8 +408,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="41.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-377.32,-943.29 -190.55,-957.03"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-344.90,-945.68)">
+                <polyline class="nad-edge-path" points="-377.32,-943.29 -190.55,-957.03"/>
+                <g class="nad-edge-infos" transform="translate(-344.90,-945.68)">
                     <g class="nad-active">
                         <g transform="rotate(85.79)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -422,8 +422,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="42">
             <g id="42.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="22.14,-945.33 12.57,-771.23"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(20.35,-912.88)">
+                <polyline class="nad-edge-path" points="22.14,-945.33 12.57,-771.23"/>
+                <g class="nad-edge-infos" transform="translate(20.35,-912.88)">
                     <g class="nad-active">
                         <g transform="rotate(-176.85)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -434,8 +434,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="42.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="3.00,-597.13 12.57,-771.23"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(4.78,-629.58)">
+                <polyline class="nad-edge-path" points="3.00,-597.13 12.57,-771.23"/>
+                <g class="nad-edge-infos" transform="translate(4.78,-629.58)">
                     <g class="nad-active">
                         <g transform="rotate(3.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -448,8 +448,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="43">
             <g id="43.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-399.20,-914.34 -364.31,-744.92"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-392.64,-882.51)">
+                <polyline class="nad-edge-path" points="-399.20,-914.34 -364.31,-744.92"/>
+                <g class="nad-edge-infos" transform="translate(-392.64,-882.51)">
                     <g class="nad-active">
                         <g transform="rotate(168.36)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -460,8 +460,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="43.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-329.42,-575.49 -364.31,-744.92"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-335.97,-607.32)">
+                <polyline class="nad-edge-path" points="-329.42,-575.49 -364.31,-744.92"/>
+                <g class="nad-edge-infos" transform="translate(-335.97,-607.32)">
                     <g class="nad-active">
                         <g transform="rotate(-11.64)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -474,8 +474,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="44">
             <g id="44.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-6.60,-543.39 -66.49,-348.75"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-16.16,-512.33)">
+                <polyline class="nad-edge-path" points="-6.60,-543.39 -66.49,-348.75"/>
+                <g class="nad-edge-infos" transform="translate(-16.16,-512.33)">
                     <g class="nad-active">
                         <g transform="rotate(-162.90)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -486,8 +486,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="44.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-126.37,-154.10 -66.49,-348.75"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-116.82,-185.17)">
+                <polyline class="nad-edge-path" points="-126.37,-154.10 -66.49,-348.75"/>
+                <g class="nad-edge-infos" transform="translate(-116.82,-185.17)">
                     <g class="nad-active">
                         <g transform="rotate(17.10)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -500,8 +500,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="45">
             <g id="45.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-108.88,-117.71 29.37,-63.06"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-78.66,-105.76)">
+                <polyline class="nad-edge-path" points="-108.88,-117.71 29.37,-63.06"/>
+                <g class="nad-edge-infos" transform="translate(-78.66,-105.76)">
                     <g class="nad-active">
                         <g transform="rotate(111.57)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -512,8 +512,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="45.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="167.62,-8.41 29.37,-63.06"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(137.39,-20.36)">
+                <polyline class="nad-edge-path" points="167.62,-8.41 29.37,-63.06"/>
+                <g class="nad-edge-infos" transform="translate(137.39,-20.36)">
                     <g class="nad-active">
                         <g transform="rotate(-68.43)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.2.svg
+++ b/network-area-diagram/src/test/resources/diamond-spring-repulsion-factor-0.2.svg
@@ -94,8 +94,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
     <g class="nad-branch-edges">
         <g id="30">
             <g id="30.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1197.55,903.79 -1009.39,1015.21"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1169.58,920.35)">
+                <polyline class="nad-edge-path" points="-1197.55,903.79 -1009.39,1015.21"/>
+                <g class="nad-edge-infos" transform="translate(-1169.58,920.35)">
                     <g class="nad-active">
                         <g transform="rotate(120.63)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -106,8 +106,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="30.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-821.23,1126.64 -1009.39,1015.21"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-849.20,1110.08)">
+                <polyline class="nad-edge-path" points="-821.23,1126.64 -1009.39,1015.21"/>
+                <g class="nad-edge-infos" transform="translate(-849.20,1110.08)">
                     <g class="nad-active">
                         <g transform="rotate(-59.37)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -120,8 +120,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="31">
             <g id="31.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-1474.42,594.89 -1376.32,709.14"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-1453.25,619.55)">
+                <polyline class="nad-edge-path" points="-1474.42,594.89 -1376.32,709.14"/>
+                <g class="nad-edge-infos" transform="translate(-1453.25,619.55)">
                     <g class="nad-active">
                         <g transform="rotate(139.35)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -132,8 +132,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="31.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-1239.13,868.91 -1337.23,754.66"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-1260.30,844.25)">
+                <polyline class="nad-edge-path" points="-1239.13,868.91 -1337.23,754.66"/>
+                <g class="nad-edge-infos" transform="translate(-1260.30,844.25)">
                     <g class="nad-active">
                         <g transform="rotate(-40.65)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -143,15 +143,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500 nad-winding" cx="-1363.29" cy="724.32" r="20.00"/>
                 <circle class="nad-vl180to300 nad-winding" cx="-1350.26" cy="739.49" r="20.00"/>
             </g>
         </g>
         <g id="32">
             <g id="32.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-770.08,1139.96 -547.35,1134.42"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-737.59,1139.16)">
+                <polyline class="nad-edge-path" points="-770.08,1139.96 -547.35,1134.42"/>
+                <g class="nad-edge-infos" transform="translate(-737.59,1139.16)">
                     <g class="nad-active">
                         <g transform="rotate(88.57)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -162,8 +162,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="32.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-324.62,1128.87 -547.35,1134.42"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-357.11,1129.68)">
+                <polyline class="nad-edge-path" points="-324.62,1128.87 -547.35,1134.42"/>
+                <g class="nad-edge-infos" transform="translate(-357.11,1129.68)">
                     <g class="nad-active">
                         <g transform="rotate(-91.43)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -176,8 +176,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="33">
             <g id="33.1" class="nad-vl50to70">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="29.58,684.88 -85.00,590.67"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(4.47,664.24)">
+                <polyline class="nad-edge-path" points="29.58,684.88 -85.00,590.67"/>
+                <g class="nad-edge-infos" transform="translate(4.47,664.24)">
                     <g class="nad-active">
                         <g transform="rotate(-50.57)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -188,8 +188,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="33.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-245.92,458.34 -131.34,552.56"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-220.81,478.99)">
+                <polyline class="nad-edge-path" points="-245.92,458.34 -131.34,552.56"/>
+                <g class="nad-edge-infos" transform="translate(-220.81,478.99)">
                     <g class="nad-active">
                         <g transform="rotate(129.43)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -199,15 +199,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl50to70 nad-winding" cx="-100.45" cy="577.96" r="20.00"/>
                 <circle class="nad-vl0to30 nad-winding" cx="-115.89" cy="565.26" r="20.00"/>
             </g>
         </g>
         <g id="34">
             <g id="34.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-279.73,1106.89 -142.14,938.50"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-259.16,1081.72)">
+                <polyline class="nad-edge-path" points="-279.73,1106.89 -142.14,938.50"/>
+                <g class="nad-edge-infos" transform="translate(-259.16,1081.72)">
                     <g class="nad-active">
                         <g transform="rotate(39.25)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -218,8 +218,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="34.2" class="nad-vl50to70">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="33.42,723.64 -104.17,892.03"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(12.85,748.81)">
+                <polyline class="nad-edge-path" points="33.42,723.64 -104.17,892.03"/>
+                <g class="nad-edge-infos" transform="translate(12.85,748.81)">
                     <g class="nad-active">
                         <g transform="rotate(-140.75)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -229,15 +229,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl180to300 nad-winding" cx="-129.48" cy="923.01" r="20.00"/>
                 <circle class="nad-vl50to70 nad-winding" cx="-116.83" cy="907.52" r="20.00"/>
             </g>
         </g>
         <g id="35">
             <g id="35.1" class="nad-vl50to70">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="67.54,680.52 229.49,469.12"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(87.31,654.72)">
+                <polyline class="nad-edge-path" points="67.54,680.52 229.49,469.12"/>
+                <g class="nad-edge-infos" transform="translate(87.31,654.72)">
                     <g class="nad-active">
                         <g transform="rotate(37.46)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -248,8 +248,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="35.2" class="nad-vl50to70">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="391.44,257.72 229.49,469.12"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(371.68,283.52)">
+                <polyline class="nad-edge-path" points="391.44,257.72 229.49,469.12"/>
+                <g class="nad-edge-infos" transform="translate(371.68,283.52)">
                     <g class="nad-active">
                         <g transform="rotate(-142.54)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -262,8 +262,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="36">
             <g id="36.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="761.78,-513.40 778.08,-788.68"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(763.71,-545.85)">
+                <polyline class="nad-edge-path" points="761.78,-513.40 778.08,-788.68"/>
+                <g class="nad-edge-infos" transform="translate(763.71,-545.85)">
                     <g class="nad-active">
                         <g transform="rotate(3.39)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -274,8 +274,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="36.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="794.38,-1063.96 778.08,-788.68"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(792.46,-1031.51)">
+                <polyline class="nad-edge-path" points="794.38,-1063.96 778.08,-788.68"/>
+                <g class="nad-edge-infos" transform="translate(792.46,-1031.51)">
                     <g class="nad-active">
                         <g transform="rotate(-176.61)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -288,8 +288,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="37">
             <g id="37.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="23.01,-627.43 378.08,-559.28"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(54.93,-621.30)">
+                <polyline class="nad-edge-path" points="23.01,-627.43 378.08,-559.28"/>
+                <g class="nad-edge-infos" transform="translate(54.93,-621.30)">
                     <g class="nad-active">
                         <g transform="rotate(100.86)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -300,8 +300,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="37.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="733.15,-491.14 378.08,-559.28"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(701.23,-497.26)">
+                <polyline class="nad-edge-path" points="733.15,-491.14 378.08,-559.28"/>
+                <g class="nad-edge-infos" transform="translate(701.23,-497.26)">
                     <g class="nad-active">
                         <g transform="rotate(-79.14)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -314,8 +314,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="38">
             <g id="38.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1289.81,-308.21 1038.02,-392.71"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1259.00,-318.55)">
+                <polyline class="nad-edge-path" points="1289.81,-308.21 1038.02,-392.71"/>
+                <g class="nad-edge-infos" transform="translate(1259.00,-318.55)">
                     <g class="nad-active">
                         <g transform="rotate(-71.45)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -326,8 +326,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="38.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="786.23,-477.20 1038.02,-392.71"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(817.04,-466.86)">
+                <polyline class="nad-edge-path" points="786.23,-477.20 1038.02,-392.71"/>
+                <g class="nad-edge-infos" transform="translate(817.04,-466.86)">
                     <g class="nad-active">
                         <g transform="rotate(108.55)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -340,8 +340,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="39">
             <g id="39.1" class="nad-vl50to70">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="420.22,211.17 571.01,-98.07"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(434.47,181.96)">
+                <polyline class="nad-edge-path" points="420.22,211.17 571.01,-98.07"/>
+                <g class="nad-edge-infos" transform="translate(434.47,181.96)">
                     <g class="nad-active">
                         <g transform="rotate(26.00)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -352,8 +352,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="39.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="748.11,-461.24 597.31,-152.00"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(733.86,-432.02)">
+                <polyline class="nad-edge-path" points="748.11,-461.24 597.31,-152.00"/>
+                <g class="nad-edge-infos" transform="translate(733.86,-432.02)">
                     <g class="nad-active">
                         <g transform="rotate(-154.00)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -363,15 +363,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl50to70 nad-winding" cx="579.78" cy="-116.04" r="20.00"/>
                 <circle class="nad-vl0to30 nad-winding" cx="588.55" cy="-134.02" r="20.00"/>
             </g>
         </g>
         <g id="40">
             <g id="40.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="768.62,-1093.88 568.36,-1111.91"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(736.25,-1096.79)">
+                <polyline class="nad-edge-path" points="768.62,-1093.88 568.36,-1111.91"/>
+                <g class="nad-edge-infos" transform="translate(736.25,-1096.79)">
                     <g class="nad-active">
                         <g transform="rotate(-84.85)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -382,8 +382,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="40.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="368.09,-1129.95 568.36,-1111.91"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(400.46,-1127.03)">
+                <polyline class="nad-edge-path" points="368.09,-1129.95 568.36,-1111.91"/>
+                <g class="nad-edge-infos" transform="translate(400.46,-1127.03)">
                     <g class="nad-active">
                         <g transform="rotate(95.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -396,8 +396,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="41">
             <g id="41.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="313.40,-1129.14 92.25,-1102.62"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(281.13,-1125.27)">
+                <polyline class="nad-edge-path" points="313.40,-1129.14 92.25,-1102.62"/>
+                <g class="nad-edge-infos" transform="translate(281.13,-1125.27)">
                     <g class="nad-active">
                         <g transform="rotate(-96.84)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -408,8 +408,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="41.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-128.90,-1076.11 92.25,-1102.62"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-96.63,-1079.98)">
+                <polyline class="nad-edge-path" points="-128.90,-1076.11 92.25,-1102.62"/>
+                <g class="nad-edge-infos" transform="translate(-96.63,-1079.98)">
                     <g class="nad-active">
                         <g transform="rotate(83.16)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -422,8 +422,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="42">
             <g id="42.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="347.47,-1105.76 429.39,-782.80"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(355.46,-1074.26)">
+                <polyline class="nad-edge-path" points="347.47,-1105.76 429.39,-782.80"/>
+                <g class="nad-edge-infos" transform="translate(355.46,-1074.26)">
                     <g class="nad-active">
                         <g transform="rotate(165.77)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -434,8 +434,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="42.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="511.30,-459.84 429.39,-782.80"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(503.31,-491.34)">
+                <polyline class="nad-edge-path" points="511.30,-459.84 429.39,-782.80"/>
+                <g class="nad-edge-infos" transform="translate(503.31,-491.34)">
                     <g class="nad-active">
                         <g transform="rotate(-14.23)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -448,8 +448,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="43">
             <g id="43.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-147.22,-1046.84 -80.10,-852.72"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-136.60,-1016.13)">
+                <polyline class="nad-edge-path" points="-147.22,-1046.84 -80.10,-852.72"/>
+                <g class="nad-edge-infos" transform="translate(-136.60,-1016.13)">
                     <g class="nad-active">
                         <g transform="rotate(160.93)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -460,8 +460,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="43.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-12.99,-658.60 -80.10,-852.72"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-23.60,-689.31)">
+                <polyline class="nad-edge-path" points="-12.99,-658.60 -80.10,-852.72"/>
+                <g class="nad-edge-infos" transform="translate(-23.60,-689.31)">
                     <g class="nad-active">
                         <g transform="rotate(-19.07)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -474,8 +474,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="44">
             <g id="44.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="540.01,-416.61 801.71,-218.89"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(565.94,-397.02)">
+                <polyline class="nad-edge-path" points="540.01,-416.61 801.71,-218.89"/>
+                <g class="nad-edge-infos" transform="translate(565.94,-397.02)">
                     <g class="nad-active">
                         <g transform="rotate(127.07)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -486,8 +486,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="44.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1063.42,-21.18 801.71,-218.89"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1037.49,-40.77)">
+                <polyline class="nad-edge-path" points="1063.42,-21.18 801.71,-218.89"/>
+                <g class="nad-edge-infos" transform="translate(1037.49,-40.77)">
                     <g class="nad-active">
                         <g transform="rotate(-52.93)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -500,8 +500,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="45">
             <g id="45.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="1102.30,-26.27 1200.62,-152.03"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(1122.32,-51.87)">
+                <polyline class="nad-edge-path" points="1102.30,-26.27 1200.62,-152.03"/>
+                <g class="nad-edge-infos" transform="translate(1122.32,-51.87)">
                     <g class="nad-active">
                         <g transform="rotate(38.02)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -512,8 +512,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="45.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="1298.94,-277.80 1200.62,-152.03"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(1278.92,-252.19)">
+                <polyline class="nad-edge-path" points="1298.94,-277.80 1200.62,-152.03"/>
+                <g class="nad-edge-infos" transform="translate(1278.92,-252.19)">
                     <g class="nad-active">
                         <g transform="rotate(-141.98)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/edge_info_current.svg
+++ b/network-area-diagram/src/test/resources/edge_info_current.svg
@@ -62,8 +62,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="4">
             <desc>l1</desc>
             <g id="4.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-68.26,-296.31 -143.24,-158.76"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-83.82,-267.77)">
+                <polyline class="nad-edge-path" points="-68.26,-296.31 -143.24,-158.76"/>
+                <g class="nad-edge-infos" transform="translate(-83.82,-267.77)">
                     <g class="nad-current nad-state-out">
                         <g transform="rotate(-151.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -74,8 +74,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="4.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-218.22,-21.21 -143.24,-158.76"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-202.66,-49.75)">
+                <polyline class="nad-edge-path" points="-218.22,-21.21 -143.24,-158.76"/>
+                <g class="nad-edge-infos" transform="translate(-202.66,-49.75)">
                     <g class="nad-current nad-state-out">
                         <g transform="rotate(28.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -89,8 +89,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="7" class="nad-dangling-line-edge">
             <desc>dl1</desc>
             <g id="7.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-217.73,23.30 -139.77,159.16"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-201.55,51.49)">
+                <polyline class="nad-edge-path" points="-217.73,23.30 -139.77,159.16"/>
+                <g class="nad-edge-infos" transform="translate(-201.55,51.49)">
                     <g class="nad-current">
                         <g transform="rotate(150.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -101,7 +101,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="7.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-61.81,295.03 -139.77,159.16"/>
+                <polyline class="nad-edge-path" points="-61.81,295.03 -139.77,159.16"/>
             </g>
         </g>
     </g>

--- a/network-area-diagram/src/test/resources/edge_info_double_labels.svg
+++ b/network-area-diagram/src/test/resources/edge_info_double_labels.svg
@@ -58,8 +58,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
     <g class="nad-branch-edges"></g>
     <g class="nad-3wt-edges">
         <g id="7" class="nad-vl0to30">
-            <polyline class="nad-edge-path nad-stretchable" points="68.27,-487.11 -14.91,-159.64"/>
-            <g class="nad-glued-1 nad-edge-infos" transform="translate(52.88,-426.53)">
+            <polyline class="nad-edge-path" points="68.27,-487.11 -14.91,-159.64"/>
+            <g class="nad-edge-infos" transform="translate(52.88,-426.53)">
                 <g class="nad-state-in">
                     <g transform="rotate(-165.75)">
                         <path class="nad-arrow-in" transform="scale(10.00)" d="M-2 -1 H2 L0 1z"/>
@@ -71,8 +71,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
             </g>
         </g>
         <g id="8" class="nad-vl120to180">
-            <polyline class="nad-edge-path nad-stretchable" points="-346.98,35.28 -53.59,-119.94"/>
-            <g class="nad-glued-1 nad-edge-infos" transform="translate(-291.73,6.06)">
+            <polyline class="nad-edge-path" points="-346.98,35.28 -53.59,-119.94"/>
+            <g class="nad-edge-infos" transform="translate(-291.73,6.06)">
                 <g class="nad-state-in">
                     <g transform="rotate(62.12)">
                         <path class="nad-arrow-in" transform="scale(10.00)" d="M-2 -1 H2 L0 1z"/>
@@ -84,8 +84,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
             </g>
         </g>
         <g id="9" class="nad-vl30to50">
-            <polyline class="nad-edge-path nad-stretchable" points="165.92,181.19 0.13,-106.29"/>
-            <g class="nad-glued-1 nad-edge-infos" transform="translate(134.70,127.05)">
+            <polyline class="nad-edge-path" points="165.92,181.19 0.13,-106.29"/>
+            <g class="nad-edge-infos" transform="translate(134.70,127.05)">
                 <g class="nad-state-in">
                     <g transform="rotate(-29.97)">
                         <path class="nad-arrow-in" transform="scale(10.00)" d="M-2 -1 H2 L0 1z"/>

--- a/network-area-diagram/src/test/resources/edge_info_missing_label.svg
+++ b/network-area-diagram/src/test/resources/edge_info_missing_label.svg
@@ -58,8 +58,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
     <g class="nad-branch-edges">
         <g id="4">
             <g id="4.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-69.22,-294.55 -143.24,-158.76"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-75.20,-283.58)">
+                <polyline class="nad-edge-path" points="-69.22,-294.55 -143.24,-158.76"/>
+                <g class="nad-edge-infos" transform="translate(-75.20,-283.58)">
                     <g class="nad-state-out">
                         <g transform="rotate(-151.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-2 -1 H2 L0 1z"/>
@@ -69,8 +69,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="4.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-217.26,-22.97 -143.24,-158.76"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-211.28,-33.94)">
+                <polyline class="nad-edge-path" points="-217.26,-22.97 -143.24,-158.76"/>
+                <g class="nad-edge-infos" transform="translate(-211.28,-33.94)">
                     <g class="nad-state-out">
                         <g transform="rotate(28.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-2 -1 H2 L0 1z"/>
@@ -82,8 +82,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="7" class="nad-dangling-line-edge">
             <g id="7.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-216.73,25.03 -139.77,159.16"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-210.51,35.87)">
+                <polyline class="nad-edge-path" points="-216.73,25.03 -139.77,159.16"/>
+                <g class="nad-edge-infos" transform="translate(-210.51,35.87)">
                     <g class="nad-state-out">
                         <g transform="rotate(150.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-2 -1 H2 L0 1z"/>
@@ -93,8 +93,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="7.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-62.80,293.29 -139.77,159.16"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-69.03,282.45)">
+                <polyline class="nad-edge-path" points="-62.80,293.29 -139.77,159.16"/>
+                <g class="nad-edge-infos" transform="translate(-69.03,282.45)">
                     <g class="nad-state-out">
                         <g transform="rotate(-29.85)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-2 -1 H2 L0 1z"/>

--- a/network-area-diagram/src/test/resources/edge_info_perpendicular_label.svg
+++ b/network-area-diagram/src/test/resources/edge_info_perpendicular_label.svg
@@ -58,8 +58,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
     <g class="nad-branch-edges">
         <g id="4">
             <g id="4.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-69.22,-294.55 -143.24,-158.76"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-94.35,-248.46)">
+                <polyline class="nad-edge-path" points="-69.22,-294.55 -143.24,-158.76"/>
+                <g class="nad-edge-infos" transform="translate(-94.35,-248.46)">
                     <g class="nad-state-out">
                         <g transform="rotate(-151.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-2 -1 H2 L0 1z"/>
@@ -71,8 +71,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="4.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-217.26,-22.97 -143.24,-158.76"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-192.13,-69.06)">
+                <polyline class="nad-edge-path" points="-217.26,-22.97 -143.24,-158.76"/>
+                <g class="nad-edge-infos" transform="translate(-192.13,-69.06)">
                     <g class="nad-state-out">
                         <g transform="rotate(28.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-2 -1 H2 L0 1z"/>
@@ -86,8 +86,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="7" class="nad-dangling-line-edge">
             <g id="7.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-216.73,25.03 -139.77,159.16"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-190.61,70.57)">
+                <polyline class="nad-edge-path" points="-216.73,25.03 -139.77,159.16"/>
+                <g class="nad-edge-infos" transform="translate(-190.61,70.57)">
                     <g class="nad-state-out">
                         <g transform="rotate(150.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-2 -1 H2 L0 1z"/>
@@ -99,8 +99,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="7.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-62.80,293.29 -139.77,159.16"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-88.93,247.76)">
+                <polyline class="nad-edge-path" points="-62.80,293.29 -139.77,159.16"/>
+                <g class="nad-edge-infos" transform="translate(-88.93,247.76)">
                     <g class="nad-state-out">
                         <g transform="rotate(-29.85)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-2 -1 H2 L0 1z"/>

--- a/network-area-diagram/src/test/resources/edge_info_reactive_power.svg
+++ b/network-area-diagram/src/test/resources/edge_info_reactive_power.svg
@@ -62,8 +62,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="4">
             <desc>l1</desc>
             <g id="4.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-68.26,-296.31 -143.24,-158.76"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-83.82,-267.77)">
+                <polyline class="nad-edge-path" points="-68.26,-296.31 -143.24,-158.76"/>
+                <g class="nad-edge-infos" transform="translate(-83.82,-267.77)">
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-151.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -74,8 +74,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="4.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-218.22,-21.21 -143.24,-158.76"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-202.66,-49.75)">
+                <polyline class="nad-edge-path" points="-218.22,-21.21 -143.24,-158.76"/>
+                <g class="nad-edge-infos" transform="translate(-202.66,-49.75)">
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(28.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -89,8 +89,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="7" class="nad-dangling-line-edge">
             <desc>dl1</desc>
             <g id="7.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-217.73,23.30 -139.77,159.16"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-201.55,51.49)">
+                <polyline class="nad-edge-path" points="-217.73,23.30 -139.77,159.16"/>
+                <g class="nad-edge-infos" transform="translate(-201.55,51.49)">
                     <g class="nad-reactive">
                         <g transform="rotate(150.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -101,7 +101,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="7.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-61.81,295.03 -139.77,159.16"/>
+                <polyline class="nad-edge-path" points="-61.81,295.03 -139.77,159.16"/>
             </g>
         </g>
     </g>

--- a/network-area-diagram/src/test/resources/edge_info_shift.svg
+++ b/network-area-diagram/src/test/resources/edge_info_shift.svg
@@ -63,8 +63,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
     <g class="nad-branch-edges">
         <g id="8">
             <g id="8.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-107.19,-205.38 -158.52,-194.37 -199.91,-156.95"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-173.36,-180.95)">
+                <polyline class="nad-edge-path" points="-107.19,-205.38 -158.52,-194.37 -199.91,-156.95"/>
+                <g class="nad-edge-infos" transform="translate(-173.36,-180.95)">
                     <g class="nad-active">
                         <g transform="rotate(-132.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -75,8 +75,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="8.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-257.43,-69.57 -241.30,-119.53 -199.91,-156.95"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-226.47,-132.95)">
+                <polyline class="nad-edge-path" points="-257.43,-69.57 -241.30,-119.53 -199.91,-156.95"/>
+                <g class="nad-edge-infos" transform="translate(-226.47,-132.95)">
                     <g class="nad-active">
                         <g transform="rotate(47.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -89,8 +89,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="9">
             <g id="9.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-97.96,-156.43 -104.87,-135.02 -146.26,-97.60"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-119.71,-121.61)">
+                <polyline class="nad-edge-path" points="-97.96,-156.43 -104.87,-135.02 -146.26,-97.60"/>
+                <g class="nad-edge-infos" transform="translate(-119.71,-121.61)">
                     <g class="nad-active">
                         <g transform="rotate(-132.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -101,8 +101,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="9.2" class="nad-disconnected nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-238.99,-49.17 -187.65,-60.19 -146.26,-97.60"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-172.82,-73.60)">
+                <polyline class="nad-edge-path" points="-238.99,-49.17 -187.65,-60.19 -146.26,-97.60"/>
+                <g class="nad-edge-infos" transform="translate(-172.82,-73.60)">
                     <g class="nad-active">
                         <g transform="rotate(47.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -115,8 +115,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="10">
             <g id="10.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-71.33,-154.36 -52.41,-34.52"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-67.82,-132.13)">
+                <polyline class="nad-edge-path" points="-71.33,-154.36 -52.41,-34.52"/>
+                <g class="nad-edge-infos" transform="translate(-67.82,-132.13)">
                     <g class="nad-active">
                         <g transform="rotate(171.03)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -127,8 +127,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="10.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-24.12,144.59 -43.05,24.75"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-32.31,92.73)">
+                <polyline class="nad-edge-path" points="-24.12,144.59 -43.05,24.75"/>
+                <g class="nad-edge-infos" transform="translate(-32.31,92.73)">
                     <g class="nad-active">
                         <g transform="rotate(-8.97)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -138,15 +138,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500 nad-winding" cx="-49.29" cy="-14.76" r="20.00"/>
                 <circle class="nad-vl180to300 nad-winding" cx="-46.17" cy="4.99" r="20.00"/>
             </g>
         </g>
         <g id="11">
             <g id="11.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-245.17,-25.30 -176.73,34.55"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-228.23,-10.49)">
+                <polyline class="nad-edge-path" points="-245.17,-25.30 -176.73,34.55"/>
+                <g class="nad-edge-infos" transform="translate(-228.23,-10.49)">
                     <g class="nad-active">
                         <g transform="rotate(131.17)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -157,8 +157,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="11.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-63.12,133.90 -131.56,74.05"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-80.06,119.09)">
+                <polyline class="nad-edge-path" points="-63.12,133.90 -131.56,74.05"/>
+                <g class="nad-edge-infos" transform="translate(-80.06,119.09)">
                     <g class="nad-active">
                         <g transform="rotate(-48.83)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -168,15 +168,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500 nad-winding" cx="-161.67" cy="47.72" r="20.00"/>
                 <circle class="nad-vl180to300 nad-winding" cx="-146.62" cy="60.88" r="20.00"/>
             </g>
         </g>
         <g id="14" class="nad-dangling-line-edge">
             <g id="14.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-242.83,-58.42 -27.76,-198.60"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-223.98,-70.70)">
+                <polyline class="nad-edge-path" points="-242.83,-58.42 -27.76,-198.60"/>
+                <g class="nad-edge-infos" transform="translate(-223.98,-70.70)">
                     <g class="nad-active">
                         <g transform="rotate(56.90)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -187,7 +187,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="14.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="187.32,-338.78 -27.76,-198.60"/>
+                <polyline class="nad-edge-path" points="187.32,-338.78 -27.76,-198.60"/>
             </g>
         </g>
     </g>

--- a/network-area-diagram/src/test/resources/edge_with_id.svg
+++ b/network-area-diagram/src/test/resources/edge_with_id.svg
@@ -63,8 +63,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
     <g class="nad-branch-edges">
         <g id="8">
             <g id="8.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-107.19,-205.38 -158.52,-194.37 -199.91,-156.95"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-180.78,-174.25)">
+                <polyline class="nad-edge-path" points="-107.19,-205.38 -158.52,-194.37 -199.91,-156.95"/>
+                <g class="nad-edge-infos" transform="translate(-180.78,-174.25)">
                     <g class="nad-active">
                         <g transform="rotate(-132.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -75,8 +75,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="8.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-257.43,-69.57 -241.30,-119.53 -199.91,-156.95"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-219.05,-139.65)">
+                <polyline class="nad-edge-path" points="-257.43,-69.57 -241.30,-119.53 -199.91,-156.95"/>
+                <g class="nad-edge-infos" transform="translate(-219.05,-139.65)">
                     <g class="nad-active">
                         <g transform="rotate(47.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -86,7 +86,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <g class="nad-edge-label" transform="translate(-199.91,-156.95)">
                     <text transform="rotate(-42.11)" x="0.00" style="text-anchor:middle">l1</text>
                 </g>
@@ -94,8 +94,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="9">
             <g id="9.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-97.96,-156.43 -104.87,-135.02 -146.26,-97.60"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-127.13,-114.90)">
+                <polyline class="nad-edge-path" points="-97.96,-156.43 -104.87,-135.02 -146.26,-97.60"/>
+                <g class="nad-edge-infos" transform="translate(-127.13,-114.90)">
                     <g class="nad-active">
                         <g transform="rotate(-132.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -106,8 +106,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="9.2" class="nad-disconnected nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-238.99,-49.17 -187.65,-60.19 -146.26,-97.60"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-165.40,-80.31)">
+                <polyline class="nad-edge-path" points="-238.99,-49.17 -187.65,-60.19 -146.26,-97.60"/>
+                <g class="nad-edge-infos" transform="translate(-165.40,-80.31)">
                     <g class="nad-active">
                         <g transform="rotate(47.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -117,7 +117,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <g class="nad-edge-label" transform="translate(-146.26,-97.60)">
                     <text transform="rotate(-42.11)" x="0.00" style="text-anchor:middle">l2</text>
                 </g>
@@ -125,8 +125,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="10">
             <g id="10.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-71.33,-154.36 -52.41,-34.52"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-66.26,-122.26)">
+                <polyline class="nad-edge-path" points="-71.33,-154.36 -52.41,-34.52"/>
+                <g class="nad-edge-infos" transform="translate(-66.26,-122.26)">
                     <g class="nad-active">
                         <g transform="rotate(171.03)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -137,8 +137,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="10.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-24.12,144.59 -43.05,24.75"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-33.87,82.85)">
+                <polyline class="nad-edge-path" points="-24.12,144.59 -43.05,24.75"/>
+                <g class="nad-edge-infos" transform="translate(-33.87,82.85)">
                     <g class="nad-active">
                         <g transform="rotate(-8.97)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -148,7 +148,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500 nad-winding" cx="-49.29" cy="-14.76" r="20.00"/>
                 <circle class="nad-vl180to300 nad-winding" cx="-46.17" cy="4.99" r="20.00"/>
                 <g class="nad-edge-label" transform="translate(-47.73,-4.88)">
@@ -158,8 +158,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="11">
             <g id="11.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-245.17,-25.30 -176.73,34.55"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-220.71,-3.90)">
+                <polyline class="nad-edge-path" points="-245.17,-25.30 -176.73,34.55"/>
+                <g class="nad-edge-infos" transform="translate(-220.71,-3.90)">
                     <g class="nad-active">
                         <g transform="rotate(131.17)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -170,8 +170,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="11.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-63.12,133.90 -131.56,74.05"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-87.58,112.51)">
+                <polyline class="nad-edge-path" points="-63.12,133.90 -131.56,74.05"/>
+                <g class="nad-edge-infos" transform="translate(-87.58,112.51)">
                     <g class="nad-active">
                         <g transform="rotate(-48.83)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -181,7 +181,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500 nad-winding" cx="-161.67" cy="47.72" r="20.00"/>
                 <circle class="nad-vl180to300 nad-winding" cx="-146.62" cy="60.88" r="20.00"/>
                 <g class="nad-edge-label" transform="translate(-154.14,54.30)">
@@ -191,8 +191,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="14" class="nad-dangling-line-edge">
             <g id="14.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-242.83,-58.42 -27.76,-198.60"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-215.61,-76.16)">
+                <polyline class="nad-edge-path" points="-242.83,-58.42 -27.76,-198.60"/>
+                <g class="nad-edge-infos" transform="translate(-215.61,-76.16)">
                     <g class="nad-active">
                         <g transform="rotate(56.90)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -203,7 +203,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="14.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="187.32,-338.78 -27.76,-198.60"/>
+                <polyline class="nad-edge-path" points="187.32,-338.78 -27.76,-198.60"/>
             </g>
         </g>
     </g>

--- a/network-area-diagram/src/test/resources/edge_without_id.svg
+++ b/network-area-diagram/src/test/resources/edge_without_id.svg
@@ -63,8 +63,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
     <g class="nad-branch-edges">
         <g id="8">
             <g id="8.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-107.19,-205.38 -158.52,-194.37 -199.91,-156.95"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-180.78,-174.25)">
+                <polyline class="nad-edge-path" points="-107.19,-205.38 -158.52,-194.37 -199.91,-156.95"/>
+                <g class="nad-edge-infos" transform="translate(-180.78,-174.25)">
                     <g class="nad-active">
                         <g transform="rotate(-132.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -75,8 +75,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="8.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-257.43,-69.57 -241.30,-119.53 -199.91,-156.95"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-219.05,-139.65)">
+                <polyline class="nad-edge-path" points="-257.43,-69.57 -241.30,-119.53 -199.91,-156.95"/>
+                <g class="nad-edge-infos" transform="translate(-219.05,-139.65)">
                     <g class="nad-active">
                         <g transform="rotate(47.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -89,8 +89,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="9">
             <g id="9.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-97.96,-156.43 -104.87,-135.02 -146.26,-97.60"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-127.13,-114.90)">
+                <polyline class="nad-edge-path" points="-97.96,-156.43 -104.87,-135.02 -146.26,-97.60"/>
+                <g class="nad-edge-infos" transform="translate(-127.13,-114.90)">
                     <g class="nad-active">
                         <g transform="rotate(-132.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -101,8 +101,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="9.2" class="nad-disconnected nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-238.99,-49.17 -187.65,-60.19 -146.26,-97.60"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-165.40,-80.31)">
+                <polyline class="nad-edge-path" points="-238.99,-49.17 -187.65,-60.19 -146.26,-97.60"/>
+                <g class="nad-edge-infos" transform="translate(-165.40,-80.31)">
                     <g class="nad-active">
                         <g transform="rotate(47.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -115,8 +115,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="10">
             <g id="10.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-71.33,-154.36 -52.41,-34.52"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-66.26,-122.26)">
+                <polyline class="nad-edge-path" points="-71.33,-154.36 -52.41,-34.52"/>
+                <g class="nad-edge-infos" transform="translate(-66.26,-122.26)">
                     <g class="nad-active">
                         <g transform="rotate(171.03)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -127,8 +127,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="10.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-24.12,144.59 -43.05,24.75"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-33.87,82.85)">
+                <polyline class="nad-edge-path" points="-24.12,144.59 -43.05,24.75"/>
+                <g class="nad-edge-infos" transform="translate(-33.87,82.85)">
                     <g class="nad-active">
                         <g transform="rotate(-8.97)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -138,15 +138,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500 nad-winding" cx="-49.29" cy="-14.76" r="20.00"/>
                 <circle class="nad-vl180to300 nad-winding" cx="-46.17" cy="4.99" r="20.00"/>
             </g>
         </g>
         <g id="11">
             <g id="11.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-245.17,-25.30 -176.73,34.55"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-220.71,-3.90)">
+                <polyline class="nad-edge-path" points="-245.17,-25.30 -176.73,34.55"/>
+                <g class="nad-edge-infos" transform="translate(-220.71,-3.90)">
                     <g class="nad-active">
                         <g transform="rotate(131.17)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -157,8 +157,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="11.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-63.12,133.90 -131.56,74.05"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-87.58,112.51)">
+                <polyline class="nad-edge-path" points="-63.12,133.90 -131.56,74.05"/>
+                <g class="nad-edge-infos" transform="translate(-87.58,112.51)">
                     <g class="nad-active">
                         <g transform="rotate(-48.83)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -168,15 +168,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500 nad-winding" cx="-161.67" cy="47.72" r="20.00"/>
                 <circle class="nad-vl180to300 nad-winding" cx="-146.62" cy="60.88" r="20.00"/>
             </g>
         </g>
         <g id="14" class="nad-dangling-line-edge">
             <g id="14.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-242.83,-58.42 -27.76,-198.60"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-215.61,-76.16)">
+                <polyline class="nad-edge-path" points="-242.83,-58.42 -27.76,-198.60"/>
+                <g class="nad-edge-infos" transform="translate(-215.61,-76.16)">
                     <g class="nad-active">
                         <g transform="rotate(56.90)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -187,7 +187,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="14.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="187.32,-338.78 -27.76,-198.60"/>
+                <polyline class="nad-edge-path" points="187.32,-338.78 -27.76,-198.60"/>
             </g>
         </g>
     </g>

--- a/network-area-diagram/src/test/resources/hvdc-vl-depth-1.svg
+++ b/network-area-diagram/src/test/resources/hvdc-vl-depth-1.svg
@@ -58,8 +58,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="4" class="nad-hvdc-edge">
             <desc>HVDC</desc>
             <g id="4.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="39.05,-165.52 -67.41,-53.73"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(16.64,-141.99)">
+                <polyline class="nad-edge-path" points="39.05,-165.52 -67.41,-53.73"/>
+                <g class="nad-edge-infos" transform="translate(16.64,-141.99)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-136.40)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -70,8 +70,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="4.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-173.88,58.06 -67.41,-53.73"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-151.46,34.53)">
+                <polyline class="nad-edge-path" points="-173.88,58.06 -67.41,-53.73"/>
+                <g class="nad-edge-infos" transform="translate(-151.46,34.53)">
                     <g class="nad-active">
                         <g transform="rotate(43.60)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -81,7 +81,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <polyline points="-43.28,-79.07 -91.55,-28.38" class="nad-hvdc"/>
             </g>
         </g>

--- a/network-area-diagram/src/test/resources/hvdc.svg
+++ b/network-area-diagram/src/test/resources/hvdc.svg
@@ -70,8 +70,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="10">
             <desc>TWT</desc>
             <g id="10.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-215.92,-490.04 -191.64,-354.01"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-210.21,-458.05)">
+                <polyline class="nad-edge-path" points="-215.92,-490.04 -191.64,-354.01"/>
+                <g class="nad-edge-infos" transform="translate(-210.21,-458.05)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(169.88)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -82,8 +82,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="10.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-156.82,-158.90 -181.10,-294.94"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-162.53,-190.90)">
+                <polyline class="nad-edge-path" points="-156.82,-158.90 -181.10,-294.94"/>
+                <g class="nad-edge-infos" transform="translate(-162.53,-190.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-10.12)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -93,7 +93,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl180to300 nad-winding" cx="-188.13" cy="-334.32" r="20.00"/>
                 <circle class="nad-vl300to500 nad-winding" cx="-184.62" cy="-314.63" r="20.00"/>
                 <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(0.18,0.98,-0.98,0.18,-162.11,-359.28)" class="nad-pst-arrow"/>
@@ -102,8 +102,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="11" class="nad-hvdc-edge">
             <desc>HVDC1</desc>
             <g id="11.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-153.08,-108.31 -157.64,48.86"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-154.02,-75.83)">
+                <polyline class="nad-edge-path" points="-153.08,-108.31 -157.64,48.86"/>
+                <g class="nad-edge-infos" transform="translate(-154.02,-75.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-178.34)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -114,8 +114,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="11.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-162.19,206.02 -157.64,48.86"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-161.25,173.54)">
+                <polyline class="nad-edge-path" points="-162.19,206.02 -157.64,48.86"/>
+                <g class="nad-edge-infos" transform="translate(-161.25,173.54)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(1.66)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -125,15 +125,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <polyline points="-156.62,13.87 -158.65,83.84" class="nad-hvdc"/>
             </g>
         </g>
         <g id="12" class="nad-hvdc-edge">
             <desc>HVDC2</desc>
             <g id="12.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-131.42,-119.22 9.40,-21.06"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-104.76,-100.63)">
+                <polyline class="nad-edge-path" points="-131.42,-119.22 9.40,-21.06"/>
+                <g class="nad-edge-infos" transform="translate(-104.76,-100.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(124.88)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -144,8 +144,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="12.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="150.21,77.11 9.40,-21.06"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(123.55,58.52)">
+                <polyline class="nad-edge-path" points="150.21,77.11 9.40,-21.06"/>
+                <g class="nad-edge-infos" transform="translate(123.55,58.52)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-55.12)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -155,15 +155,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <polyline points="-19.32,-41.07 38.11,-1.04" class="nad-hvdc"/>
             </g>
         </g>
         <g id="13">
             <desc>LINE_S2S3</desc>
             <g id="13.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-139.41,221.67 4.10,161.60"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-109.43,209.12)">
+                <polyline class="nad-edge-path" points="-139.41,221.67 4.10,161.60"/>
+                <g class="nad-edge-infos" transform="translate(-109.43,209.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(67.29)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -174,8 +174,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="13.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="147.61,101.53 4.10,161.60"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(117.63,114.08)">
+                <polyline class="nad-edge-path" points="147.61,101.53 4.10,161.60"/>
+                <g class="nad-edge-infos" transform="translate(117.63,114.08)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-112.71)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -189,8 +189,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="14">
             <desc>LINE_S3S4</desc>
             <g id="14.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="192.56,105.52 334.24,197.00"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(219.86,123.15)">
+                <polyline class="nad-edge-path" points="192.56,105.52 334.24,197.00"/>
+                <g class="nad-edge-infos" transform="translate(219.86,123.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(122.85)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -201,8 +201,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="14.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="475.92,288.48 334.24,197.00"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(448.62,270.85)">
+                <polyline class="nad-edge-path" points="475.92,288.48 334.24,197.00"/>
+                <g class="nad-edge-infos" transform="translate(448.62,270.85)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-57.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/parallel_transformers.svg
+++ b/network-area-diagram/src/test/resources/parallel_transformers.svg
@@ -59,8 +59,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
     <g class="nad-branch-edges">
         <g id="5">
             <g id="5.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-79.53,-304.37 -124.34,-277.01 -164.00,-204.24"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-138.70,-250.67)">
+                <polyline class="nad-edge-path" points="-79.53,-304.37 -124.34,-277.01 -164.00,-204.24"/>
+                <g class="nad-edge-infos" transform="translate(-138.70,-250.67)">
                     <g class="nad-active">
                         <g transform="rotate(-151.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -71,8 +71,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="5.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-231.10,-26.31 -232.38,-78.80 -192.72,-151.56"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-218.03,-105.14)">
+                <polyline class="nad-edge-path" points="-231.10,-26.31 -232.38,-78.80 -192.72,-151.56"/>
+                <g class="nad-edge-infos" transform="translate(-218.03,-105.14)">
                     <g class="nad-active">
                         <g transform="rotate(28.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -82,15 +82,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500 nad-winding" cx="-173.58" cy="-186.68" r="20.00"/>
                 <circle class="nad-vl180to300 nad-winding" cx="-183.15" cy="-169.12" r="20.00"/>
             </g>
         </g>
         <g id="6">
             <g id="6.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-54.65,-261.22 -54.10,-238.72 -93.76,-165.96"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-68.45,-212.38)">
+                <polyline class="nad-edge-path" points="-54.65,-261.22 -54.10,-238.72 -93.76,-165.96"/>
+                <g class="nad-edge-infos" transform="translate(-68.45,-212.38)">
                     <g class="nad-active">
                         <g transform="rotate(-151.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -101,8 +101,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="6.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-206.95,-13.15 -162.14,-40.51 -122.48,-113.27"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-147.78,-66.85)">
+                <polyline class="nad-edge-path" points="-206.95,-13.15 -162.14,-40.51 -122.48,-113.27"/>
+                <g class="nad-edge-infos" transform="translate(-147.78,-66.85)">
                     <g class="nad-active">
                         <g transform="rotate(28.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -112,15 +112,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500 nad-winding" cx="-103.33" cy="-148.40" r="20.00"/>
                 <circle class="nad-vl180to300 nad-winding" cx="-112.90" cy="-130.84" r="20.00"/>
             </g>
         </g>
         <g id="9" class="nad-dangling-line-edge">
             <g id="9.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-216.73,25.03 -139.77,159.16"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-200.56,53.22)">
+                <polyline class="nad-edge-path" points="-216.73,25.03 -139.77,159.16"/>
+                <g class="nad-edge-infos" transform="translate(-200.56,53.22)">
                     <g class="nad-active">
                         <g transform="rotate(150.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -131,7 +131,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="9.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-62.80,293.29 -139.77,159.16"/>
+                <polyline class="nad-edge-path" points="-62.80,293.29 -139.77,159.16"/>
             </g>
         </g>
     </g>

--- a/network-area-diagram/src/test/resources/production_consumption_text_node.svg
+++ b/network-area-diagram/src/test/resources/production_consumption_text_node.svg
@@ -128,8 +128,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
     <g class="nad-branch-edges">
         <g id="8">
             <g id="8.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-107.19,-205.38 -158.52,-194.37 -199.91,-156.95"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-180.78,-174.25)">
+                <polyline class="nad-edge-path" points="-107.19,-205.38 -158.52,-194.37 -199.91,-156.95"/>
+                <g class="nad-edge-infos" transform="translate(-180.78,-174.25)">
                     <g class="nad-active">
                         <g transform="rotate(-132.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -140,8 +140,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="8.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-257.43,-69.57 -241.30,-119.53 -199.91,-156.95"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-219.05,-139.65)">
+                <polyline class="nad-edge-path" points="-257.43,-69.57 -241.30,-119.53 -199.91,-156.95"/>
+                <g class="nad-edge-infos" transform="translate(-219.05,-139.65)">
                     <g class="nad-active">
                         <g transform="rotate(47.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -154,8 +154,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="9">
             <g id="9.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-97.96,-156.43 -104.87,-135.02 -146.26,-97.60"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-127.13,-114.90)">
+                <polyline class="nad-edge-path" points="-97.96,-156.43 -104.87,-135.02 -146.26,-97.60"/>
+                <g class="nad-edge-infos" transform="translate(-127.13,-114.90)">
                     <g class="nad-active">
                         <g transform="rotate(-132.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -166,8 +166,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="9.2" class="nad-disconnected nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-238.99,-49.17 -187.65,-60.19 -146.26,-97.60"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-165.40,-80.31)">
+                <polyline class="nad-edge-path" points="-238.99,-49.17 -187.65,-60.19 -146.26,-97.60"/>
+                <g class="nad-edge-infos" transform="translate(-165.40,-80.31)">
                     <g class="nad-active">
                         <g transform="rotate(47.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -180,8 +180,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="10">
             <g id="10.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-71.33,-154.36 -52.41,-34.52"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-66.26,-122.26)">
+                <polyline class="nad-edge-path" points="-71.33,-154.36 -52.41,-34.52"/>
+                <g class="nad-edge-infos" transform="translate(-66.26,-122.26)">
                     <g class="nad-active">
                         <g transform="rotate(171.03)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -192,8 +192,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="10.2" class="nad-vl180to300-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-24.12,144.59 -43.05,24.75"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-33.87,82.85)">
+                <polyline class="nad-edge-path" points="-24.12,144.59 -43.05,24.75"/>
+                <g class="nad-edge-infos" transform="translate(-33.87,82.85)">
                     <g class="nad-active">
                         <g transform="rotate(-8.97)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -203,15 +203,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500-line nad-winding" cx="-49.29" cy="-14.76" r="20.00"/>
                 <circle class="nad-vl180to300-line nad-winding" cx="-46.17" cy="4.99" r="20.00"/>
             </g>
         </g>
         <g id="11">
             <g id="11.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-245.17,-25.30 -176.73,34.55"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-220.71,-3.90)">
+                <polyline class="nad-edge-path" points="-245.17,-25.30 -176.73,34.55"/>
+                <g class="nad-edge-infos" transform="translate(-220.71,-3.90)">
                     <g class="nad-active">
                         <g transform="rotate(131.17)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -222,8 +222,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="11.2" class="nad-vl180to300-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-63.12,133.90 -131.56,74.05"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-87.58,112.51)">
+                <polyline class="nad-edge-path" points="-63.12,133.90 -131.56,74.05"/>
+                <g class="nad-edge-infos" transform="translate(-87.58,112.51)">
                     <g class="nad-active">
                         <g transform="rotate(-48.83)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -233,15 +233,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500-line nad-winding" cx="-161.67" cy="47.72" r="20.00"/>
                 <circle class="nad-vl180to300-line nad-winding" cx="-146.62" cy="60.88" r="20.00"/>
             </g>
         </g>
         <g id="14" class="nad-dangling-line-edge">
             <g id="14.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-242.83,-58.42 -27.76,-198.60"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-215.61,-76.16)">
+                <polyline class="nad-edge-path" points="-242.83,-58.42 -27.76,-198.60"/>
+                <g class="nad-edge-infos" transform="translate(-215.61,-76.16)">
                     <g class="nad-active">
                         <g transform="rotate(56.90)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -252,7 +252,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="14.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="187.32,-338.78 -27.76,-198.60"/>
+                <polyline class="nad-edge-path" points="187.32,-338.78 -27.76,-198.60"/>
             </g>
         </g>
     </g>

--- a/network-area-diagram/src/test/resources/production_consumption_text_node_nan.svg
+++ b/network-area-diagram/src/test/resources/production_consumption_text_node_nan.svg
@@ -128,8 +128,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
     <g class="nad-branch-edges">
         <g id="8">
             <g id="8.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-107.19,-205.38 -158.52,-194.37 -199.91,-156.95"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-180.78,-174.25)">
+                <polyline class="nad-edge-path" points="-107.19,-205.38 -158.52,-194.37 -199.91,-156.95"/>
+                <g class="nad-edge-infos" transform="translate(-180.78,-174.25)">
                     <g class="nad-active">
                         <g transform="rotate(-132.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -140,8 +140,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="8.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-257.43,-69.57 -241.30,-119.53 -199.91,-156.95"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-219.05,-139.65)">
+                <polyline class="nad-edge-path" points="-257.43,-69.57 -241.30,-119.53 -199.91,-156.95"/>
+                <g class="nad-edge-infos" transform="translate(-219.05,-139.65)">
                     <g class="nad-active">
                         <g transform="rotate(47.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -154,8 +154,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="9">
             <g id="9.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-97.96,-156.43 -104.87,-135.02 -146.26,-97.60"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-127.13,-114.90)">
+                <polyline class="nad-edge-path" points="-97.96,-156.43 -104.87,-135.02 -146.26,-97.60"/>
+                <g class="nad-edge-infos" transform="translate(-127.13,-114.90)">
                     <g class="nad-active">
                         <g transform="rotate(-132.11)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -166,8 +166,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="9.2" class="nad-disconnected nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-238.99,-49.17 -187.65,-60.19 -146.26,-97.60"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-165.40,-80.31)">
+                <polyline class="nad-edge-path" points="-238.99,-49.17 -187.65,-60.19 -146.26,-97.60"/>
+                <g class="nad-edge-infos" transform="translate(-165.40,-80.31)">
                     <g class="nad-active">
                         <g transform="rotate(47.89)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -180,8 +180,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="10">
             <g id="10.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-71.33,-154.36 -52.41,-34.52"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-66.26,-122.26)">
+                <polyline class="nad-edge-path" points="-71.33,-154.36 -52.41,-34.52"/>
+                <g class="nad-edge-infos" transform="translate(-66.26,-122.26)">
                     <g class="nad-active">
                         <g transform="rotate(171.03)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -192,8 +192,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="10.2" class="nad-vl180to300-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-24.12,144.59 -43.05,24.75"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-33.87,82.85)">
+                <polyline class="nad-edge-path" points="-24.12,144.59 -43.05,24.75"/>
+                <g class="nad-edge-infos" transform="translate(-33.87,82.85)">
                     <g class="nad-active">
                         <g transform="rotate(-8.97)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -203,15 +203,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500-line nad-winding" cx="-49.29" cy="-14.76" r="20.00"/>
                 <circle class="nad-vl180to300-line nad-winding" cx="-46.17" cy="4.99" r="20.00"/>
             </g>
         </g>
         <g id="11">
             <g id="11.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-245.17,-25.30 -176.73,34.55"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-220.71,-3.90)">
+                <polyline class="nad-edge-path" points="-245.17,-25.30 -176.73,34.55"/>
+                <g class="nad-edge-infos" transform="translate(-220.71,-3.90)">
                     <g class="nad-active">
                         <g transform="rotate(131.17)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -222,8 +222,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="11.2" class="nad-vl180to300-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-63.12,133.90 -131.56,74.05"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-87.58,112.51)">
+                <polyline class="nad-edge-path" points="-63.12,133.90 -131.56,74.05"/>
+                <g class="nad-edge-infos" transform="translate(-87.58,112.51)">
                     <g class="nad-active">
                         <g transform="rotate(-48.83)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -233,15 +233,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500-line nad-winding" cx="-161.67" cy="47.72" r="20.00"/>
                 <circle class="nad-vl180to300-line nad-winding" cx="-146.62" cy="60.88" r="20.00"/>
             </g>
         </g>
         <g id="14" class="nad-dangling-line-edge">
             <g id="14.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-242.83,-58.42 -27.76,-198.60"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-215.61,-76.16)">
+                <polyline class="nad-edge-path" points="-242.83,-58.42 -27.76,-198.60"/>
+                <g class="nad-edge-infos" transform="translate(-215.61,-76.16)">
                     <g class="nad-active">
                         <g transform="rotate(56.90)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -252,7 +252,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="14.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="187.32,-338.78 -27.76,-198.60"/>
+                <polyline class="nad-edge-path" points="187.32,-338.78 -27.76,-198.60"/>
             </g>
         </g>
     </g>

--- a/network-area-diagram/src/test/resources/simple-eu-loop100.svg
+++ b/network-area-diagram/src/test/resources/simple-eu-loop100.svg
@@ -157,8 +157,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="22">
             <desc>BBE1AA1  BBE2AA1  1</desc>
             <g id="22.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-338.35,-446.77 -380.56,-415.55 -443.79,-270.18"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-392.53,-388.04)">
+                <polyline class="nad-edge-path" points="-338.35,-446.77 -380.56,-415.55 -443.79,-270.18"/>
+                <g class="nad-edge-infos" transform="translate(-392.53,-388.04)">
                     <g class="nad-active">
                         <g transform="rotate(-156.49)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -169,8 +169,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="22.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-501.07,-72.65 -507.01,-124.81 -443.79,-270.18"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-495.05,-152.32)">
+                <polyline class="nad-edge-path" points="-501.07,-72.65 -507.01,-124.81 -443.79,-270.18"/>
+                <g class="nad-edge-infos" transform="translate(-495.05,-152.32)">
                     <g class="nad-active">
                         <g transform="rotate(23.51)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -211,8 +211,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="24">
             <desc>BBE2AA1  BBE3AA1  1</desc>
             <g id="24.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-475.85,-61.68 -433.65,-92.90 -370.42,-238.27"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-421.68,-120.41)">
+                <polyline class="nad-edge-path" points="-475.85,-61.68 -433.65,-92.90 -370.42,-238.27"/>
+                <g class="nad-edge-infos" transform="translate(-421.68,-120.41)">
                     <g class="nad-active">
                         <g transform="rotate(23.51)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -223,8 +223,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="24.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-309.74,-405.99 -307.20,-383.64 -370.42,-238.27"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-319.16,-356.13)">
+                <polyline class="nad-edge-path" points="-309.74,-405.99 -307.20,-383.64 -370.42,-238.27"/>
+                <g class="nad-edge-infos" transform="translate(-319.16,-356.13)">
                     <g class="nad-active">
                         <g transform="rotate(-156.49)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -238,8 +238,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="25">
             <desc>NNL2AA1  BBE3AA1  1</desc>
             <g id="25.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="82.27,-639.85 -90.71,-563.14"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(52.56,-626.68)">
+                <polyline class="nad-edge-path" points="82.27,-639.85 -90.71,-563.14"/>
+                <g class="nad-edge-infos" transform="translate(52.56,-626.68)">
                     <g class="nad-active">
                         <g transform="rotate(-113.92)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -250,8 +250,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="25.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-263.68,-486.43 -90.71,-563.14"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-233.97,-499.61)">
+                <polyline class="nad-edge-path" points="-263.68,-486.43 -90.71,-563.14"/>
+                <g class="nad-edge-infos" transform="translate(-233.97,-499.61)">
                     <g class="nad-active">
                         <g transform="rotate(66.08)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -288,7 +288,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500-line nad-winding" cx="-247.23" cy="-364.45" r="20.00"/>
                 <circle class="nad-vl300to500-line nad-winding" cx="-264.52" cy="-354.39" r="20.00"/>
                 <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(-0.86,0.50,-0.50,-0.86,-214.86,-348.58)" class="nad-pst-arrow"/>
@@ -297,8 +297,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="27">
             <desc>BBE2AA1  FFR3AA1  1</desc>
             <g id="27.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-493.07,-18.26 -457.16,180.45"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-487.29,13.72)">
+                <polyline class="nad-edge-path" points="-493.07,-18.26 -457.16,180.45"/>
+                <g class="nad-edge-infos" transform="translate(-487.29,13.72)">
                     <g class="nad-active">
                         <g transform="rotate(169.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -309,8 +309,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="27.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-421.24,379.16 -457.16,180.45"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-427.02,347.17)">
+                <polyline class="nad-edge-path" points="-421.24,379.16 -457.16,180.45"/>
+                <g class="nad-edge-infos" transform="translate(-427.02,347.17)">
                     <g class="nad-active">
                         <g transform="rotate(-10.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -324,8 +324,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="28">
             <desc>DDE1AA1  DDE2AA1  1</desc>
             <g id="28.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="287.06,207.22 402.57,141.82"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(315.34,191.21)">
+                <polyline class="nad-edge-path" points="287.06,207.22 402.57,141.82"/>
+                <g class="nad-edge-infos" transform="translate(315.34,191.21)">
                     <g class="nad-active">
                         <g transform="rotate(60.48)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -336,8 +336,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="28.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="518.08,76.42 402.57,141.82"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(489.80,92.43)">
+                <polyline class="nad-edge-path" points="518.08,76.42 402.57,141.82"/>
+                <g class="nad-edge-infos" transform="translate(489.80,92.43)">
                     <g class="nad-active">
                         <g transform="rotate(-119.52)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -351,8 +351,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="29">
             <desc>DDE1AA1  DDE3AA1  1</desc>
             <g id="29.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="271.22,247.05 309.16,370.20"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(280.79,278.11)">
+                <polyline class="nad-edge-path" points="271.22,247.05 309.16,370.20"/>
+                <g class="nad-edge-infos" transform="translate(280.79,278.11)">
                     <g class="nad-active">
                         <g transform="rotate(162.88)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -363,8 +363,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="29.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="347.10,493.35 309.16,370.20"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(337.53,462.29)">
+                <polyline class="nad-edge-path" points="347.10,493.35 309.16,370.20"/>
+                <g class="nad-edge-infos" transform="translate(337.53,462.29)">
                     <g class="nad-active">
                         <g transform="rotate(-17.12)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -378,8 +378,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="30">
             <desc>DDE2AA1  DDE3AA1  1</desc>
             <g id="30.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="531.60,88.32 448.60,291.25"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(519.29,118.40)">
+                <polyline class="nad-edge-path" points="531.60,88.32 448.60,291.25"/>
+                <g class="nad-edge-infos" transform="translate(519.29,118.40)">
                     <g class="nad-active">
                         <g transform="rotate(-157.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -390,8 +390,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="30.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="365.60,494.18 448.60,291.25"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(377.90,464.10)">
+                <polyline class="nad-edge-path" points="365.60,494.18 448.60,291.25"/>
+                <g class="nad-edge-infos" transform="translate(377.90,464.10)">
                     <g class="nad-active">
                         <g transform="rotate(22.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -405,8 +405,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="31">
             <desc>DDE2AA1  NNL3AA1  1</desc>
             <g id="31.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="537.59,35.72 502.77,-178.25"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(532.37,3.65)">
+                <polyline class="nad-edge-path" points="537.59,35.72 502.77,-178.25"/>
+                <g class="nad-edge-infos" transform="translate(532.37,3.65)">
                     <g class="nad-active">
                         <g transform="rotate(-9.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -417,8 +417,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="31.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="467.94,-392.22 502.77,-178.25"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(473.16,-360.14)">
+                <polyline class="nad-edge-path" points="467.94,-392.22 502.77,-178.25"/>
+                <g class="nad-edge-infos" transform="translate(473.16,-360.14)">
                     <g class="nad-active">
                         <g transform="rotate(170.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -432,8 +432,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="32">
             <desc>FFR2AA1  DDE3AA1  1</desc>
             <g id="32.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-15.40,666.51 157.11,598.14"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(14.81,654.53)">
+                <polyline class="nad-edge-path" points="-15.40,666.51 157.11,598.14"/>
+                <g class="nad-edge-infos" transform="translate(14.81,654.53)">
                     <g class="nad-active">
                         <g transform="rotate(68.38)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -444,8 +444,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="32.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="329.63,529.77 157.11,598.14"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(299.41,541.74)">
+                <polyline class="nad-edge-path" points="329.63,529.77 157.11,598.14"/>
+                <g class="nad-edge-infos" transform="translate(299.41,541.74)">
                     <g class="nad-active">
                         <g transform="rotate(-111.62)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -486,8 +486,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="34">
             <desc>FFR1AA1  FFR3AA1  1</desc>
             <g id="34.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-78.71,662.02 -97.51,613.00 -217.43,515.87"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-120.83,594.12)">
+                <polyline class="nad-edge-path" points="-78.71,662.02 -97.51,613.00 -217.43,515.87"/>
+                <g class="nad-edge-infos" transform="translate(-120.83,594.12)">
                     <g class="nad-active">
                         <g transform="rotate(-50.99)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -498,8 +498,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="34.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-389.19,410.52 -337.34,418.74 -217.43,515.87"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-314.03,437.63)">
+                <polyline class="nad-edge-path" points="-389.19,410.52 -337.34,418.74 -217.43,515.87"/>
+                <g class="nad-edge-infos" transform="translate(-314.03,437.63)">
                     <g class="nad-active">
                         <g transform="rotate(129.01)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -513,8 +513,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="35">
             <desc>FFR2AA1  FFR3AA1  1</desc>
             <g id="35.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-125.65,678.69 -147.87,675.17 -267.78,578.04"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-171.18,656.28)">
+                <polyline class="nad-edge-path" points="-125.65,678.69 -147.87,675.17 -267.78,578.04"/>
+                <g class="nad-edge-infos" transform="translate(-171.18,656.28)">
                     <g class="nad-active">
                         <g transform="rotate(-50.99)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -525,8 +525,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="35.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-406.50,431.89 -387.69,480.91 -267.78,578.04"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-364.38,499.79)">
+                <polyline class="nad-edge-path" points="-406.50,431.89 -387.69,480.91 -267.78,578.04"/>
+                <g class="nad-edge-infos" transform="translate(-364.38,499.79)">
                     <g class="nad-active">
                         <g transform="rotate(129.01)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -563,7 +563,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500-line nad-winding" cx="-91.98" cy="569.52" r="20.00"/>
                 <circle class="nad-vl300to500-line nad-winding" cx="-72.10" cy="567.32" r="20.00"/>
                 <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(0.99,-0.11,0.11,0.99,-115.15,541.90)" class="nad-pst-arrow"/>
@@ -572,8 +572,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="37">
             <desc>NNL1AA1  NNL2AA1  1</desc>
             <g id="37.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="435.39,-786.36 284.11,-723.93"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(405.34,-773.97)">
+                <polyline class="nad-edge-path" points="435.39,-786.36 284.11,-723.93"/>
+                <g class="nad-edge-infos" transform="translate(405.34,-773.97)">
                     <g class="nad-active">
                         <g transform="rotate(-112.43)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -584,8 +584,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="37.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="132.83,-661.49 284.11,-723.93"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(162.87,-673.89)">
+                <polyline class="nad-edge-path" points="132.83,-661.49 284.11,-723.93"/>
+                <g class="nad-edge-infos" transform="translate(162.87,-673.89)">
                     <g class="nad-active">
                         <g transform="rotate(67.57)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -599,8 +599,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="38">
             <desc>NNL1AA1  NNL3AA1  1</desc>
             <g id="38.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="461.00,-769.36 462.17,-608.11"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(461.24,-736.86)">
+                <polyline class="nad-edge-path" points="461.00,-769.36 462.17,-608.11"/>
+                <g class="nad-edge-infos" transform="translate(461.24,-736.86)">
                     <g class="nad-active">
                         <g transform="rotate(179.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -611,8 +611,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="38.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="463.33,-446.86 462.17,-608.11"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(463.09,-479.36)">
+                <polyline class="nad-edge-path" points="463.33,-446.86 462.17,-608.11"/>
+                <g class="nad-edge-infos" transform="translate(463.09,-479.36)">
                     <g class="nad-active">
                         <g transform="rotate(-0.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -626,8 +626,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="39">
             <desc>NNL2AA1  NNL3AA1  1</desc>
             <g id="39.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="130.46,-636.01 285.47,-535.18"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(157.71,-618.29)">
+                <polyline class="nad-edge-path" points="130.46,-636.01 285.47,-535.18"/>
+                <g class="nad-edge-infos" transform="translate(157.71,-618.29)">
                     <g class="nad-active">
                         <g transform="rotate(123.04)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -638,8 +638,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="39.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="440.47,-434.36 285.47,-535.18"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(413.23,-452.08)">
+                <polyline class="nad-edge-path" points="440.47,-434.36 285.47,-535.18"/>
+                <g class="nad-edge-infos" transform="translate(413.23,-452.08)">
                     <g class="nad-active">
                         <g transform="rotate(-56.96)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/simple-eu-loop80.svg
+++ b/network-area-diagram/src/test/resources/simple-eu-loop80.svg
@@ -157,8 +157,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="22">
             <desc>BBE1AA1  BBE2AA1  1</desc>
             <g id="22.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-338.35,-446.77 -380.56,-415.55 -443.79,-270.18"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-392.53,-388.04)">
+                <polyline class="nad-edge-path" points="-338.35,-446.77 -380.56,-415.55 -443.79,-270.18"/>
+                <g class="nad-edge-infos" transform="translate(-392.53,-388.04)">
                     <g class="nad-active">
                         <g transform="rotate(-156.49)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -169,8 +169,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="22.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-501.07,-72.65 -507.01,-124.81 -443.79,-270.18"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-495.05,-152.32)">
+                <polyline class="nad-edge-path" points="-501.07,-72.65 -507.01,-124.81 -443.79,-270.18"/>
+                <g class="nad-edge-infos" transform="translate(-495.05,-152.32)">
                     <g class="nad-active">
                         <g transform="rotate(23.51)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -211,8 +211,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="24">
             <desc>BBE2AA1  BBE3AA1  1</desc>
             <g id="24.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-475.85,-61.68 -433.65,-92.90 -370.42,-238.27"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-421.68,-120.41)">
+                <polyline class="nad-edge-path" points="-475.85,-61.68 -433.65,-92.90 -370.42,-238.27"/>
+                <g class="nad-edge-infos" transform="translate(-421.68,-120.41)">
                     <g class="nad-active">
                         <g transform="rotate(23.51)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -223,8 +223,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="24.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-309.74,-405.99 -307.20,-383.64 -370.42,-238.27"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-319.16,-356.13)">
+                <polyline class="nad-edge-path" points="-309.74,-405.99 -307.20,-383.64 -370.42,-238.27"/>
+                <g class="nad-edge-infos" transform="translate(-319.16,-356.13)">
                     <g class="nad-active">
                         <g transform="rotate(-156.49)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -238,8 +238,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="25">
             <desc>NNL2AA1  BBE3AA1  1</desc>
             <g id="25.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="82.27,-639.85 -90.71,-563.14"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(52.56,-626.68)">
+                <polyline class="nad-edge-path" points="82.27,-639.85 -90.71,-563.14"/>
+                <g class="nad-edge-infos" transform="translate(52.56,-626.68)">
                     <g class="nad-active">
                         <g transform="rotate(-113.92)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -250,8 +250,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="25.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-263.68,-486.43 -90.71,-563.14"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-233.97,-499.61)">
+                <polyline class="nad-edge-path" points="-263.68,-486.43 -90.71,-563.14"/>
+                <g class="nad-edge-infos" transform="translate(-233.97,-499.61)">
                     <g class="nad-active">
                         <g transform="rotate(66.08)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -288,7 +288,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500-line nad-winding" cx="-385.26" cy="-561.80" r="20.00"/>
                 <circle class="nad-vl300to500-line nad-winding" cx="-367.97" cy="-571.86" r="20.00"/>
                 <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(0.86,-0.50,0.50,0.86,-417.64,-577.67)" class="nad-pst-arrow"/>
@@ -297,8 +297,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="27">
             <desc>BBE2AA1  FFR3AA1  1</desc>
             <g id="27.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-493.07,-18.26 -457.16,180.45"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-487.29,13.72)">
+                <polyline class="nad-edge-path" points="-493.07,-18.26 -457.16,180.45"/>
+                <g class="nad-edge-infos" transform="translate(-487.29,13.72)">
                     <g class="nad-active">
                         <g transform="rotate(169.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -309,8 +309,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="27.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-421.24,379.16 -457.16,180.45"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-427.02,347.17)">
+                <polyline class="nad-edge-path" points="-421.24,379.16 -457.16,180.45"/>
+                <g class="nad-edge-infos" transform="translate(-427.02,347.17)">
                     <g class="nad-active">
                         <g transform="rotate(-10.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -324,8 +324,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="28">
             <desc>DDE1AA1  DDE2AA1  1</desc>
             <g id="28.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="287.06,207.22 402.57,141.82"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(315.34,191.21)">
+                <polyline class="nad-edge-path" points="287.06,207.22 402.57,141.82"/>
+                <g class="nad-edge-infos" transform="translate(315.34,191.21)">
                     <g class="nad-active">
                         <g transform="rotate(60.48)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -336,8 +336,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="28.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="518.08,76.42 402.57,141.82"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(489.80,92.43)">
+                <polyline class="nad-edge-path" points="518.08,76.42 402.57,141.82"/>
+                <g class="nad-edge-infos" transform="translate(489.80,92.43)">
                     <g class="nad-active">
                         <g transform="rotate(-119.52)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -351,8 +351,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="29">
             <desc>DDE1AA1  DDE3AA1  1</desc>
             <g id="29.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="271.22,247.05 309.16,370.20"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(280.79,278.11)">
+                <polyline class="nad-edge-path" points="271.22,247.05 309.16,370.20"/>
+                <g class="nad-edge-infos" transform="translate(280.79,278.11)">
                     <g class="nad-active">
                         <g transform="rotate(162.88)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -363,8 +363,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="29.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="347.10,493.35 309.16,370.20"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(337.53,462.29)">
+                <polyline class="nad-edge-path" points="347.10,493.35 309.16,370.20"/>
+                <g class="nad-edge-infos" transform="translate(337.53,462.29)">
                     <g class="nad-active">
                         <g transform="rotate(-17.12)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -378,8 +378,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="30">
             <desc>DDE2AA1  DDE3AA1  1</desc>
             <g id="30.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="531.60,88.32 448.60,291.25"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(519.29,118.40)">
+                <polyline class="nad-edge-path" points="531.60,88.32 448.60,291.25"/>
+                <g class="nad-edge-infos" transform="translate(519.29,118.40)">
                     <g class="nad-active">
                         <g transform="rotate(-157.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -390,8 +390,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="30.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="365.60,494.18 448.60,291.25"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(377.90,464.10)">
+                <polyline class="nad-edge-path" points="365.60,494.18 448.60,291.25"/>
+                <g class="nad-edge-infos" transform="translate(377.90,464.10)">
                     <g class="nad-active">
                         <g transform="rotate(22.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -405,8 +405,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="31">
             <desc>DDE2AA1  NNL3AA1  1</desc>
             <g id="31.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="537.59,35.72 502.77,-178.25"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(532.37,3.65)">
+                <polyline class="nad-edge-path" points="537.59,35.72 502.77,-178.25"/>
+                <g class="nad-edge-infos" transform="translate(532.37,3.65)">
                     <g class="nad-active">
                         <g transform="rotate(-9.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -417,8 +417,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="31.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="467.94,-392.22 502.77,-178.25"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(473.16,-360.14)">
+                <polyline class="nad-edge-path" points="467.94,-392.22 502.77,-178.25"/>
+                <g class="nad-edge-infos" transform="translate(473.16,-360.14)">
                     <g class="nad-active">
                         <g transform="rotate(170.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -432,8 +432,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="32">
             <desc>FFR2AA1  DDE3AA1  1</desc>
             <g id="32.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-15.40,666.51 157.11,598.14"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(14.81,654.53)">
+                <polyline class="nad-edge-path" points="-15.40,666.51 157.11,598.14"/>
+                <g class="nad-edge-infos" transform="translate(14.81,654.53)">
                     <g class="nad-active">
                         <g transform="rotate(68.38)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -444,8 +444,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="32.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="329.63,529.77 157.11,598.14"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(299.41,541.74)">
+                <polyline class="nad-edge-path" points="329.63,529.77 157.11,598.14"/>
+                <g class="nad-edge-infos" transform="translate(299.41,541.74)">
                     <g class="nad-active">
                         <g transform="rotate(-111.62)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -486,8 +486,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="34">
             <desc>FFR1AA1  FFR3AA1  1</desc>
             <g id="34.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-78.71,662.02 -97.51,613.00 -217.43,515.87"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-120.83,594.12)">
+                <polyline class="nad-edge-path" points="-78.71,662.02 -97.51,613.00 -217.43,515.87"/>
+                <g class="nad-edge-infos" transform="translate(-120.83,594.12)">
                     <g class="nad-active">
                         <g transform="rotate(-50.99)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -498,8 +498,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="34.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-389.19,410.52 -337.34,418.74 -217.43,515.87"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-314.03,437.63)">
+                <polyline class="nad-edge-path" points="-389.19,410.52 -337.34,418.74 -217.43,515.87"/>
+                <g class="nad-edge-infos" transform="translate(-314.03,437.63)">
                     <g class="nad-active">
                         <g transform="rotate(129.01)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -513,8 +513,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="35">
             <desc>FFR2AA1  FFR3AA1  1</desc>
             <g id="35.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-125.65,678.69 -147.87,675.17 -267.78,578.04"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-171.18,656.28)">
+                <polyline class="nad-edge-path" points="-125.65,678.69 -147.87,675.17 -267.78,578.04"/>
+                <g class="nad-edge-infos" transform="translate(-171.18,656.28)">
                     <g class="nad-active">
                         <g transform="rotate(-50.99)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -525,8 +525,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="35.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-406.50,431.89 -387.69,480.91 -267.78,578.04"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-364.38,499.79)">
+                <polyline class="nad-edge-path" points="-406.50,431.89 -387.69,480.91 -267.78,578.04"/>
+                <g class="nad-edge-infos" transform="translate(-364.38,499.79)">
                     <g class="nad-active">
                         <g transform="rotate(129.01)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -563,7 +563,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500-line nad-winding" cx="-141.94" cy="783.39" r="20.00"/>
                 <circle class="nad-vl300to500-line nad-winding" cx="-156.77" cy="769.98" r="20.00"/>
                 <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(-0.74,-0.67,0.67,-0.74,-147.23,819.06)" class="nad-pst-arrow"/>
@@ -572,8 +572,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="37">
             <desc>NNL1AA1  NNL2AA1  1</desc>
             <g id="37.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="435.39,-786.36 284.11,-723.93"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(405.34,-773.97)">
+                <polyline class="nad-edge-path" points="435.39,-786.36 284.11,-723.93"/>
+                <g class="nad-edge-infos" transform="translate(405.34,-773.97)">
                     <g class="nad-active">
                         <g transform="rotate(-112.43)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -584,8 +584,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="37.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="132.83,-661.49 284.11,-723.93"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(162.87,-673.89)">
+                <polyline class="nad-edge-path" points="132.83,-661.49 284.11,-723.93"/>
+                <g class="nad-edge-infos" transform="translate(162.87,-673.89)">
                     <g class="nad-active">
                         <g transform="rotate(67.57)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -599,8 +599,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="38">
             <desc>NNL1AA1  NNL3AA1  1</desc>
             <g id="38.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="461.00,-769.36 462.17,-608.11"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(461.24,-736.86)">
+                <polyline class="nad-edge-path" points="461.00,-769.36 462.17,-608.11"/>
+                <g class="nad-edge-infos" transform="translate(461.24,-736.86)">
                     <g class="nad-active">
                         <g transform="rotate(179.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -611,8 +611,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="38.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="463.33,-446.86 462.17,-608.11"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(463.09,-479.36)">
+                <polyline class="nad-edge-path" points="463.33,-446.86 462.17,-608.11"/>
+                <g class="nad-edge-infos" transform="translate(463.09,-479.36)">
                     <g class="nad-active">
                         <g transform="rotate(-0.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -626,8 +626,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="39">
             <desc>NNL2AA1  NNL3AA1  1</desc>
             <g id="39.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="130.46,-636.01 285.47,-535.18"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(157.71,-618.29)">
+                <polyline class="nad-edge-path" points="130.46,-636.01 285.47,-535.18"/>
+                <g class="nad-edge-infos" transform="translate(157.71,-618.29)">
                     <g class="nad-active">
                         <g transform="rotate(123.04)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -638,8 +638,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="39.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="440.47,-434.36 285.47,-535.18"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(413.23,-452.08)">
+                <polyline class="nad-edge-path" points="440.47,-434.36 285.47,-535.18"/>
+                <g class="nad-edge-infos" transform="translate(413.23,-452.08)">
                     <g class="nad-active">
                         <g transform="rotate(-56.96)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/simple-eu.svg
+++ b/network-area-diagram/src/test/resources/simple-eu.svg
@@ -157,8 +157,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="22">
             <desc>BBE1AA1  BBE2AA1  1</desc>
             <g id="22.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-338.35,-446.77 -380.56,-415.55 -443.79,-270.18"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-392.53,-388.04)">
+                <polyline class="nad-edge-path" points="-338.35,-446.77 -380.56,-415.55 -443.79,-270.18"/>
+                <g class="nad-edge-infos" transform="translate(-392.53,-388.04)">
                     <g class="nad-active">
                         <g transform="rotate(-156.49)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -169,8 +169,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="22.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-501.07,-72.65 -507.01,-124.81 -443.79,-270.18"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-495.05,-152.32)">
+                <polyline class="nad-edge-path" points="-501.07,-72.65 -507.01,-124.81 -443.79,-270.18"/>
+                <g class="nad-edge-infos" transform="translate(-495.05,-152.32)">
                     <g class="nad-active">
                         <g transform="rotate(23.51)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -211,8 +211,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="24">
             <desc>BBE2AA1  BBE3AA1  1</desc>
             <g id="24.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-475.85,-61.68 -433.65,-92.90 -370.42,-238.27"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-421.68,-120.41)">
+                <polyline class="nad-edge-path" points="-475.85,-61.68 -433.65,-92.90 -370.42,-238.27"/>
+                <g class="nad-edge-infos" transform="translate(-421.68,-120.41)">
                     <g class="nad-active">
                         <g transform="rotate(23.51)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -223,8 +223,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="24.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-309.74,-405.99 -307.20,-383.64 -370.42,-238.27"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-319.16,-356.13)">
+                <polyline class="nad-edge-path" points="-309.74,-405.99 -307.20,-383.64 -370.42,-238.27"/>
+                <g class="nad-edge-infos" transform="translate(-319.16,-356.13)">
                     <g class="nad-active">
                         <g transform="rotate(-156.49)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -238,8 +238,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="25">
             <desc>NNL2AA1  BBE3AA1  1</desc>
             <g id="25.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="82.27,-639.85 -90.71,-563.14"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(52.56,-626.68)">
+                <polyline class="nad-edge-path" points="82.27,-639.85 -90.71,-563.14"/>
+                <g class="nad-edge-infos" transform="translate(52.56,-626.68)">
                     <g class="nad-active">
                         <g transform="rotate(-113.92)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -250,8 +250,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="25.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-263.68,-486.43 -90.71,-563.14"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-233.97,-499.61)">
+                <polyline class="nad-edge-path" points="-263.68,-486.43 -90.71,-563.14"/>
+                <g class="nad-edge-infos" transform="translate(-233.97,-499.61)">
                     <g class="nad-active">
                         <g transform="rotate(66.08)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -288,7 +288,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500-line nad-winding" cx="-385.26" cy="-561.80" r="20.00"/>
                 <circle class="nad-vl300to500-line nad-winding" cx="-367.97" cy="-571.86" r="20.00"/>
                 <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(0.86,-0.50,0.50,0.86,-417.64,-577.67)" class="nad-pst-arrow"/>
@@ -297,8 +297,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="27">
             <desc>BBE2AA1  FFR3AA1  1</desc>
             <g id="27.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-493.07,-18.26 -457.16,180.45"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-487.29,13.72)">
+                <polyline class="nad-edge-path" points="-493.07,-18.26 -457.16,180.45"/>
+                <g class="nad-edge-infos" transform="translate(-487.29,13.72)">
                     <g class="nad-active">
                         <g transform="rotate(169.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -309,8 +309,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="27.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-421.24,379.16 -457.16,180.45"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-427.02,347.17)">
+                <polyline class="nad-edge-path" points="-421.24,379.16 -457.16,180.45"/>
+                <g class="nad-edge-infos" transform="translate(-427.02,347.17)">
                     <g class="nad-active">
                         <g transform="rotate(-10.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -324,8 +324,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="28">
             <desc>DDE1AA1  DDE2AA1  1</desc>
             <g id="28.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="287.06,207.22 402.57,141.82"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(315.34,191.21)">
+                <polyline class="nad-edge-path" points="287.06,207.22 402.57,141.82"/>
+                <g class="nad-edge-infos" transform="translate(315.34,191.21)">
                     <g class="nad-active">
                         <g transform="rotate(60.48)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -336,8 +336,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="28.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="518.08,76.42 402.57,141.82"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(489.80,92.43)">
+                <polyline class="nad-edge-path" points="518.08,76.42 402.57,141.82"/>
+                <g class="nad-edge-infos" transform="translate(489.80,92.43)">
                     <g class="nad-active">
                         <g transform="rotate(-119.52)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -351,8 +351,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="29">
             <desc>DDE1AA1  DDE3AA1  1</desc>
             <g id="29.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="271.22,247.05 309.16,370.20"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(280.79,278.11)">
+                <polyline class="nad-edge-path" points="271.22,247.05 309.16,370.20"/>
+                <g class="nad-edge-infos" transform="translate(280.79,278.11)">
                     <g class="nad-active">
                         <g transform="rotate(162.88)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -363,8 +363,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="29.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="347.10,493.35 309.16,370.20"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(337.53,462.29)">
+                <polyline class="nad-edge-path" points="347.10,493.35 309.16,370.20"/>
+                <g class="nad-edge-infos" transform="translate(337.53,462.29)">
                     <g class="nad-active">
                         <g transform="rotate(-17.12)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -378,8 +378,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="30">
             <desc>DDE2AA1  DDE3AA1  1</desc>
             <g id="30.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="531.60,88.32 448.60,291.25"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(519.29,118.40)">
+                <polyline class="nad-edge-path" points="531.60,88.32 448.60,291.25"/>
+                <g class="nad-edge-infos" transform="translate(519.29,118.40)">
                     <g class="nad-active">
                         <g transform="rotate(-157.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -390,8 +390,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="30.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="365.60,494.18 448.60,291.25"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(377.90,464.10)">
+                <polyline class="nad-edge-path" points="365.60,494.18 448.60,291.25"/>
+                <g class="nad-edge-infos" transform="translate(377.90,464.10)">
                     <g class="nad-active">
                         <g transform="rotate(22.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -405,8 +405,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="31">
             <desc>DDE2AA1  NNL3AA1  1</desc>
             <g id="31.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="537.59,35.72 502.77,-178.25"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(532.37,3.65)">
+                <polyline class="nad-edge-path" points="537.59,35.72 502.77,-178.25"/>
+                <g class="nad-edge-infos" transform="translate(532.37,3.65)">
                     <g class="nad-active">
                         <g transform="rotate(-9.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -417,8 +417,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="31.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="467.94,-392.22 502.77,-178.25"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(473.16,-360.14)">
+                <polyline class="nad-edge-path" points="467.94,-392.22 502.77,-178.25"/>
+                <g class="nad-edge-infos" transform="translate(473.16,-360.14)">
                     <g class="nad-active">
                         <g transform="rotate(170.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -432,8 +432,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="32">
             <desc>FFR2AA1  DDE3AA1  1</desc>
             <g id="32.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-15.40,666.51 157.11,598.14"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(14.81,654.53)">
+                <polyline class="nad-edge-path" points="-15.40,666.51 157.11,598.14"/>
+                <g class="nad-edge-infos" transform="translate(14.81,654.53)">
                     <g class="nad-active">
                         <g transform="rotate(68.38)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -444,8 +444,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="32.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="329.63,529.77 157.11,598.14"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(299.41,541.74)">
+                <polyline class="nad-edge-path" points="329.63,529.77 157.11,598.14"/>
+                <g class="nad-edge-infos" transform="translate(299.41,541.74)">
                     <g class="nad-active">
                         <g transform="rotate(-111.62)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -486,8 +486,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="34">
             <desc>FFR1AA1  FFR3AA1  1</desc>
             <g id="34.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-78.71,662.02 -97.51,613.00 -217.43,515.87"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-120.83,594.12)">
+                <polyline class="nad-edge-path" points="-78.71,662.02 -97.51,613.00 -217.43,515.87"/>
+                <g class="nad-edge-infos" transform="translate(-120.83,594.12)">
                     <g class="nad-active">
                         <g transform="rotate(-50.99)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -498,8 +498,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="34.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-389.19,410.52 -337.34,418.74 -217.43,515.87"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-314.03,437.63)">
+                <polyline class="nad-edge-path" points="-389.19,410.52 -337.34,418.74 -217.43,515.87"/>
+                <g class="nad-edge-infos" transform="translate(-314.03,437.63)">
                     <g class="nad-active">
                         <g transform="rotate(129.01)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -513,8 +513,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="35">
             <desc>FFR2AA1  FFR3AA1  1</desc>
             <g id="35.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-125.65,678.69 -147.87,675.17 -267.78,578.04"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-171.18,656.28)">
+                <polyline class="nad-edge-path" points="-125.65,678.69 -147.87,675.17 -267.78,578.04"/>
+                <g class="nad-edge-infos" transform="translate(-171.18,656.28)">
                     <g class="nad-active">
                         <g transform="rotate(-50.99)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -525,8 +525,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="35.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-406.50,431.89 -387.69,480.91 -267.78,578.04"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-364.38,499.79)">
+                <polyline class="nad-edge-path" points="-406.50,431.89 -387.69,480.91 -267.78,578.04"/>
+                <g class="nad-edge-infos" transform="translate(-364.38,499.79)">
                     <g class="nad-active">
                         <g transform="rotate(129.01)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -563,7 +563,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500-line nad-winding" cx="-45.74" cy="805.87" r="20.00"/>
                 <circle class="nad-vl300to500-line nad-winding" cx="-65.61" cy="808.07" r="20.00"/>
                 <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(-0.99,0.11,-0.11,-0.99,-22.56,833.49)" class="nad-pst-arrow"/>
@@ -572,8 +572,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="37">
             <desc>NNL1AA1  NNL2AA1  1</desc>
             <g id="37.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="435.39,-786.36 284.11,-723.93"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(405.34,-773.97)">
+                <polyline class="nad-edge-path" points="435.39,-786.36 284.11,-723.93"/>
+                <g class="nad-edge-infos" transform="translate(405.34,-773.97)">
                     <g class="nad-active">
                         <g transform="rotate(-112.43)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -584,8 +584,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="37.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="132.83,-661.49 284.11,-723.93"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(162.87,-673.89)">
+                <polyline class="nad-edge-path" points="132.83,-661.49 284.11,-723.93"/>
+                <g class="nad-edge-infos" transform="translate(162.87,-673.89)">
                     <g class="nad-active">
                         <g transform="rotate(67.57)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -599,8 +599,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="38">
             <desc>NNL1AA1  NNL3AA1  1</desc>
             <g id="38.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="461.00,-769.36 462.17,-608.11"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(461.24,-736.86)">
+                <polyline class="nad-edge-path" points="461.00,-769.36 462.17,-608.11"/>
+                <g class="nad-edge-infos" transform="translate(461.24,-736.86)">
                     <g class="nad-active">
                         <g transform="rotate(179.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -611,8 +611,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="38.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="463.33,-446.86 462.17,-608.11"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(463.09,-479.36)">
+                <polyline class="nad-edge-path" points="463.33,-446.86 462.17,-608.11"/>
+                <g class="nad-edge-infos" transform="translate(463.09,-479.36)">
                     <g class="nad-active">
                         <g transform="rotate(-0.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -626,8 +626,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="39">
             <desc>NNL2AA1  NNL3AA1  1</desc>
             <g id="39.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="130.46,-636.01 285.47,-535.18"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(157.71,-618.29)">
+                <polyline class="nad-edge-path" points="130.46,-636.01 285.47,-535.18"/>
+                <g class="nad-edge-infos" transform="translate(157.71,-618.29)">
                     <g class="nad-active">
                         <g transform="rotate(123.04)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -638,8 +638,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="39.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="440.47,-434.36 285.47,-535.18"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(413.23,-452.08)">
+                <polyline class="nad-edge-path" points="440.47,-434.36 285.47,-535.18"/>
+                <g class="nad-edge-infos" transform="translate(413.23,-452.08)">
                     <g class="nad-active">
                         <g transform="rotate(-56.96)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/simple-eu_overridden_styles.svg
+++ b/network-area-diagram/src/test/resources/simple-eu_overridden_styles.svg
@@ -157,8 +157,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="22">
             <desc>BBE1AA1  BBE2AA1  1</desc>
             <g id="22.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-338.35,-446.77 -380.56,-415.55 -443.79,-270.18"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-392.53,-388.04)">
+                <polyline class="nad-edge-path" points="-338.35,-446.77 -380.56,-415.55 -443.79,-270.18"/>
+                <g class="nad-edge-infos" transform="translate(-392.53,-388.04)">
                     <g class="nad-active">
                         <g transform="rotate(-156.49)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -169,8 +169,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="22.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-501.07,-72.65 -507.01,-124.81 -443.79,-270.18"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-495.05,-152.32)">
+                <polyline class="nad-edge-path" points="-501.07,-72.65 -507.01,-124.81 -443.79,-270.18"/>
+                <g class="nad-edge-infos" transform="translate(-495.05,-152.32)">
                     <g class="nad-active">
                         <g transform="rotate(23.51)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -211,8 +211,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="24">
             <desc>BBE2AA1  BBE3AA1  1</desc>
             <g id="24.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-475.85,-61.68 -433.65,-92.90 -370.42,-238.27"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-421.68,-120.41)">
+                <polyline class="nad-edge-path" points="-475.85,-61.68 -433.65,-92.90 -370.42,-238.27"/>
+                <g class="nad-edge-infos" transform="translate(-421.68,-120.41)">
                     <g class="nad-active">
                         <g transform="rotate(23.51)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -223,8 +223,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="24.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-309.74,-405.99 -307.20,-383.64 -370.42,-238.27"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-319.16,-356.13)">
+                <polyline class="nad-edge-path" points="-309.74,-405.99 -307.20,-383.64 -370.42,-238.27"/>
+                <g class="nad-edge-infos" transform="translate(-319.16,-356.13)">
                     <g class="nad-active">
                         <g transform="rotate(-156.49)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -238,8 +238,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="25">
             <desc>NNL2AA1  BBE3AA1  1</desc>
             <g id="25.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" style="stroke-dasharray:15,9;stroke-width:10px;stroke:black" points="82.27,-639.85 -90.71,-563.14"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(52.56,-626.68)">
+                <polyline class="nad-edge-path" style="stroke-dasharray:15,9;stroke-width:10px;stroke:black" points="82.27,-639.85 -90.71,-563.14"/>
+                <g class="nad-edge-infos" transform="translate(52.56,-626.68)">
                     <g class="nad-active">
                         <g transform="rotate(-113.92)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -250,8 +250,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="25.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" style="stroke-dasharray:15,9;stroke-width:10px;stroke:black" points="-263.68,-486.43 -90.71,-563.14"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-233.97,-499.61)">
+                <polyline class="nad-edge-path" style="stroke-dasharray:15,9;stroke-width:10px;stroke:black" points="-263.68,-486.43 -90.71,-563.14"/>
+                <g class="nad-edge-infos" transform="translate(-233.97,-499.61)">
                     <g class="nad-active">
                         <g transform="rotate(66.08)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -288,7 +288,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500-line nad-winding" cx="-385.26" cy="-561.80" r="20.00"/>
                 <circle class="nad-vl300to500-line nad-winding" cx="-367.97" cy="-571.86" r="20.00"/>
                 <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(0.86,-0.50,0.50,0.86,-417.64,-577.67)" class="nad-pst-arrow"/>
@@ -297,8 +297,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="27">
             <desc>BBE2AA1  FFR3AA1  1</desc>
             <g id="27.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" style="stroke-dasharray:15,9;stroke-width:10px;stroke:black" points="-493.07,-18.26 -457.16,180.45"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-487.29,13.72)">
+                <polyline class="nad-edge-path" style="stroke-dasharray:15,9;stroke-width:10px;stroke:black" points="-493.07,-18.26 -457.16,180.45"/>
+                <g class="nad-edge-infos" transform="translate(-487.29,13.72)">
                     <g class="nad-active">
                         <g transform="rotate(169.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -309,8 +309,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="27.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" style="stroke-dasharray:15,9;stroke-width:10px;stroke:black" points="-421.24,379.16 -457.16,180.45"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-427.02,347.17)">
+                <polyline class="nad-edge-path" style="stroke-dasharray:15,9;stroke-width:10px;stroke:black" points="-421.24,379.16 -457.16,180.45"/>
+                <g class="nad-edge-infos" transform="translate(-427.02,347.17)">
                     <g class="nad-active">
                         <g transform="rotate(-10.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -324,8 +324,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="28">
             <desc>DDE1AA1  DDE2AA1  1</desc>
             <g id="28.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="287.06,207.22 402.57,141.82"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(315.34,191.21)">
+                <polyline class="nad-edge-path" points="287.06,207.22 402.57,141.82"/>
+                <g class="nad-edge-infos" transform="translate(315.34,191.21)">
                     <g class="nad-active">
                         <g transform="rotate(60.48)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -336,8 +336,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="28.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="518.08,76.42 402.57,141.82"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(489.80,92.43)">
+                <polyline class="nad-edge-path" points="518.08,76.42 402.57,141.82"/>
+                <g class="nad-edge-infos" transform="translate(489.80,92.43)">
                     <g class="nad-active">
                         <g transform="rotate(-119.52)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -351,8 +351,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="29">
             <desc>DDE1AA1  DDE3AA1  1</desc>
             <g id="29.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="271.22,247.05 309.16,370.20"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(280.79,278.11)">
+                <polyline class="nad-edge-path" points="271.22,247.05 309.16,370.20"/>
+                <g class="nad-edge-infos" transform="translate(280.79,278.11)">
                     <g class="nad-active">
                         <g transform="rotate(162.88)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -363,8 +363,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="29.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="347.10,493.35 309.16,370.20"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(337.53,462.29)">
+                <polyline class="nad-edge-path" points="347.10,493.35 309.16,370.20"/>
+                <g class="nad-edge-infos" transform="translate(337.53,462.29)">
                     <g class="nad-active">
                         <g transform="rotate(-17.12)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -378,8 +378,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="30">
             <desc>DDE2AA1  DDE3AA1  1</desc>
             <g id="30.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="531.60,88.32 448.60,291.25"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(519.29,118.40)">
+                <polyline class="nad-edge-path" points="531.60,88.32 448.60,291.25"/>
+                <g class="nad-edge-infos" transform="translate(519.29,118.40)">
                     <g class="nad-active">
                         <g transform="rotate(-157.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -390,8 +390,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="30.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="365.60,494.18 448.60,291.25"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(377.90,464.10)">
+                <polyline class="nad-edge-path" points="365.60,494.18 448.60,291.25"/>
+                <g class="nad-edge-infos" transform="translate(377.90,464.10)">
                     <g class="nad-active">
                         <g transform="rotate(22.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -405,8 +405,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="31">
             <desc>DDE2AA1  NNL3AA1  1</desc>
             <g id="31.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" style="stroke-dasharray:15,9;stroke-width:10px;stroke:black" points="537.59,35.72 502.77,-178.25"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(532.37,3.65)">
+                <polyline class="nad-edge-path" style="stroke-dasharray:15,9;stroke-width:10px;stroke:black" points="537.59,35.72 502.77,-178.25"/>
+                <g class="nad-edge-infos" transform="translate(532.37,3.65)">
                     <g class="nad-active">
                         <g transform="rotate(-9.24)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -417,8 +417,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="31.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" style="stroke-dasharray:15,9;stroke-width:10px;stroke:black" points="467.94,-392.22 502.77,-178.25"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(473.16,-360.14)">
+                <polyline class="nad-edge-path" style="stroke-dasharray:15,9;stroke-width:10px;stroke:black" points="467.94,-392.22 502.77,-178.25"/>
+                <g class="nad-edge-infos" transform="translate(473.16,-360.14)">
                     <g class="nad-active">
                         <g transform="rotate(170.76)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -432,8 +432,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="32">
             <desc>FFR2AA1  DDE3AA1  1</desc>
             <g id="32.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" style="stroke-dasharray:15,9;stroke-width:10px;stroke:black" points="-15.40,666.51 157.11,598.14"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(14.81,654.53)">
+                <polyline class="nad-edge-path" style="stroke-dasharray:15,9;stroke-width:10px;stroke:black" points="-15.40,666.51 157.11,598.14"/>
+                <g class="nad-edge-infos" transform="translate(14.81,654.53)">
                     <g class="nad-active">
                         <g transform="rotate(68.38)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -444,8 +444,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="32.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" style="stroke-dasharray:15,9;stroke-width:10px;stroke:black" points="329.63,529.77 157.11,598.14"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(299.41,541.74)">
+                <polyline class="nad-edge-path" style="stroke-dasharray:15,9;stroke-width:10px;stroke:black" points="329.63,529.77 157.11,598.14"/>
+                <g class="nad-edge-infos" transform="translate(299.41,541.74)">
                     <g class="nad-active">
                         <g transform="rotate(-111.62)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -486,8 +486,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="34">
             <desc>FFR1AA1  FFR3AA1  1</desc>
             <g id="34.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-78.71,662.02 -97.51,613.00 -217.43,515.87"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-120.83,594.12)">
+                <polyline class="nad-edge-path" points="-78.71,662.02 -97.51,613.00 -217.43,515.87"/>
+                <g class="nad-edge-infos" transform="translate(-120.83,594.12)">
                     <g class="nad-active">
                         <g transform="rotate(-50.99)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -498,8 +498,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="34.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-389.19,410.52 -337.34,418.74 -217.43,515.87"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-314.03,437.63)">
+                <polyline class="nad-edge-path" points="-389.19,410.52 -337.34,418.74 -217.43,515.87"/>
+                <g class="nad-edge-infos" transform="translate(-314.03,437.63)">
                     <g class="nad-active">
                         <g transform="rotate(129.01)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -513,8 +513,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="35">
             <desc>FFR2AA1  FFR3AA1  1</desc>
             <g id="35.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-125.65,678.69 -147.87,675.17 -267.78,578.04"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-171.18,656.28)">
+                <polyline class="nad-edge-path" points="-125.65,678.69 -147.87,675.17 -267.78,578.04"/>
+                <g class="nad-edge-infos" transform="translate(-171.18,656.28)">
                     <g class="nad-active">
                         <g transform="rotate(-50.99)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -525,8 +525,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="35.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-406.50,431.89 -387.69,480.91 -267.78,578.04"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-364.38,499.79)">
+                <polyline class="nad-edge-path" points="-406.50,431.89 -387.69,480.91 -267.78,578.04"/>
+                <g class="nad-edge-infos" transform="translate(-364.38,499.79)">
                     <g class="nad-active">
                         <g transform="rotate(129.01)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -563,7 +563,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500-line nad-winding" cx="-45.74" cy="805.87" r="20.00"/>
                 <circle class="nad-vl300to500-line nad-winding" cx="-65.61" cy="808.07" r="20.00"/>
                 <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(-0.99,0.11,-0.11,-0.99,-22.56,833.49)" class="nad-pst-arrow"/>
@@ -572,8 +572,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="37">
             <desc>NNL1AA1  NNL2AA1  1</desc>
             <g id="37.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="435.39,-786.36 284.11,-723.93"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(405.34,-773.97)">
+                <polyline class="nad-edge-path" points="435.39,-786.36 284.11,-723.93"/>
+                <g class="nad-edge-infos" transform="translate(405.34,-773.97)">
                     <g class="nad-active">
                         <g transform="rotate(-112.43)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -584,8 +584,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="37.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="132.83,-661.49 284.11,-723.93"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(162.87,-673.89)">
+                <polyline class="nad-edge-path" points="132.83,-661.49 284.11,-723.93"/>
+                <g class="nad-edge-infos" transform="translate(162.87,-673.89)">
                     <g class="nad-active">
                         <g transform="rotate(67.57)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -599,8 +599,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="38">
             <desc>NNL1AA1  NNL3AA1  1</desc>
             <g id="38.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="461.00,-769.36 462.17,-608.11"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(461.24,-736.86)">
+                <polyline class="nad-edge-path" points="461.00,-769.36 462.17,-608.11"/>
+                <g class="nad-edge-infos" transform="translate(461.24,-736.86)">
                     <g class="nad-active">
                         <g transform="rotate(179.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -611,8 +611,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="38.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="463.33,-446.86 462.17,-608.11"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(463.09,-479.36)">
+                <polyline class="nad-edge-path" points="463.33,-446.86 462.17,-608.11"/>
+                <g class="nad-edge-infos" transform="translate(463.09,-479.36)">
                     <g class="nad-active">
                         <g transform="rotate(-0.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -626,8 +626,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <g id="39">
             <desc>NNL2AA1  NNL3AA1  1</desc>
             <g id="39.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="130.46,-636.01 285.47,-535.18"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(157.71,-618.29)">
+                <polyline class="nad-edge-path" points="130.46,-636.01 285.47,-535.18"/>
+                <g class="nad-edge-infos" transform="translate(157.71,-618.29)">
                     <g class="nad-active">
                         <g transform="rotate(123.04)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -638,8 +638,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="39.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="440.47,-434.36 285.47,-535.18"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(413.23,-452.08)">
+                <polyline class="nad-edge-path" points="440.47,-434.36 285.47,-535.18"/>
+                <g class="nad-edge-infos" transform="translate(413.23,-452.08)">
                     <g class="nad-active">
                         <g transform="rotate(-56.96)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>

--- a/network-area-diagram/src/test/resources/tie_line.svg
+++ b/network-area-diagram/src/test/resources/tie_line.svg
@@ -61,8 +61,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
     <g class="nad-branch-edges">
         <g id="8">
             <g id="8.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-437.24,-251.19 -365.67,-144.75"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-419.11,-224.22)">
+                <polyline class="nad-edge-path" points="-437.24,-251.19 -365.67,-144.75"/>
+                <g class="nad-edge-infos" transform="translate(-419.11,-224.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(146.08)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -73,8 +73,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="8.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-260.61,11.48 -332.19,-94.96"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-278.75,-15.49)">
+                <polyline class="nad-edge-path" points="-260.61,11.48 -332.19,-94.96"/>
+                <g class="nad-edge-infos" transform="translate(-278.75,-15.49)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-33.92)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -84,15 +84,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl0to30 nad-winding" cx="-354.51" cy="-128.15" r="20.00"/>
                 <circle class="nad-vl300to500 nad-winding" cx="-343.35" cy="-111.56" r="20.00"/>
             </g>
         </g>
         <g id="9" class="nad-tie-line-edge">
             <g id="9.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-222.36,49.52 -178.64,78.58 -54.98,86.38"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-148.70,80.47)">
+                <polyline class="nad-edge-path" points="-222.36,49.52 -178.64,78.58 -54.98,86.38"/>
+                <g class="nad-edge-infos" transform="translate(-148.70,80.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(93.61)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -103,8 +103,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="9.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="115.70,70.84 68.67,94.17 -54.98,86.38"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(38.73,92.28)">
+                <polyline class="nad-edge-path" points="115.70,70.84 68.67,94.17 -54.98,86.38"/>
+                <g class="nad-edge-infos" transform="translate(38.73,92.28)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-86.39)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -114,12 +114,12 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center"></g>
+            <g></g>
         </g>
         <g id="10" class="nad-tie-line-edge">
             <g id="10.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-220.63,22.07 -173.60,-1.26 -49.95,6.53"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-143.66,0.62)">
+                <polyline class="nad-edge-path" points="-220.63,22.07 -173.60,-1.26 -49.95,6.53"/>
+                <g class="nad-edge-infos" transform="translate(-143.66,0.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(93.61)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -130,8 +130,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="10.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="117.43,43.39 73.71,14.33 -49.95,6.53"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(43.77,12.44)">
+                <polyline class="nad-edge-path" points="117.43,43.39 73.71,14.33 -49.95,6.53"/>
+                <g class="nad-edge-infos" transform="translate(43.77,12.44)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-86.39)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -141,12 +141,12 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center"></g>
+            <g></g>
         </g>
         <g id="11">
             <g id="11.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="161.80,41.42 262.20,-38.97"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(187.17,21.11)">
+                <polyline class="nad-edge-path" points="161.80,41.42 262.20,-38.97"/>
+                <g class="nad-edge-infos" transform="translate(187.17,21.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(51.32)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -157,8 +157,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="11.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="409.44,-156.86 309.04,-76.47"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(384.07,-136.55)">
+                <polyline class="nad-edge-path" points="409.44,-156.86 309.04,-76.47"/>
+                <g class="nad-edge-infos" transform="translate(384.07,-136.55)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-128.68)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -168,7 +168,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500 nad-winding" cx="277.81" cy="-51.47" r="20.00"/>
                 <circle class="nad-vl120to180 nad-winding" cx="293.43" cy="-63.97" r="20.00"/>
             </g>

--- a/network-area-diagram/src/test/resources/tie_line_filtered.svg
+++ b/network-area-diagram/src/test/resources/tie_line_filtered.svg
@@ -58,8 +58,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
     <g class="nad-branch-edges">
         <g id="8">
             <g id="8.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-437.24,-251.19 -365.67,-144.75"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-419.11,-224.22)">
+                <polyline class="nad-edge-path" points="-437.24,-251.19 -365.67,-144.75"/>
+                <g class="nad-edge-infos" transform="translate(-419.11,-224.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(146.08)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -70,8 +70,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="8.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-260.61,11.48 -332.19,-94.96"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-278.75,-15.49)">
+                <polyline class="nad-edge-path" points="-260.61,11.48 -332.19,-94.96"/>
+                <g class="nad-edge-infos" transform="translate(-278.75,-15.49)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-33.92)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -81,15 +81,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl0to30 nad-winding" cx="-354.51" cy="-128.15" r="20.00"/>
                 <circle class="nad-vl300to500 nad-winding" cx="-343.35" cy="-111.56" r="20.00"/>
             </g>
         </g>
         <g id="9" class="nad-tie-line-edge">
             <g id="9.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-222.36,49.52 -178.64,78.58 -54.98,86.38"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-148.70,80.47)">
+                <polyline class="nad-edge-path" points="-222.36,49.52 -178.64,78.58 -54.98,86.38"/>
+                <g class="nad-edge-infos" transform="translate(-148.70,80.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(93.61)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -100,8 +100,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="9.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="115.70,70.84 68.67,94.17 -54.98,86.38"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(38.73,92.28)">
+                <polyline class="nad-edge-path" points="115.70,70.84 68.67,94.17 -54.98,86.38"/>
+                <g class="nad-edge-infos" transform="translate(38.73,92.28)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-86.39)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -111,12 +111,12 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center"></g>
+            <g></g>
         </g>
         <g id="10" class="nad-tie-line-edge">
             <g id="10.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-220.63,22.07 -173.60,-1.26 -49.95,6.53"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-143.66,0.62)">
+                <polyline class="nad-edge-path" points="-220.63,22.07 -173.60,-1.26 -49.95,6.53"/>
+                <g class="nad-edge-infos" transform="translate(-143.66,0.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(93.61)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -127,8 +127,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="10.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="117.43,43.39 73.71,14.33 -49.95,6.53"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(43.77,12.44)">
+                <polyline class="nad-edge-path" points="117.43,43.39 73.71,14.33 -49.95,6.53"/>
+                <g class="nad-edge-infos" transform="translate(43.77,12.44)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-86.39)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -138,12 +138,12 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                     </g>
                 </g>
             </g>
-            <g class="nad-glued-center"></g>
+            <g></g>
         </g>
         <g id="11">
             <g id="11.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="161.80,41.42 262.20,-38.97"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(187.17,21.11)">
+                <polyline class="nad-edge-path" points="161.80,41.42 262.20,-38.97"/>
+                <g class="nad-edge-infos" transform="translate(187.17,21.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(51.32)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -154,7 +154,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="11.2" class="nad-vl120to180"></g>
-            <g class="nad-glued-center">
+            <g>
                 <circle class="nad-vl300to500 nad-winding" cx="277.81" cy="-51.47" r="20.00"/>
                 <circle class="nad-vl120to180 nad-winding" cx="293.43" cy="-63.97" r="20.00"/>
             </g>

--- a/network-area-diagram/src/test/resources/vl_description_id.svg
+++ b/network-area-diagram/src/test/resources/vl_description_id.svg
@@ -123,8 +123,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
     <g class="nad-branch-edges">
         <g id="4">
             <g id="4.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-69.22,-294.55 -143.24,-158.76"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-84.78,-266.02)">
+                <polyline class="nad-edge-path" points="-69.22,-294.55 -143.24,-158.76"/>
+                <g class="nad-edge-infos" transform="translate(-84.78,-266.02)">
                     <g class="nad-active">
                         <g transform="rotate(-151.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -135,8 +135,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="4.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-217.26,-22.97 -143.24,-158.76"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-201.70,-51.50)">
+                <polyline class="nad-edge-path" points="-217.26,-22.97 -143.24,-158.76"/>
+                <g class="nad-edge-infos" transform="translate(-201.70,-51.50)">
                     <g class="nad-active">
                         <g transform="rotate(28.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -149,8 +149,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="7" class="nad-dangling-line-edge">
             <g id="7.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-216.73,25.03 -139.77,159.16"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-200.56,53.22)">
+                <polyline class="nad-edge-path" points="-216.73,25.03 -139.77,159.16"/>
+                <g class="nad-edge-infos" transform="translate(-200.56,53.22)">
                     <g class="nad-active">
                         <g transform="rotate(150.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -161,7 +161,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="7.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-62.80,293.29 -139.77,159.16"/>
+                <polyline class="nad-edge-path" points="-62.80,293.29 -139.77,159.16"/>
             </g>
         </g>
     </g>

--- a/network-area-diagram/src/test/resources/vl_description_substation.svg
+++ b/network-area-diagram/src/test/resources/vl_description_substation.svg
@@ -123,8 +123,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
     <g class="nad-branch-edges">
         <g id="4">
             <g id="4.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-69.22,-294.55 -143.24,-158.76"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-84.78,-266.02)">
+                <polyline class="nad-edge-path" points="-69.22,-294.55 -143.24,-158.76"/>
+                <g class="nad-edge-infos" transform="translate(-84.78,-266.02)">
                     <g class="nad-active">
                         <g transform="rotate(-151.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -135,8 +135,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="4.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-217.26,-22.97 -143.24,-158.76"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-201.70,-51.50)">
+                <polyline class="nad-edge-path" points="-217.26,-22.97 -143.24,-158.76"/>
+                <g class="nad-edge-infos" transform="translate(-201.70,-51.50)">
                     <g class="nad-active">
                         <g transform="rotate(28.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -149,8 +149,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="7" class="nad-dangling-line-edge">
             <g id="7.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-216.73,25.03 -139.77,159.16"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-200.56,53.22)">
+                <polyline class="nad-edge-path" points="-216.73,25.03 -139.77,159.16"/>
+                <g class="nad-edge-infos" transform="translate(-200.56,53.22)">
                     <g class="nad-active">
                         <g transform="rotate(150.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -161,7 +161,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="7.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-62.80,293.29 -139.77,159.16"/>
+                <polyline class="nad-edge-path" points="-62.80,293.29 -139.77,159.16"/>
             </g>
         </g>
     </g>

--- a/network-area-diagram/src/test/resources/vl_description_substation_id.svg
+++ b/network-area-diagram/src/test/resources/vl_description_substation_id.svg
@@ -123,8 +123,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
     <g class="nad-branch-edges">
         <g id="4">
             <g id="4.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-69.22,-294.55 -143.24,-158.76"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-84.78,-266.02)">
+                <polyline class="nad-edge-path" points="-69.22,-294.55 -143.24,-158.76"/>
+                <g class="nad-edge-infos" transform="translate(-84.78,-266.02)">
                     <g class="nad-active">
                         <g transform="rotate(-151.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -135,8 +135,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="4.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-217.26,-22.97 -143.24,-158.76"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-201.70,-51.50)">
+                <polyline class="nad-edge-path" points="-217.26,-22.97 -143.24,-158.76"/>
+                <g class="nad-edge-infos" transform="translate(-201.70,-51.50)">
                     <g class="nad-active">
                         <g transform="rotate(28.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -149,8 +149,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="7" class="nad-dangling-line-edge">
             <g id="7.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-216.73,25.03 -139.77,159.16"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-200.56,53.22)">
+                <polyline class="nad-edge-path" points="-216.73,25.03 -139.77,159.16"/>
+                <g class="nad-edge-infos" transform="translate(-200.56,53.22)">
                     <g class="nad-active">
                         <g transform="rotate(150.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -161,7 +161,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="7.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-62.80,293.29 -139.77,159.16"/>
+                <polyline class="nad-edge-path" points="-62.80,293.29 -139.77,159.16"/>
             </g>
         </g>
     </g>

--- a/network-area-diagram/src/test/resources/voltage_limits.svg
+++ b/network-area-diagram/src/test/resources/voltage_limits.svg
@@ -59,8 +59,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
     <g class="nad-branch-edges">
         <g id="5">
             <g id="5.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-79.53,-304.37 -124.34,-277.01 -178.36,-177.90"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-138.70,-250.67)">
+                <polyline class="nad-edge-path" points="-79.53,-304.37 -124.34,-277.01 -178.36,-177.90"/>
+                <g class="nad-edge-infos" transform="translate(-138.70,-250.67)">
                     <g class="nad-active">
                         <g transform="rotate(-151.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -71,8 +71,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="5.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-231.10,-26.31 -232.38,-78.80 -178.36,-177.90"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-218.03,-105.14)">
+                <polyline class="nad-edge-path" points="-231.10,-26.31 -232.38,-78.80 -178.36,-177.90"/>
+                <g class="nad-edge-infos" transform="translate(-218.03,-105.14)">
                     <g class="nad-active">
                         <g transform="rotate(28.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -85,8 +85,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="6">
             <g id="6.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-54.65,-261.22 -54.10,-238.72 -108.12,-139.62"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-68.45,-212.38)">
+                <polyline class="nad-edge-path" points="-54.65,-261.22 -54.10,-238.72 -108.12,-139.62"/>
+                <g class="nad-edge-infos" transform="translate(-68.45,-212.38)">
                     <g class="nad-active">
                         <g transform="rotate(-151.41)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -97,8 +97,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="6.2" class="nad-disconnected nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-206.95,-13.15 -162.14,-40.51 -108.12,-139.62"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(-147.78,-66.85)">
+                <polyline class="nad-edge-path" points="-206.95,-13.15 -162.14,-40.51 -108.12,-139.62"/>
+                <g class="nad-edge-infos" transform="translate(-147.78,-66.85)">
                     <g class="nad-active">
                         <g transform="rotate(28.59)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -111,8 +111,8 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         </g>
         <g id="9" class="nad-dangling-line-edge">
             <g id="9.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-216.73,25.03 -139.77,159.16"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-200.56,53.22)">
+                <polyline class="nad-edge-path" points="-216.73,25.03 -139.77,159.16"/>
+                <g class="nad-edge-infos" transform="translate(-200.56,53.22)">
                     <g class="nad-active">
                         <g transform="rotate(150.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
@@ -123,7 +123,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 </g>
             </g>
             <g id="9.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-62.80,293.29 -139.77,159.16"/>
+                <polyline class="nad-edge-path" points="-62.80,293.29 -139.77,159.16"/>
             </g>
         </g>
     </g>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
Fixes #673 


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

**Does this PR introduce a new Powsybl Action implying to be implemented in simulators or pypowsybl?**
- [ ] Yes, the corresponding issue is [here](link)
- [x] No

**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
