### PR TITLE
moves some svg pars checking from writer to the labelprovider impl

### DIFF
--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/SvgWriter.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/SvgWriter.java
@@ -690,24 +690,23 @@ public class SvgWriter {
     }
 
     private void writeBusNodeLegend(XMLStreamWriter writer, VoltageLevelNode vlNode) throws XMLStreamException {
-        boolean isBusLegend = vlNode.getBusNodeStream().anyMatch(bus -> StringUtils.isNotEmpty(labelProvider.getBusDescription(bus)));
-        if (isBusLegend) {
-            writer.writeStartElement(TABLE_ELEMENT_NAME);
+        List<BusNode> notEmptyDescrBusNodes = vlNode.getBusNodeStream()
+                .filter(busNode -> StringUtils.isNotEmpty(labelProvider.getBusDescription(busNode)))
+                .toList();
 
-            for (BusNode busNode : vlNode.getBusNodes()) {
-                String busNodeLegend = labelProvider.getBusDescription(busNode);
-                if (!StringUtils.isEmpty(busNodeLegend)) {
-                    writer.writeStartElement(TABLE_ROW_ELEMENT_NAME);
-                    writer.writeStartElement(TABLE_DATA_ELEMENT_NAME);
-                    writer.writeEmptyElement(DIV_ELEMENT_NAME);
-                    writeStyleClasses(writer, styleProvider.getBusNodeStyleClasses(busNode), StyleProvider.LEGEND_SQUARE_CLASS);
-                    writeStyleAttribute(writer, styleProvider.getBusNodeStyle(busNode));
-                    writer.writeEndElement();
-                    writer.writeStartElement(TABLE_DATA_ELEMENT_NAME);
-                    writer.writeCharacters(busNodeLegend);
-                    writer.writeEndElement();
-                    writer.writeEndElement();
-                }
+        if (!notEmptyDescrBusNodes.isEmpty()) {
+            writer.writeStartElement(TABLE_ELEMENT_NAME);
+            for (BusNode busNode : notEmptyDescrBusNodes) {
+                writer.writeStartElement(TABLE_ROW_ELEMENT_NAME);
+                writer.writeStartElement(TABLE_DATA_ELEMENT_NAME);
+                writer.writeEmptyElement(DIV_ELEMENT_NAME);
+                writeStyleClasses(writer, styleProvider.getBusNodeStyleClasses(busNode), StyleProvider.LEGEND_SQUARE_CLASS);
+                writeStyleAttribute(writer, styleProvider.getBusNodeStyle(busNode));
+                writer.writeEndElement();
+                writer.writeStartElement(TABLE_DATA_ELEMENT_NAME);
+                writer.writeCharacters(labelProvider.getBusDescription(busNode));
+                writer.writeEndElement();
+                writer.writeEndElement();
             }
             writer.writeEndElement();
         }

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/SvgWriter.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/SvgWriter.java
@@ -39,7 +39,6 @@ public class SvgWriter {
     private static final String PATH_ELEMENT_NAME = "path";
     private static final String CIRCLE_ELEMENT_NAME = "circle";
     private static final String TEXT_ELEMENT_NAME = "text";
-    private static final String TSPAN_ELEMENT_NAME = "tspan";
     private static final String FOREIGN_OBJECT_ELEMENT_NAME = "foreignObject";
     private static final String DIV_ELEMENT_NAME = "div";
     private static final String TABLE_ELEMENT_NAME = "table";
@@ -58,7 +57,6 @@ public class SvgWriter {
     private static final String PATH_D_ATTRIBUTE = "d";
     private static final String X_ATTRIBUTE = "x";
     private static final String Y_ATTRIBUTE = "y";
-    private static final String DY_ATTRIBUTE = "dy";
     private static final String POINTS_ATTRIBUTE = "points";
     private static final String HREF_ATTRIBUTE = "href";
 
@@ -206,8 +204,7 @@ public class SvgWriter {
         if (!BranchEdge.LINE_EDGE.equals(edge.getType()) || !StringUtils.isEmpty(edgeLabel)) {
             writer.writeStartElement(GROUP_ELEMENT_NAME);
             switch (edge.getType()) {
-                case BranchEdge.PST_EDGE:
-                case BranchEdge.TWO_WT_EDGE:
+                case BranchEdge.PST_EDGE, BranchEdge.TWO_WT_EDGE:
                     draw2Wt(writer, edge);
                     break;
                 case BranchEdge.HVDC_LINE_EDGE:

--- a/network-area-diagram/src/test/java/com/powsybl/nad/svg/CustomLabelProviderTest.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/svg/CustomLabelProviderTest.java
@@ -31,14 +31,14 @@ class CustomLabelProviderTest extends AbstractTest {
     void setup() {
         setLayoutParameters(new LayoutParameters());
 
-        //Note: SvgParameters EdgeNameDisplayed, VoltageLevelDetails, and BusLegend must be true,
-        // for the edge names, the VL descriptions plus VL details, and bus descriptions to be rendered
+        //Note: sets SvgParameters EdgeNameDisplayed, VoltageLevelDetails, and BusLegend explicitly to false, to demonstrate that
+        // the custom label provider ignores them when rendering edge names, the VL descriptions, and VL details.
         setSvgParameters(new SvgParameters()
                 .setSvgWidthAndHeightAdded(true)
                 .setFixedWidth(800)
-                .setEdgeNameDisplayed(true)
-                .setVoltageLevelDetails(true)
-                .setBusLegend(true));
+                .setEdgeNameDisplayed(false)
+                .setVoltageLevelDetails(false)
+                .setBusLegend(false));
     }
 
     @Override

--- a/network-area-diagram/src/test/java/com/powsybl/nad/svg/TextNodeTest.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/svg/TextNodeTest.java
@@ -17,6 +17,7 @@ import com.powsybl.nad.svg.iidm.TopologicalStyleProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -47,12 +48,16 @@ class TextNodeTest extends AbstractTest {
         return new DefaultLabelProvider(network, getSvgParameters()) {
             @Override
             public List<String> getVoltageLevelDetails(VoltageLevelNode vlNode) {
-                VoltageLevel vl = network.getVoltageLevel(vlNode.getEquipmentId());
-                return List.of(
-                        vl.getLoadCount() + " loads",
-                        vl.getGeneratorCount() + " generators",
-                        vl.getBatteryCount() + " batteries",
-                        vl.getDanglingLineCount() + " dangling lines");
+                if (getSvgParameters().isVoltageLevelDetails()) {
+                    VoltageLevel vl = network.getVoltageLevel(vlNode.getEquipmentId());
+                    return List.of(
+                            vl.getLoadCount() + " loads",
+                            vl.getGeneratorCount() + " generators",
+                            vl.getBatteryCount() + " batteries",
+                            vl.getDanglingLineCount() + " dangling lines");
+                } else {
+                    return Collections.emptyList();
+                }
             }
         };
     }

--- a/network-area-diagram/src/test/resources/3wt_disconnected.svg
+++ b/network-area-diagram/src/test/resources/3wt_disconnected.svg
@@ -147,7 +147,6 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <foreignObject id="4-textnode" y="164.68" x="280.23" height="1" width="1">
             <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
                 <div>VL_33</div>
-                <table></table>
             </div>
         </foreignObject>
     </g>

--- a/network-area-diagram/src/test/resources/3wt_disconnected_topological.svg
+++ b/network-area-diagram/src/test/resources/3wt_disconnected_topological.svg
@@ -212,7 +212,6 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <foreignObject id="4-textnode" y="164.68" x="280.23" height="1" width="1">
             <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
                 <div>VL_33</div>
-                <table></table>
             </div>
         </foreignObject>
     </g>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_disconnection.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_disconnection.svg
@@ -734,7 +734,6 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <foreignObject id="10-textnode" y="379.24" x="212.11" height="1" width="1">
             <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
                 <div>VL14</div>
-                <table></table>
             </div>
         </foreignObject>
         <foreignObject id="11-textnode" y="-424.58" x="162.40" height="1" width="1">

--- a/network-area-diagram/src/test/resources/vl_description_id.svg
+++ b/network-area-diagram/src/test/resources/vl_description_id.svg
@@ -175,7 +175,15 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
         <polyline id="2-textedge" points="-200.75,-3.27 -130.42,-13.82"/>
     </g>
     <g class="nad-text-nodes">
-        <text id="0-textnode" y="-333.70" x="43.94">vl1</text>
-        <text id="2-textnode" y="-13.82" x="-130.42">vl2</text>
+        <foreignObject id="0-textnode" y="-358.70" x="43.94" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>vl1</div>
+            </div>
+        </foreignObject>
+        <foreignObject id="2-textnode" y="-38.82" x="-130.42" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>vl2</div>
+            </div>
+        </foreignObject>
     </g>
 </svg>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->

Fixes #680

Removes some NAD SVG parameters checking from the SvgWriter. The parameters involved are:

- edgeNameDisplayed (label along the branch edges)
- voltageLevelDetails (VL info box content)
- busLegend  (VL info box content)
 
The idea behind this PR is that the interpretation of those parameters should be a LabelProvider implementation's responsibility.
The DefaultLabelProvider has been changed, accordingly. The CustomLabelProvider simply ignores them (the content it provides is driven by the maps in its constructor, only).


Also in this PR: the simple rendering mode for the VL text nodes (i.e. the simple label) is removed from the SvgWriter. Now the detailed rendering mode is always used.



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
