### PR TITLE
[SLD] Fix missing style class for bus legend

### DIFF
--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/iidm/TopologicalStyleProvider.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/iidm/TopologicalStyleProvider.java
@@ -114,19 +114,11 @@ public class TopologicalStyleProvider extends AbstractVoltageStyleProvider {
         return busIdStyleMap;
     }
 
-    private List<String> getNodeTopologicalStyles(String baseVoltageName, String vlId, Node node) {
+    private String getNodeTopologicalStyle(String baseVoltageName, String vlId, Node node) {
         Map<String, String> busIdStyleMap = vlBusIdStyleMap.computeIfAbsent(vlId, k -> createBusIdStyleMap(baseVoltageName, vlId));
         Map<String, String> nodeIdStyleMap = vlNodeIdStyleMap.computeIfAbsent(vlId, k -> new HashMap<>());
         String nodeTopologicalStyle = nodeIdStyleMap.get(node.getId());
-        List<String> styles = new ArrayList<>();
-        styles.add(StyleClassConstants.STYLE_PREFIX + baseVoltageName);
-        if (nodeTopologicalStyle == null) {
-            nodeTopologicalStyle = findConnectedStyle(vlId, busIdStyleMap, nodeIdStyleMap, node);
-        }
-        if (nodeTopologicalStyle != null) {
-            styles.add(nodeTopologicalStyle);
-        }
-        return styles;
+        return nodeTopologicalStyle != null ? nodeTopologicalStyle : findConnectedStyle(vlId, busIdStyleMap, nodeIdStyleMap, node);
     }
 
     private String findConnectedStyle(String vlId, Map<String, String> busIdStyleMap, Map<String, String> nodeIdStyleMap, Node node) {
@@ -184,13 +176,16 @@ public class TopologicalStyleProvider extends AbstractVoltageStyleProvider {
 
     @Override
     public List<String> getNodeStyles(VoltageLevelInfos voltageLevelInfos, Node node) {
+        List<String> nodeStyles = new ArrayList<>();
+        getVoltageLevelStyle(voltageLevelInfos).ifPresent(nodeStyles::add);
         if (node.getType() == NodeType.SWITCH && ((SwitchNode) node).isOpen()) {
-            return List.of(StyleClassConstants.DISCONNECTED_STYLE_CLASS);
+            nodeStyles.add(StyleClassConstants.DISCONNECTED_STYLE_CLASS);
+        } else {
+            getBaseVoltageName(voltageLevelInfos)
+                    .map(baseVoltageName -> getNodeTopologicalStyle(baseVoltageName, voltageLevelInfos.getId(), node))
+                    .ifPresentOrElse(nodeStyles::add, () -> nodeStyles.add(StyleClassConstants.DISCONNECTED_STYLE_CLASS));
         }
-        return Optional.ofNullable(voltageLevelInfos)
-                .flatMap(vli -> baseVoltagesConfig.getBaseVoltageName(vli.getNominalVoltage(), BASE_VOLTAGE_PROFILE))
-                .map(baseVoltageName -> getNodeTopologicalStyles(baseVoltageName, voltageLevelInfos.getId(), node))
-                .orElse(List.of(StyleClassConstants.DISCONNECTED_STYLE_CLASS));
+        return nodeStyles;
     }
 
     @Override
@@ -200,9 +195,23 @@ public class TopologicalStyleProvider extends AbstractVoltageStyleProvider {
 
     @Override
     public List<String> getBusStyles(String busId, VoltageLevelGraph graph) {
+        List<String> busStyles = new ArrayList<>();
+        getVoltageLevelStyle(graph.getVoltageLevelInfos()).ifPresent(busStyles::add);
         String busStyle = vlBusIdStyleMap.getOrDefault(graph.getVoltageLevelInfos().getId(), Collections.emptyMap())
                 .getOrDefault(busId, null);
-        return busStyle != null ? List.of(busStyle, NODE_INFOS) : List.of(NODE_INFOS);
+        Optional.ofNullable(busStyle).ifPresent(busStyles::add);
+        busStyles.add(NODE_INFOS);
+        return busStyles;
+    }
+
+    private Optional<String> getVoltageLevelStyle(VoltageLevelInfos voltageLevelInfos) {
+        return getBaseVoltageName(voltageLevelInfos)
+                .map(baseVoltageName -> StyleClassConstants.STYLE_PREFIX + baseVoltageName);
+    }
+
+    private Optional<String> getBaseVoltageName(VoltageLevelInfos voltageLevelInfos) {
+        return Optional.ofNullable(voltageLevelInfos)
+                .flatMap(vli -> baseVoltagesConfig.getBaseVoltageName(vli.getNominalVoltage(), BASE_VOLTAGE_PROFILE));
     }
 
     @Override

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
@@ -122,7 +122,7 @@ public abstract class AbstractTestCase {
             SingleLineDiagram.draw(graph, writer, NullWriter.nullWriter(), componentLibrary, layoutParameters, svgParameters, labelProvider, styleProvider);
 
             if (debugSvgFiles) {
-                writeToFileInDebugDir(filename, writer);
+                writeToFileInDebugDir(filename.replace(".svg", "_new.svg"), writer);
             }
             if (overrideTestReferences) {
                 overrideTestReference(filename, writer);

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
@@ -122,7 +122,7 @@ public abstract class AbstractTestCase {
             SingleLineDiagram.draw(graph, writer, NullWriter.nullWriter(), componentLibrary, layoutParameters, svgParameters, labelProvider, styleProvider);
 
             if (debugSvgFiles) {
-                writeToFileInDebugDir(filename.replace(".svg", "_new.svg"), writer);
+                writeToFileInDebugDir(filename, writer);
             }
             if (overrideTestReferences) {
                 overrideTestReference(filename, writer);

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/CustomLabelProviderTest1.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/CustomLabelProviderTest1.svg
@@ -255,7 +255,7 @@
             <g class="sld-wire sld-vl300to500 sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_ground_95_ground">
                 <polyline points="65.0,142.0,65.0,90.0"/>
             </g>
-            <g class="sld-disconnector sld-open sld-disconnected" id="idgd" transform="translate(61.0,249.0)">
+            <g class="sld-disconnector sld-open sld-vl300to500 sld-disconnected" id="idgd" transform="translate(61.0,249.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
                 <text class="sld-label" id="idgd_95_N_95_LABEL" x="-5.0" y="-5.0">C_GD</text>

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/GroundDisconnectorsAndGround.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/GroundDisconnectorsAndGround.svg
@@ -263,7 +263,7 @@
             <g class="sld-wire sld-vl300to500 sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_ground_95_ground">
                 <polyline points="65.0,142.0,65.0,90.0"/>
             </g>
-            <g class="sld-disconnector sld-open sld-disconnected" id="idgd" transform="translate(61.0,249.0)">
+            <g class="sld-disconnector sld-open sld-vl300to500 sld-disconnected" id="idgd" transform="translate(61.0,249.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/GroundDisconnectorsAndGroundFlat.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/GroundDisconnectorsAndGroundFlat.svg
@@ -245,7 +245,7 @@
             <g class="sld-wire sld-vl300to500 sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_ground_95_ground">
                 <polyline points="65.0,142.0,65.0,90.0"/>
             </g>
-            <g class="sld-disconnector sld-open sld-disconnected" id="idgd" transform="translate(61.0,249.0)">
+            <g class="sld-disconnector sld-open sld-vl300to500 sld-disconnected" id="idgd" transform="translate(61.0,249.0)">
                 <rect height="8" rx="2" ry="2" width="8" x="0" y="0"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500 sld-disconnected" id="idINTERNAL_95_vl_95_gd_45_ground" transform="translate(61.0,219.0)">

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/NodeDecoratorsBranchStatusBusBreaker.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/NodeDecoratorsBranchStatusBusBreaker.svg
@@ -179,7 +179,7 @@
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500 sld-bus-0" id="idINTERNAL_95_VL1_95_BUSCO_95_B11_95_BR1_45_BR1" transform="translate(111.0,208.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-breaker sld-open sld-disconnected" id="idBR1" transform="translate(80.0,202.0)">
+            <g class="sld-breaker sld-open sld-vl300to500 sld-disconnected" id="idBR1" transform="translate(80.0,202.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
             </g>

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/TestBatteries.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/TestBatteries.svg
@@ -211,7 +211,7 @@
             <g class="sld-wire sld-vl300to500 sld-bus-0" id="_95_vl1_95_INTERNAL_95_vl1_95_BUSCO_95_bbs11_95_b2_45_b2_95_b2">
                 <polyline points="115.0,283.0,115.0,300.0"/>
             </g>
-            <g class="sld-wire sld-disconnected" id="_95_vl1_95_d2b_95_b2">
+            <g class="sld-wire sld-vl300to500 sld-disconnected" id="_95_vl1_95_d2b_95_b2">
                 <polyline points="115.0,337.0,115.0,320.0"/>
             </g>
             <g class="sld-wire sld-vl300to500 sld-disconnected" id="_95_vl1_95_d2b_95_INTERNAL_95_vl1_95_batt2">
@@ -236,11 +236,11 @@
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500 sld-bus-0" id="idINTERNAL_95_vl1_95_BUSCO_95_bbs11_95_b2_45_b2" transform="translate(111.0,279.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-breaker sld-open sld-disconnected" id="idb2" transform="translate(105.0,300.0)">
+            <g class="sld-breaker sld-open sld-vl300to500 sld-disconnected" id="idb2" transform="translate(105.0,300.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-disconnector sld-open sld-disconnected" id="idd2b" transform="translate(111.0,333.0)">
+            <g class="sld-disconnector sld-open sld-vl300to500 sld-disconnected" id="idd2b" transform="translate(111.0,333.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/TestBusBarOverVoltageLimitHightlight.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/TestBusBarOverVoltageLimitHightlight.svg
@@ -303,7 +303,7 @@
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl180to300 sld-bus-0" id="idINTERNAL_95_vl_95_d1_45_b1" transform="translate(61.0,246.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-breaker sld-open sld-disconnected" id="idb1" transform="translate(55.0,213.0)">
+            <g class="sld-breaker sld-open sld-vl180to300 sld-disconnected" id="idb1" transform="translate(55.0,213.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
@@ -328,7 +328,7 @@
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-breaker sld-open sld-disconnected" id="idb4" transform="translate(205.0,213.0)">
+            <g class="sld-breaker sld-open sld-vl180to300 sld-disconnected" id="idb4" transform="translate(205.0,213.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
@@ -387,7 +387,7 @@
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl180to300 sld-bus-0" id="idINTERNAL_95_vl_95_8" transform="translate(236.0,246.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-breaker sld-open sld-disconnected" id="idb4" transform="translate(205.0,213.0)">
+            <g class="sld-breaker sld-open sld-vl180to300 sld-disconnected" id="idb4" transform="translate(205.0,213.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/TestBusBarUnderVoltageLimitHightlight.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/TestBusBarUnderVoltageLimitHightlight.svg
@@ -303,7 +303,7 @@
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl180to300 sld-bus-0" id="idINTERNAL_95_vl_95_d1_45_b1" transform="translate(61.0,246.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-breaker sld-open sld-disconnected" id="idb1" transform="translate(55.0,213.0)">
+            <g class="sld-breaker sld-open sld-vl180to300 sld-disconnected" id="idb1" transform="translate(55.0,213.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
@@ -328,7 +328,7 @@
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-breaker sld-open sld-disconnected" id="idb4" transform="translate(205.0,213.0)">
+            <g class="sld-breaker sld-open sld-vl180to300 sld-disconnected" id="idb4" transform="translate(205.0,213.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
@@ -387,7 +387,7 @@
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl180to300 sld-bus-0" id="idINTERNAL_95_vl_95_8" transform="translate(236.0,246.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-breaker sld-open sld-disconnected" id="idb4" transform="translate(205.0,213.0)">
+            <g class="sld-breaker sld-open sld-vl180to300 sld-disconnected" id="idb4" transform="translate(205.0,213.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosTopological.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosTopological.svg
@@ -796,12 +796,12 @@
         </g>
         <g class="sld-legend">
             <g id="idNODE_95_vl1_95_0">
-                <circle class="sld-bus-0 sld-node-infos" cx="70.0" cy="519.0" id="idNODE_95_vl1_95_0_95_circle" r="10" stroke-width="10"/>
+                <circle class="sld-vl300to500 sld-bus-0 sld-node-infos" cx="70.0" cy="519.0" id="idNODE_95_vl1_95_0_95_circle" r="10" stroke-width="10"/>
                 <text class="sld-voltage sld-bus-legend-info" id="idNODE_95_vl1_95_0_95_v" x="60.0" y="544.0">392.0 kV</text>
                 <text class="sld-angle sld-bus-legend-info" id="idNODE_95_vl1_95_0_95_angle" x="60.0" y="559.0">-2.3°</text>
             </g>
             <g id="idNODE_95_vl1_95_2">
-                <circle class="sld-bus-1 sld-node-infos" cx="140.0" cy="519.0" id="idNODE_95_vl1_95_2_95_circle" r="10" stroke-width="10"/>
+                <circle class="sld-vl300to500 sld-bus-1 sld-node-infos" cx="140.0" cy="519.0" id="idNODE_95_vl1_95_2_95_circle" r="10" stroke-width="10"/>
                 <text class="sld-voltage sld-bus-legend-info" id="idNODE_95_vl1_95_2_95_v" x="130.0" y="544.0">403.0 kV</text>
                 <text class="sld-angle sld-bus-legend-info" id="idNODE_95_vl1_95_2_95_angle" x="130.0" y="559.0">-1.7°</text>
             </g>

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/TestCaseBusBreakerBusConnected.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/TestCaseBusBreakerBusConnected.svg
@@ -213,7 +213,7 @@
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl180to300 sld-bus-0" id="idINTERNAL_95_vlBb_95_BUSCO_95_b2_95_s23_45_s23" transform="translate(211.0,208.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-breaker sld-open sld-disconnected" id="ids23" transform="translate(180.0,202.0)">
+            <g class="sld-breaker sld-open sld-vl180to300 sld-disconnected" id="ids23" transform="translate(180.0,202.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
             </g>

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/TestCaseComplexExternCellOnFourSections.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/TestCaseComplexExternCellOnFourSections.svg
@@ -228,7 +228,7 @@
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl180to300 sld-bus-0" id="idINTERNAL_95_vl_95_d1_45_b1" transform="translate(61.0,246.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-breaker sld-open sld-disconnected" id="idb1" transform="translate(55.0,213.0)">
+            <g class="sld-breaker sld-open sld-vl180to300 sld-disconnected" id="idb1" transform="translate(55.0,213.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
@@ -253,7 +253,7 @@
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-breaker sld-open sld-disconnected" id="idb4" transform="translate(205.0,213.0)">
+            <g class="sld-breaker sld-open sld-vl180to300 sld-disconnected" id="idb4" transform="translate(205.0,213.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
@@ -312,7 +312,7 @@
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl180to300 sld-bus-0" id="idINTERNAL_95_vl_95_8" transform="translate(236.0,246.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-breaker sld-open sld-disconnected" id="idb4" transform="translate(205.0,213.0)">
+            <g class="sld-breaker sld-open sld-vl180to300 sld-disconnected" id="idb4" transform="translate(205.0,213.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/TestCaseComplexExternCellOnTwoSections.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/TestCaseComplexExternCellOnTwoSections.svg
@@ -226,7 +226,7 @@
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl180to300 sld-bus-0" id="idINTERNAL_95_vl_95_d1_45_b1" transform="translate(61.0,246.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-breaker sld-open sld-disconnected" id="idb1" transform="translate(55.0,213.0)">
+            <g class="sld-breaker sld-open sld-vl180to300 sld-disconnected" id="idb1" transform="translate(55.0,213.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/TestCaseLoadBreakSwitch.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/TestCaseLoadBreakSwitch.svg
@@ -173,7 +173,7 @@
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500 sld-bus-0" id="idINTERNAL_95_vl_95_BUSCO_95_bbs_95_b1_45_b1" transform="translate(111.0,208.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-load-break-switch sld-open sld-disconnected" id="idb1" transform="translate(80.0,202.0)">
+            <g class="sld-load-break-switch sld-open sld-vl300to500 sld-disconnected" id="idb1" transform="translate(80.0,202.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15 M1,19 19,1" transform="rotate(90.0,10.0,10.0)"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15 M1,19 19,1" transform="rotate(90.0,10.0,10.0)"/>
             </g>
@@ -289,22 +289,22 @@
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500 sld-bus-0" id="idINTERNAL_95_vl_95_BUSCO_95_bbs_95_b2_45_b2" transform="translate(211.0,303.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-load-break-switch sld-open sld-disconnected" id="idb2" transform="translate(205.0,324.0)">
+            <g class="sld-load-break-switch sld-open sld-vl300to500 sld-disconnected" id="idb2" transform="translate(205.0,324.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15 M1,19 19,1"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15 M1,19 19,1"/>
             </g>
             <g class="sld-two-wt" id="idT11" transform="translate(210.0,353.5)">
-                <circle class="sld-disconnected sld-winding" cx="5" cy="10" r="5" transform="rotate(180.0,5.0,7.5)"/>
-                <circle class="sld-disconnected sld-winding" cx="5" cy="5" r="5" transform="rotate(180.0,5.0,7.5)"/>
+                <circle class="sld-vl300to500 sld-disconnected sld-winding" cx="5" cy="10" r="5" transform="rotate(180.0,5.0,7.5)"/>
+                <circle class="sld-vl300to500 sld-disconnected sld-winding" cx="5" cy="5" r="5" transform="rotate(180.0,5.0,7.5)"/>
             </g>
-            <g class="sld-load-break-switch sld-open sld-disconnected" id="idb4" transform="translate(205.0,378.0)">
+            <g class="sld-load-break-switch sld-open sld-vl300to500 sld-disconnected" id="idb4" transform="translate(205.0,378.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15 M1,19 19,1"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15 M1,19 19,1"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500 sld-disconnected" id="idINTERNAL_95_vl_95_5" transform="translate(236.0,411.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-load-break-switch sld-open sld-disconnected" id="idb3" transform="translate(255.0,351.0)">
+            <g class="sld-load-break-switch sld-open sld-vl300to500 sld-disconnected" id="idb3" transform="translate(255.0,351.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15 M1,19 19,1"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15 M1,19 19,1"/>
             </g>
@@ -314,14 +314,14 @@
             <g class="sld-bus-connection sld-fictitious sld-vl300to500 sld-disconnected" id="idBUSCO_95_bbs2_95_b3" transform="translate(261.0,273.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-load-break-switch sld-open sld-disconnected" id="idb5" transform="translate(230.0,432.0)">
+            <g class="sld-load-break-switch sld-open sld-vl300to500 sld-disconnected" id="idb5" transform="translate(230.0,432.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15 M1,19 19,1"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15 M1,19 19,1"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500 sld-disconnected" id="idINTERNAL_95_vl_95_l_95_fork" transform="translate(211.0,465.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-load-break-switch sld-open sld-disconnected" id="idb" transform="translate(155.0,378.0)">
+            <g class="sld-load-break-switch sld-open sld-vl300to500 sld-disconnected" id="idb" transform="translate(155.0,378.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15 M1,19 19,1"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15 M1,19 19,1"/>
             </g>

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/TestCaseNodeBreakerBbsConnected.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/TestCaseNodeBreakerBbsConnected.svg
@@ -214,7 +214,7 @@
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-disconnector sld-open sld-disconnected" id="idsLoad" transform="translate(111.0,248.0)">
+            <g class="sld-disconnector sld-open sld-vl180to300 sld-disconnected" id="idsLoad" transform="translate(111.0,248.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/TestComplexParallelLegsInternalPst.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/TestComplexParallelLegsInternalPst.svg
@@ -207,19 +207,19 @@
             </g>
             <g class="sld-pst" id="idtrf3" transform="translate(59.0,179.5)">
                 <path class="sld-vl300to500 sld-bus-0 sld-winding" d="M0.59 10.43 a6 6 0 1 0 10.82 0 A7 7 0 0 1 4.8 12.9 L3.36 15.9 L1.55 15 L2.9 12.25 A7 7 0 0 1 0.59 10.43z" transform="rotate(180.0,6.0,9.5)"/>
-                <path class="sld-disconnected sld-winding" d="M3.3 11.35 L6 5.55 3.4 6.5 2.7 4.6 8.6 2.5 10.7 8.4 8.8 9.1 7.85 6.4 5.2 11.94 A6 6 0 1 0 3.3 11.35z" transform="rotate(180.0,6.0,9.5)"/>
+                <path class="sld-vl300to500 sld-disconnected sld-winding" d="M3.3 11.35 L6 5.55 3.4 6.5 2.7 4.6 8.6 2.5 10.7 8.4 8.8 9.1 7.85 6.4 5.2 11.94 A6 6 0 1 0 3.3 11.35z" transform="rotate(180.0,6.0,9.5)"/>
             </g>
-            <g class="sld-breaker sld-open sld-disconnected" id="iddpst" transform="translate(57.0,208.0)">
+            <g class="sld-breaker sld-open sld-vl300to500 sld-disconnected" id="iddpst" transform="translate(57.0,208.0)">
                 <path class="sld-sw-closed" d="M16,5 c0,-2.8 -2.2,-5 -5,-5 h-6 c-2.8,0 -5,2.2 -5,5 v6 c0,2.8 2.2,5 5,5 h6 c2.8,0 5,-2.2 5,-5z M6.4,3.2 h3.2 v9.6 h-3.2z"/>
                 <path class="sld-sw-open" d="M16,5 c0,-2.8 -2.2,-5 -5,-5 h-6 c-2.8,0 -5,2.2 -5,5 v6 c0,2.8 2.2,5 5,5 h6 c2.8,0 5,-2.2 5,-5z M12.8,6.4 v3.2 h-9.6 v-3.2Z"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500 sld-disconnected" id="idINTERNAL_95_vl1_95_5" transform="translate(86.0,239.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-disconnector sld-open sld-disconnected" id="idd1b" transform="translate(111.0,76.0)">
+            <g class="sld-disconnector sld-open sld-vl300to500 sld-disconnected" id="idd1b" transform="translate(111.0,76.0)">
                 <rect height="8" rx="2" ry="2" width="8" x="0" y="0"/>
             </g>
-            <g class="sld-disconnector sld-open sld-disconnected" id="idd2b" transform="translate(111.0,101.0)">
+            <g class="sld-disconnector sld-open sld-vl300to500 sld-disconnected" id="idd2b" transform="translate(111.0,101.0)">
                 <rect height="8" rx="2" ry="2" width="8" x="0" y="0"/>
             </g>
             <g class="sld-breaker sld-closed sld-vl300to500 sld-disconnected" id="idbl" transform="translate(82.0,262.0)">

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/TestInternCellDifferentSubsections.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/TestInternCellDifferentSubsections.svg
@@ -171,14 +171,14 @@
             <g class="sld-wire sld-vl300to500 sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_d1_45_d2_95_d2">
                 <polyline points="90.0,70.0,165.0,70.0,165.0,110.0"/>
             </g>
-            <g class="sld-disconnector sld-open sld-disconnected" id="idd1" transform="translate(61.0,106.0)">
+            <g class="sld-disconnector sld-open sld-vl300to500 sld-disconnected" id="idd1" transform="translate(61.0,106.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500 sld-disconnected" id="idINTERNAL_95_vl_95_d1_45_d2" transform="translate(86.0,66.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-disconnector sld-open sld-disconnected" id="idd2" transform="translate(161.0,106.0)">
+            <g class="sld-disconnector sld-open sld-vl300to500 sld-disconnected" id="idd2" transform="translate(161.0,106.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/TestOneLegInternCellDifferentSubsectionsLbs.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/TestOneLegInternCellDifferentSubsectionsLbs.svg
@@ -181,7 +181,7 @@
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500 sld-bus-0" id="idINTERNAL_95_vl_95_11" transform="translate(111.0,208.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-disconnector sld-open sld-disconnected" id="idd12" transform="translate(111.0,273.0)">
+            <g class="sld-disconnector sld-open sld-vl300to500 sld-disconnected" id="idd12" transform="translate(111.0,273.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
@@ -220,7 +220,7 @@
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500 sld-bus-0" id="idINTERNAL_95_vl_95_dl11_45_load" transform="translate(61.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-disconnector sld-open sld-disconnected" id="iddl121" transform="translate(61.0,273.0)">
+            <g class="sld-disconnector sld-open sld-vl300to500 sld-disconnected" id="iddl121" transform="translate(61.0,273.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/TestOneLegInternCellDifferentSubsectionsSi.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/TestOneLegInternCellDifferentSubsectionsSi.svg
@@ -174,7 +174,7 @@
             <g class="sld-wire sld-vl300to500 sld-bus-1" id="_95_vl_95_d21_95_INTERNAL_95_vl_95_11">
                 <polyline points="165.0,252.0,165.0,212.0,115.0,212.0"/>
             </g>
-            <g class="sld-disconnector sld-open sld-disconnected" id="idd11" transform="translate(111.0,248.0)">
+            <g class="sld-disconnector sld-open sld-vl300to500 sld-disconnected" id="idd11" transform="translate(111.0,248.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/TestTieLineSubstation.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/TestTieLineSubstation.svg
@@ -176,7 +176,7 @@
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500 sld-bus-0" id="idINTERNAL_95_VL1_95_BUSCO_95_B11_95_BR1_45_BR1" transform="translate(171.0,268.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-breaker sld-open sld-disconnected" id="idBR1" transform="translate(140.0,262.0)">
+            <g class="sld-breaker sld-open sld-vl300to500 sld-disconnected" id="idBR1" transform="translate(140.0,262.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
             </g>

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/TestTieLineSubstationUnifiedColors.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/TestTieLineSubstationUnifiedColors.svg
@@ -176,7 +176,7 @@
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500 sld-bus-0" id="idINTERNAL_95_VL1_95_BUSCO_95_B11_95_BR1_45_BR1" transform="translate(171.0,268.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-breaker sld-open sld-disconnected" id="idBR1" transform="translate(140.0,262.0)">
+            <g class="sld-breaker sld-open sld-vl300to500 sld-disconnected" id="idBR1" transform="translate(140.0,262.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
             </g>

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/TestTieLineVoltageLevel.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/TestTieLineVoltageLevel.svg
@@ -173,7 +173,7 @@
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500 sld-bus-0" id="idINTERNAL_95_VL1_95_BUSCO_95_B11_95_BR1_45_BR1" transform="translate(111.0,208.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-breaker sld-open sld-disconnected" id="idBR1" transform="translate(80.0,202.0)">
+            <g class="sld-breaker sld-open sld-vl300to500 sld-disconnected" id="idBR1" transform="translate(80.0,202.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
             </g>

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/TestUnknownLibrary.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/TestUnknownLibrary.svg
@@ -804,12 +804,12 @@
         </g>
         <g class="sld-legend">
             <g id="idNODE_95_vl1_95_0">
-                <circle class="sld-bus-0 sld-node-infos" cx="70.0" cy="519.0" id="idNODE_95_vl1_95_0_95_circle" r="10" stroke-width="10"/>
+                <circle class="sld-vl300to500 sld-bus-0 sld-node-infos" cx="70.0" cy="519.0" id="idNODE_95_vl1_95_0_95_circle" r="10" stroke-width="10"/>
                 <text class="sld-voltage sld-bus-legend-info" id="idNODE_95_vl1_95_0_95_v" x="60.0" y="544.0">— kV</text>
                 <text class="sld-angle sld-bus-legend-info" id="idNODE_95_vl1_95_0_95_angle" x="60.0" y="559.0">—°</text>
             </g>
             <g id="idNODE_95_vl1_95_2">
-                <circle class="sld-bus-1 sld-node-infos" cx="140.0" cy="519.0" id="idNODE_95_vl1_95_2_95_circle" r="10" stroke-width="10"/>
+                <circle class="sld-vl300to500 sld-bus-1 sld-node-infos" cx="140.0" cy="519.0" id="idNODE_95_vl1_95_2_95_circle" r="10" stroke-width="10"/>
                 <text class="sld-voltage sld-bus-legend-info" id="idNODE_95_vl1_95_2_95_v" x="130.0" y="544.0">— kV</text>
                 <text class="sld-angle sld-bus-legend-info" id="idNODE_95_vl1_95_2_95_angle" x="130.0" y="559.0">—°</text>
             </g>

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/VerticalInternalPstBranchStatusNodeBreaker.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/VerticalInternalPstBranchStatusNodeBreaker.svg
@@ -224,24 +224,24 @@
             </g>
             <g class="sld-pst" id="idtrf3" transform="translate(58.0,181.5)">
                 <circle class="sld-vl300to500 sld-bus-0 sld-winding" cx="7" cy="10" r="5" transform="rotate(180.0,7.0,7.5)"/>
-                <circle class="sld-disconnected sld-winding" cx="7" cy="5" r="5" transform="rotate(180.0,7.0,7.5)"/>
+                <circle class="sld-vl300to500 sld-disconnected sld-winding" cx="7" cy="5" r="5" transform="rotate(180.0,7.0,7.5)"/>
                 <path class="sld-vl300to500 sld-bus-0 sld-pst-arrow" d="M14,0 0,14 M11,0 14,0 14,3" transform="rotate(180.0,7.0,7.5)"/>
                 <g class="sld-flash">
                     <path class="sld-vl300to500 sld-bus-0" d="M 5.5,14.5 8.5,6.36 4.32,5.83 4.2,0.3 1.3,8.47 5.4,8.99 Z" transform="translate(17.0,0.0)"/>
                 </g>
             </g>
-            <g class="sld-breaker sld-open sld-disconnected" id="iddpst" transform="translate(55.0,206.0)">
+            <g class="sld-breaker sld-open sld-vl300to500 sld-disconnected" id="iddpst" transform="translate(55.0,206.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500 sld-disconnected" id="idINTERNAL_95_vl1_95_5" transform="translate(86.0,239.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-disconnector sld-open sld-disconnected" id="idd1b" transform="translate(111.0,76.0)">
+            <g class="sld-disconnector sld-open sld-vl300to500 sld-disconnected" id="idd1b" transform="translate(111.0,76.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
-            <g class="sld-disconnector sld-open sld-disconnected" id="idd2b" transform="translate(111.0,101.0)">
+            <g class="sld-disconnector sld-open sld-vl300to500 sld-disconnected" id="idd2b" transform="translate(111.0,101.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/consecutive_shunts.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/consecutive_shunts.svg
@@ -347,7 +347,7 @@
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
                 <text class="sld-label" id="idFN_95_NW" text-anchor="middle" x="4.0" y="-1.0">FN</text>
             </g>
-            <g class="sld-breaker sld-open sld-disconnected" id="idDJ" transform="translate(530.0,400.85714285714283)">
+            <g class="sld-breaker sld-open sld-vl70to120 sld-disconnected" id="idDJ" transform="translate(530.0,400.85714285714283)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
                 <text class="sld-label" id="idDJ_95_NW" text-anchor="middle" x="4.0" y="-1.0">DJ</text>
@@ -512,7 +512,7 @@
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
                 <text class="sld-label" id="idCL_95_NW" text-anchor="middle" x="4.0" y="-1.0">CL</text>
             </g>
-            <g class="sld-breaker sld-open sld-disconnected" id="idDH" transform="translate(555.0,392.5)">
+            <g class="sld-breaker sld-open sld-vl70to120 sld-disconnected" id="idDH" transform="translate(555.0,392.5)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
                 <text class="sld-label" id="idDH_95_NW" text-anchor="middle" x="4.0" y="-1.0">DH</text>

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/disconnectedComponentsBusBreaker.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/disconnectedComponentsBusBreaker.svg
@@ -179,7 +179,7 @@
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500 sld-bus-0" id="idINTERNAL_95_VL1_95_BUSCO_95_B11_95_BR1_45_BR1" transform="translate(111.0,208.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-breaker sld-open sld-disconnected" id="idBR1" transform="translate(80.0,202.0)">
+            <g class="sld-breaker sld-open sld-vl300to500 sld-disconnected" id="idBR1" transform="translate(80.0,202.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
             </g>

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/topological_style_substation.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/topological_style_substation.svg
@@ -322,7 +322,7 @@
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl180to300 sld-disconnected" id="idINTERNAL_95_vl2_95_d2WT_95_2_45_b2WT_95_2" transform="translate(251.0,248.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-breaker sld-open sld-fictitious sld-disconnected" id="idb2WT_95_2" transform="translate(245.0,202.0)">
+            <g class="sld-breaker sld-open sld-fictitious sld-vl180to300 sld-disconnected" id="idb2WT_95_2" transform="translate(245.0,202.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
@@ -363,7 +363,7 @@
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl180to300 sld-disconnected" id="idINTERNAL_95_vl2_95_d3WT_95_2_45_b3WT_95_2" transform="translate(301.0,248.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-breaker sld-open sld-fictitious sld-disconnected" id="idb3WT_95_2" transform="translate(295.0,202.0)">
+            <g class="sld-breaker sld-open sld-fictitious sld-vl180to300 sld-disconnected" id="idb3WT_95_2" transform="translate(295.0,202.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior?**
With TopologicalStyleProvider, circle in bus legend info is black instead of the bus color 

**What is the new behavior (if this is a feature change)?**
Circle in bus legend info takes the colour of the corresponding bus

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
