### PR TITLE
[SLD] Fix optimized svg

### DIFF
--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
@@ -1109,7 +1109,7 @@ public class DefaultSVGWriter implements SVGWriter {
         for (Map.Entry<String, List<Element>> subComponent : subComponents.entrySet()) {
             if (subComponents.size() > 1) {
                 Element subComponentGroup = group.getOwnerDocument().createElement("g");
-                subComponentGroup.setAttribute("id", IdUtil.escapeId(getHRefValue(subComponents.size(), componentType, subComponent.getKey())));
+                subComponentGroup.setAttribute("id", getHRefValue(subComponents.size(), componentType, subComponent.getKey()));
                 addSvgSubComponentsToElement(subComponent.getValue(), subComponentGroup);
                 group.getOwnerDocument().adoptNode(subComponentGroup);
                 group.appendChild(subComponentGroup);

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
@@ -1091,7 +1091,7 @@ public class DefaultSVGWriter implements SVGWriter {
                 Map<String, List<Element>> subComponents = componentLibrary.getSvgElements(c);
                 if (subComponents != null) {
                     Element group = document.createElement(GROUP);
-                    group.setAttribute("id", IdUtil.escapeId(c));
+                    group.setAttribute("id", c);
 
                     insertSVGComponentIntoDefsArea(c, group, subComponents);
 

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/substation_optimized.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/substation_optimized.svg
@@ -72,12 +72,12 @@
 .sld-ground-disconnection .sld-sw-closed {stroke: black; fill: none}
 ]]></style>
     <defs>
-        <g id="idGENERATOR">
+        <g id="GENERATOR">
             <circle cx="6" cy="6" r="6"/>
             <path d="M6,6 A 6 40 0 0 0 2,6"/>
             <path d="M6,6 A 6 40 0 0 0 10,6"/>
         </g>
-        <g id="idARROW_95_REACTIVE">
+        <g id="ARROW_REACTIVE">
             <g id="idARROW_95_REACTIVE_45_UP">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
@@ -85,12 +85,12 @@
                 <polygon points="0,0 10,0 5,10"/>
             </g>
         </g>
-        <g id="idLOAD">
+        <g id="LOAD">
             <rect height="9" width="16"/>
             <line x1="0" x2="16" y1="0" y2="9"/>
             <line x1="16" x2="0" y1="0" y2="9"/>
         </g>
-        <g id="idARROW_95_ACTIVE">
+        <g id="ARROW_ACTIVE">
             <g id="idARROW_95_ACTIVE_45_UP">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
@@ -98,7 +98,7 @@
                 <polygon points="0,0 10,0 5,10"/>
             </g>
         </g>
-        <g id="idDISCONNECTOR">
+        <g id="DISCONNECTOR">
             <g id="idDISCONNECTOR_45_CLOSED">
                 <path d="M0,0 8,8 M8,0 0,8"/>
             </g>
@@ -106,13 +106,13 @@
                 <path d="M8,0 0,8"/>
             </g>
         </g>
-        <g id="idCAPACITOR">
+        <g id="CAPACITOR">
             <line x1="6" x2="6" y1="0" y2="4.5"/>
             <line x1="0" x2="12" y1="4.5" y2="4.5"/>
             <line x1="0" x2="12" y1="7.5" y2="7.5"/>
             <line x1="6" x2="6" y1="7.5" y2="12"/>
         </g>
-        <g id="idTWO_95_WINDINGS_95_TRANSFORMER">
+        <g id="TWO_WINDINGS_TRANSFORMER">
             <g id="idTWO_95_WINDINGS_95_TRANSFORMER_45_WINDING1">
                 <circle cx="5" cy="10" r="5"/>
             </g>
@@ -120,7 +120,7 @@
                 <circle cx="5" cy="5" r="5"/>
             </g>
         </g>
-        <g id="idTHREE_95_WINDINGS_95_TRANSFORMER">
+        <g id="THREE_WINDINGS_TRANSFORMER">
             <g id="idTHREE_95_WINDINGS_95_TRANSFORMER_45_WINDING1">
                 <circle cx="5" cy="15" r="5"/>
             </g>
@@ -131,7 +131,7 @@
                 <circle cx="8" cy="19" r="5"/>
             </g>
         </g>
-        <g id="idBREAKER">
+        <g id="BREAKER">
             <g id="idBREAKER_45_CLOSED">
                 <path d="M1,1 V19 H19 V1z M10,5 V15"/>
             </g>

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/substation_optimized.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/substation_optimized.svg
@@ -78,10 +78,10 @@
             <path d="M6,6 A 6 40 0 0 0 10,6"/>
         </g>
         <g id="ARROW_REACTIVE">
-            <g id="idARROW_95_REACTIVE_45_UP">
+            <g id="ARROW_REACTIVE-UP">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
-            <g id="idARROW_95_REACTIVE_45_DOWN">
+            <g id="ARROW_REACTIVE-DOWN">
                 <polygon points="0,0 10,0 5,10"/>
             </g>
         </g>
@@ -91,18 +91,18 @@
             <line x1="16" x2="0" y1="0" y2="9"/>
         </g>
         <g id="ARROW_ACTIVE">
-            <g id="idARROW_95_ACTIVE_45_UP">
+            <g id="ARROW_ACTIVE-UP">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
-            <g id="idARROW_95_ACTIVE_45_DOWN">
+            <g id="ARROW_ACTIVE-DOWN">
                 <polygon points="0,0 10,0 5,10"/>
             </g>
         </g>
         <g id="DISCONNECTOR">
-            <g id="idDISCONNECTOR_45_CLOSED">
+            <g id="DISCONNECTOR-CLOSED">
                 <path d="M0,0 8,8 M8,0 0,8"/>
             </g>
-            <g id="idDISCONNECTOR_45_OPEN">
+            <g id="DISCONNECTOR-OPEN">
                 <path d="M8,0 0,8"/>
             </g>
         </g>
@@ -113,29 +113,29 @@
             <line x1="6" x2="6" y1="7.5" y2="12"/>
         </g>
         <g id="TWO_WINDINGS_TRANSFORMER">
-            <g id="idTWO_95_WINDINGS_95_TRANSFORMER_45_WINDING1">
+            <g id="TWO_WINDINGS_TRANSFORMER-WINDING1">
                 <circle cx="5" cy="10" r="5"/>
             </g>
-            <g id="idTWO_95_WINDINGS_95_TRANSFORMER_45_WINDING2">
+            <g id="TWO_WINDINGS_TRANSFORMER-WINDING2">
                 <circle cx="5" cy="5" r="5"/>
             </g>
         </g>
         <g id="THREE_WINDINGS_TRANSFORMER">
-            <g id="idTHREE_95_WINDINGS_95_TRANSFORMER_45_WINDING1">
+            <g id="THREE_WINDINGS_TRANSFORMER-WINDING1">
                 <circle cx="5" cy="15" r="5"/>
             </g>
-            <g id="idTHREE_95_WINDINGS_95_TRANSFORMER_45_WINDING2">
+            <g id="THREE_WINDINGS_TRANSFORMER-WINDING2">
                 <circle cx="11" cy="15" r="5"/>
             </g>
-            <g id="idTHREE_95_WINDINGS_95_TRANSFORMER_45_WINDING3">
+            <g id="THREE_WINDINGS_TRANSFORMER-WINDING3">
                 <circle cx="8" cy="19" r="5"/>
             </g>
         </g>
         <g id="BREAKER">
-            <g id="idBREAKER_45_CLOSED">
+            <g id="BREAKER-CLOSED">
                 <path d="M1,1 V19 H19 V1z M10,5 V15"/>
             </g>
-            <g id="idBREAKER_45_OPEN">
+            <g id="BREAKER-OPEN">
                 <path d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
         </g>

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/vl1_multiline_tooltip.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/vl1_multiline_tooltip.svg
@@ -72,7 +72,7 @@
 .sld-ground-disconnection .sld-sw-closed {stroke: black; fill: none}
 ]]></style>
     <defs>
-        <g id="idARROW_95_REACTIVE">
+        <g id="ARROW_REACTIVE">
             <g id="idARROW_95_REACTIVE_45_UP">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
@@ -80,12 +80,12 @@
                 <polygon points="0,0 10,0 5,10"/>
             </g>
         </g>
-        <g id="idLOAD">
+        <g id="LOAD">
             <rect height="9" width="16"/>
             <line x1="0" x2="16" y1="0" y2="9"/>
             <line x1="16" x2="0" y1="0" y2="9"/>
         </g>
-        <g id="idARROW_95_ACTIVE">
+        <g id="ARROW_ACTIVE">
             <g id="idARROW_95_ACTIVE_45_UP">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
@@ -93,7 +93,7 @@
                 <polygon points="0,0 10,0 5,10"/>
             </g>
         </g>
-        <g id="idDISCONNECTOR">
+        <g id="DISCONNECTOR">
             <g id="idDISCONNECTOR_45_CLOSED">
                 <path d="M0,0 8,8 M8,0 0,8"/>
             </g>
@@ -101,7 +101,7 @@
                 <path d="M8,0 0,8"/>
             </g>
         </g>
-        <g id="idTWO_95_WINDINGS_95_TRANSFORMER">
+        <g id="TWO_WINDINGS_TRANSFORMER">
             <g id="idTWO_95_WINDINGS_95_TRANSFORMER_45_WINDING1">
                 <circle cx="5" cy="10" r="5"/>
             </g>
@@ -109,7 +109,7 @@
                 <circle cx="5" cy="5" r="5"/>
             </g>
         </g>
-        <g id="idTHREE_95_WINDINGS_95_TRANSFORMER">
+        <g id="THREE_WINDINGS_TRANSFORMER">
             <g id="idTHREE_95_WINDINGS_95_TRANSFORMER_45_WINDING1">
                 <circle cx="5" cy="15" r="5"/>
             </g>
@@ -120,7 +120,7 @@
                 <circle cx="8" cy="19" r="5"/>
             </g>
         </g>
-        <g id="idBREAKER">
+        <g id="BREAKER">
             <g id="idBREAKER_45_CLOSED">
                 <path d="M1,1 V19 H19 V1z M10,5 V15"/>
             </g>

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/vl1_multiline_tooltip.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/vl1_multiline_tooltip.svg
@@ -73,10 +73,10 @@
 ]]></style>
     <defs>
         <g id="ARROW_REACTIVE">
-            <g id="idARROW_95_REACTIVE_45_UP">
+            <g id="ARROW_REACTIVE-UP">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
-            <g id="idARROW_95_REACTIVE_45_DOWN">
+            <g id="ARROW_REACTIVE-DOWN">
                 <polygon points="0,0 10,0 5,10"/>
             </g>
         </g>
@@ -86,45 +86,45 @@
             <line x1="16" x2="0" y1="0" y2="9"/>
         </g>
         <g id="ARROW_ACTIVE">
-            <g id="idARROW_95_ACTIVE_45_UP">
+            <g id="ARROW_ACTIVE-UP">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
-            <g id="idARROW_95_ACTIVE_45_DOWN">
+            <g id="ARROW_ACTIVE-DOWN">
                 <polygon points="0,0 10,0 5,10"/>
             </g>
         </g>
         <g id="DISCONNECTOR">
-            <g id="idDISCONNECTOR_45_CLOSED">
+            <g id="DISCONNECTOR-CLOSED">
                 <path d="M0,0 8,8 M8,0 0,8"/>
             </g>
-            <g id="idDISCONNECTOR_45_OPEN">
+            <g id="DISCONNECTOR-OPEN">
                 <path d="M8,0 0,8"/>
             </g>
         </g>
         <g id="TWO_WINDINGS_TRANSFORMER">
-            <g id="idTWO_95_WINDINGS_95_TRANSFORMER_45_WINDING1">
+            <g id="TWO_WINDINGS_TRANSFORMER-WINDING1">
                 <circle cx="5" cy="10" r="5"/>
             </g>
-            <g id="idTWO_95_WINDINGS_95_TRANSFORMER_45_WINDING2">
+            <g id="TWO_WINDINGS_TRANSFORMER-WINDING2">
                 <circle cx="5" cy="5" r="5"/>
             </g>
         </g>
         <g id="THREE_WINDINGS_TRANSFORMER">
-            <g id="idTHREE_95_WINDINGS_95_TRANSFORMER_45_WINDING1">
+            <g id="THREE_WINDINGS_TRANSFORMER-WINDING1">
                 <circle cx="5" cy="15" r="5"/>
             </g>
-            <g id="idTHREE_95_WINDINGS_95_TRANSFORMER_45_WINDING2">
+            <g id="THREE_WINDINGS_TRANSFORMER-WINDING2">
                 <circle cx="11" cy="15" r="5"/>
             </g>
-            <g id="idTHREE_95_WINDINGS_95_TRANSFORMER_45_WINDING3">
+            <g id="THREE_WINDINGS_TRANSFORMER-WINDING3">
                 <circle cx="8" cy="19" r="5"/>
             </g>
         </g>
         <g id="BREAKER">
-            <g id="idBREAKER_45_CLOSED">
+            <g id="BREAKER-CLOSED">
                 <path d="M1,1 V19 H19 V1z M10,5 V15"/>
             </g>
-            <g id="idBREAKER_45_OPEN">
+            <g id="BREAKER-OPEN">
                 <path d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
         </g>

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/vl1_optimized.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/vl1_optimized.svg
@@ -72,7 +72,7 @@
 .sld-ground-disconnection .sld-sw-closed {stroke: black; fill: none}
 ]]></style>
     <defs>
-        <g id="idARROW_95_REACTIVE">
+        <g id="ARROW_REACTIVE">
             <g id="idARROW_95_REACTIVE_45_UP">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
@@ -80,12 +80,12 @@
                 <polygon points="0,0 10,0 5,10"/>
             </g>
         </g>
-        <g id="idLOAD">
+        <g id="LOAD">
             <rect height="9" width="16"/>
             <line x1="0" x2="16" y1="0" y2="9"/>
             <line x1="16" x2="0" y1="0" y2="9"/>
         </g>
-        <g id="idARROW_95_ACTIVE">
+        <g id="ARROW_ACTIVE">
             <g id="idARROW_95_ACTIVE_45_UP">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
@@ -93,7 +93,7 @@
                 <polygon points="0,0 10,0 5,10"/>
             </g>
         </g>
-        <g id="idDISCONNECTOR">
+        <g id="DISCONNECTOR">
             <g id="idDISCONNECTOR_45_CLOSED">
                 <path d="M0,0 8,8 M8,0 0,8"/>
             </g>
@@ -101,7 +101,7 @@
                 <path d="M8,0 0,8"/>
             </g>
         </g>
-        <g id="idTWO_95_WINDINGS_95_TRANSFORMER">
+        <g id="TWO_WINDINGS_TRANSFORMER">
             <g id="idTWO_95_WINDINGS_95_TRANSFORMER_45_WINDING1">
                 <circle cx="5" cy="10" r="5"/>
             </g>
@@ -109,7 +109,7 @@
                 <circle cx="5" cy="5" r="5"/>
             </g>
         </g>
-        <g id="idTHREE_95_WINDINGS_95_TRANSFORMER">
+        <g id="THREE_WINDINGS_TRANSFORMER">
             <g id="idTHREE_95_WINDINGS_95_TRANSFORMER_45_WINDING1">
                 <circle cx="5" cy="15" r="5"/>
             </g>
@@ -120,7 +120,7 @@
                 <circle cx="8" cy="19" r="5"/>
             </g>
         </g>
-        <g id="idBREAKER">
+        <g id="BREAKER">
             <g id="idBREAKER_45_CLOSED">
                 <path d="M1,1 V19 H19 V1z M10,5 V15"/>
             </g>

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/vl1_optimized.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/vl1_optimized.svg
@@ -73,10 +73,10 @@
 ]]></style>
     <defs>
         <g id="ARROW_REACTIVE">
-            <g id="idARROW_95_REACTIVE_45_UP">
+            <g id="ARROW_REACTIVE-UP">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
-            <g id="idARROW_95_REACTIVE_45_DOWN">
+            <g id="ARROW_REACTIVE-DOWN">
                 <polygon points="0,0 10,0 5,10"/>
             </g>
         </g>
@@ -86,45 +86,45 @@
             <line x1="16" x2="0" y1="0" y2="9"/>
         </g>
         <g id="ARROW_ACTIVE">
-            <g id="idARROW_95_ACTIVE_45_UP">
+            <g id="ARROW_ACTIVE-UP">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
-            <g id="idARROW_95_ACTIVE_45_DOWN">
+            <g id="ARROW_ACTIVE-DOWN">
                 <polygon points="0,0 10,0 5,10"/>
             </g>
         </g>
         <g id="DISCONNECTOR">
-            <g id="idDISCONNECTOR_45_CLOSED">
+            <g id="DISCONNECTOR-CLOSED">
                 <path d="M0,0 8,8 M8,0 0,8"/>
             </g>
-            <g id="idDISCONNECTOR_45_OPEN">
+            <g id="DISCONNECTOR-OPEN">
                 <path d="M8,0 0,8"/>
             </g>
         </g>
         <g id="TWO_WINDINGS_TRANSFORMER">
-            <g id="idTWO_95_WINDINGS_95_TRANSFORMER_45_WINDING1">
+            <g id="TWO_WINDINGS_TRANSFORMER-WINDING1">
                 <circle cx="5" cy="10" r="5"/>
             </g>
-            <g id="idTWO_95_WINDINGS_95_TRANSFORMER_45_WINDING2">
+            <g id="TWO_WINDINGS_TRANSFORMER-WINDING2">
                 <circle cx="5" cy="5" r="5"/>
             </g>
         </g>
         <g id="THREE_WINDINGS_TRANSFORMER">
-            <g id="idTHREE_95_WINDINGS_95_TRANSFORMER_45_WINDING1">
+            <g id="THREE_WINDINGS_TRANSFORMER-WINDING1">
                 <circle cx="5" cy="15" r="5"/>
             </g>
-            <g id="idTHREE_95_WINDINGS_95_TRANSFORMER_45_WINDING2">
+            <g id="THREE_WINDINGS_TRANSFORMER-WINDING2">
                 <circle cx="11" cy="15" r="5"/>
             </g>
-            <g id="idTHREE_95_WINDINGS_95_TRANSFORMER_45_WINDING3">
+            <g id="THREE_WINDINGS_TRANSFORMER-WINDING3">
                 <circle cx="8" cy="19" r="5"/>
             </g>
         </g>
         <g id="BREAKER">
-            <g id="idBREAKER_45_CLOSED">
+            <g id="BREAKER-CLOSED">
                 <path d="M1,1 V19 H19 V1z M10,5 V15"/>
             </g>
-            <g id="idBREAKER_45_OPEN">
+            <g id="BREAKER-OPEN">
                 <path d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
         </g>

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/vl2_optimized.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/vl2_optimized.svg
@@ -78,53 +78,53 @@
             <path d="M6,6 A 6 40 0 0 0 10,6"/>
         </g>
         <g id="ARROW_REACTIVE">
-            <g id="idARROW_95_REACTIVE_45_UP">
+            <g id="ARROW_REACTIVE-UP">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
-            <g id="idARROW_95_REACTIVE_45_DOWN">
+            <g id="ARROW_REACTIVE-DOWN">
                 <polygon points="0,0 10,0 5,10"/>
             </g>
         </g>
         <g id="ARROW_ACTIVE">
-            <g id="idARROW_95_ACTIVE_45_UP">
+            <g id="ARROW_ACTIVE-UP">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
-            <g id="idARROW_95_ACTIVE_45_DOWN">
+            <g id="ARROW_ACTIVE-DOWN">
                 <polygon points="0,0 10,0 5,10"/>
             </g>
         </g>
         <g id="DISCONNECTOR">
-            <g id="idDISCONNECTOR_45_CLOSED">
+            <g id="DISCONNECTOR-CLOSED">
                 <path d="M0,0 8,8 M8,0 0,8"/>
             </g>
-            <g id="idDISCONNECTOR_45_OPEN">
+            <g id="DISCONNECTOR-OPEN">
                 <path d="M8,0 0,8"/>
             </g>
         </g>
         <g id="TWO_WINDINGS_TRANSFORMER">
-            <g id="idTWO_95_WINDINGS_95_TRANSFORMER_45_WINDING1">
+            <g id="TWO_WINDINGS_TRANSFORMER-WINDING1">
                 <circle cx="5" cy="10" r="5"/>
             </g>
-            <g id="idTWO_95_WINDINGS_95_TRANSFORMER_45_WINDING2">
+            <g id="TWO_WINDINGS_TRANSFORMER-WINDING2">
                 <circle cx="5" cy="5" r="5"/>
             </g>
         </g>
         <g id="THREE_WINDINGS_TRANSFORMER">
-            <g id="idTHREE_95_WINDINGS_95_TRANSFORMER_45_WINDING1">
+            <g id="THREE_WINDINGS_TRANSFORMER-WINDING1">
                 <circle cx="5" cy="15" r="5"/>
             </g>
-            <g id="idTHREE_95_WINDINGS_95_TRANSFORMER_45_WINDING2">
+            <g id="THREE_WINDINGS_TRANSFORMER-WINDING2">
                 <circle cx="11" cy="15" r="5"/>
             </g>
-            <g id="idTHREE_95_WINDINGS_95_TRANSFORMER_45_WINDING3">
+            <g id="THREE_WINDINGS_TRANSFORMER-WINDING3">
                 <circle cx="8" cy="19" r="5"/>
             </g>
         </g>
         <g id="BREAKER">
-            <g id="idBREAKER_45_CLOSED">
+            <g id="BREAKER-CLOSED">
                 <path d="M1,1 V19 H19 V1z M10,5 V15"/>
             </g>
-            <g id="idBREAKER_45_OPEN">
+            <g id="BREAKER-OPEN">
                 <path d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
         </g>

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/vl2_optimized.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/vl2_optimized.svg
@@ -72,12 +72,12 @@
 .sld-ground-disconnection .sld-sw-closed {stroke: black; fill: none}
 ]]></style>
     <defs>
-        <g id="idGENERATOR">
+        <g id="GENERATOR">
             <circle cx="6" cy="6" r="6"/>
             <path d="M6,6 A 6 40 0 0 0 2,6"/>
             <path d="M6,6 A 6 40 0 0 0 10,6"/>
         </g>
-        <g id="idARROW_95_REACTIVE">
+        <g id="ARROW_REACTIVE">
             <g id="idARROW_95_REACTIVE_45_UP">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
@@ -85,7 +85,7 @@
                 <polygon points="0,0 10,0 5,10"/>
             </g>
         </g>
-        <g id="idARROW_95_ACTIVE">
+        <g id="ARROW_ACTIVE">
             <g id="idARROW_95_ACTIVE_45_UP">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
@@ -93,7 +93,7 @@
                 <polygon points="0,0 10,0 5,10"/>
             </g>
         </g>
-        <g id="idDISCONNECTOR">
+        <g id="DISCONNECTOR">
             <g id="idDISCONNECTOR_45_CLOSED">
                 <path d="M0,0 8,8 M8,0 0,8"/>
             </g>
@@ -101,7 +101,7 @@
                 <path d="M8,0 0,8"/>
             </g>
         </g>
-        <g id="idTWO_95_WINDINGS_95_TRANSFORMER">
+        <g id="TWO_WINDINGS_TRANSFORMER">
             <g id="idTWO_95_WINDINGS_95_TRANSFORMER_45_WINDING1">
                 <circle cx="5" cy="10" r="5"/>
             </g>
@@ -109,7 +109,7 @@
                 <circle cx="5" cy="5" r="5"/>
             </g>
         </g>
-        <g id="idTHREE_95_WINDINGS_95_TRANSFORMER">
+        <g id="THREE_WINDINGS_TRANSFORMER">
             <g id="idTHREE_95_WINDINGS_95_TRANSFORMER_45_WINDING1">
                 <circle cx="5" cy="15" r="5"/>
             </g>
@@ -120,7 +120,7 @@
                 <circle cx="8" cy="19" r="5"/>
             </g>
         </g>
-        <g id="idBREAKER">
+        <g id="BREAKER">
             <g id="idBREAKER_45_CLOSED">
                 <path d="M1,1 V19 H19 V1z M10,5 V15"/>
             </g>

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/vl3_optimized.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/vl3_optimized.svg
@@ -73,18 +73,18 @@
 ]]></style>
     <defs>
         <g id="ARROW_REACTIVE">
-            <g id="idARROW_95_REACTIVE_45_UP">
+            <g id="ARROW_REACTIVE-UP">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
-            <g id="idARROW_95_REACTIVE_45_DOWN">
+            <g id="ARROW_REACTIVE-DOWN">
                 <polygon points="0,0 10,0 5,10"/>
             </g>
         </g>
         <g id="ARROW_ACTIVE">
-            <g id="idARROW_95_ACTIVE_45_UP">
+            <g id="ARROW_ACTIVE-UP">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
-            <g id="idARROW_95_ACTIVE_45_DOWN">
+            <g id="ARROW_ACTIVE-DOWN">
                 <polygon points="0,0 10,0 5,10"/>
             </g>
         </g>
@@ -95,29 +95,29 @@
             <line x1="6" x2="6" y1="7.5" y2="12"/>
         </g>
         <g id="DISCONNECTOR">
-            <g id="idDISCONNECTOR_45_CLOSED">
+            <g id="DISCONNECTOR-CLOSED">
                 <path d="M0,0 8,8 M8,0 0,8"/>
             </g>
-            <g id="idDISCONNECTOR_45_OPEN">
+            <g id="DISCONNECTOR-OPEN">
                 <path d="M8,0 0,8"/>
             </g>
         </g>
         <g id="THREE_WINDINGS_TRANSFORMER">
-            <g id="idTHREE_95_WINDINGS_95_TRANSFORMER_45_WINDING1">
+            <g id="THREE_WINDINGS_TRANSFORMER-WINDING1">
                 <circle cx="5" cy="15" r="5"/>
             </g>
-            <g id="idTHREE_95_WINDINGS_95_TRANSFORMER_45_WINDING2">
+            <g id="THREE_WINDINGS_TRANSFORMER-WINDING2">
                 <circle cx="11" cy="15" r="5"/>
             </g>
-            <g id="idTHREE_95_WINDINGS_95_TRANSFORMER_45_WINDING3">
+            <g id="THREE_WINDINGS_TRANSFORMER-WINDING3">
                 <circle cx="8" cy="19" r="5"/>
             </g>
         </g>
         <g id="BREAKER">
-            <g id="idBREAKER_45_CLOSED">
+            <g id="BREAKER-CLOSED">
                 <path d="M1,1 V19 H19 V1z M10,5 V15"/>
             </g>
-            <g id="idBREAKER_45_OPEN">
+            <g id="BREAKER-OPEN">
                 <path d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
         </g>

--- a/single-line-diagram/single-line-diagram-core/src/test/resources/vl3_optimized.svg
+++ b/single-line-diagram/single-line-diagram-core/src/test/resources/vl3_optimized.svg
@@ -72,7 +72,7 @@
 .sld-ground-disconnection .sld-sw-closed {stroke: black; fill: none}
 ]]></style>
     <defs>
-        <g id="idARROW_95_REACTIVE">
+        <g id="ARROW_REACTIVE">
             <g id="idARROW_95_REACTIVE_45_UP">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
@@ -80,7 +80,7 @@
                 <polygon points="0,0 10,0 5,10"/>
             </g>
         </g>
-        <g id="idARROW_95_ACTIVE">
+        <g id="ARROW_ACTIVE">
             <g id="idARROW_95_ACTIVE_45_UP">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
@@ -88,13 +88,13 @@
                 <polygon points="0,0 10,0 5,10"/>
             </g>
         </g>
-        <g id="idCAPACITOR">
+        <g id="CAPACITOR">
             <line x1="6" x2="6" y1="0" y2="4.5"/>
             <line x1="0" x2="12" y1="4.5" y2="4.5"/>
             <line x1="0" x2="12" y1="7.5" y2="7.5"/>
             <line x1="6" x2="6" y1="7.5" y2="12"/>
         </g>
-        <g id="idDISCONNECTOR">
+        <g id="DISCONNECTOR">
             <g id="idDISCONNECTOR_45_CLOSED">
                 <path d="M0,0 8,8 M8,0 0,8"/>
             </g>
@@ -102,7 +102,7 @@
                 <path d="M8,0 0,8"/>
             </g>
         </g>
-        <g id="idTHREE_95_WINDINGS_95_TRANSFORMER">
+        <g id="THREE_WINDINGS_TRANSFORMER">
             <g id="idTHREE_95_WINDINGS_95_TRANSFORMER_45_WINDING1">
                 <circle cx="5" cy="15" r="5"/>
             </g>
@@ -113,7 +113,7 @@
                 <circle cx="8" cy="19" r="5"/>
             </g>
         </g>
-        <g id="idBREAKER">
+        <g id="BREAKER">
             <g id="idBREAKER_45_CLOSED">
                 <path d="M1,1 V19 H19 V1z M10,5 V15"/>
             </g>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines

**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior?**
Optimized SVG are broken (due to #700 escaping id)

**What is the new behavior (if this is a feature change)?**
Optimized SVG are back: we do not escape the provided component types, as the user has control over it (and the default component types include only allowed characters) 

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
