### PR TITLE
Rewrite addGraphEdges in SLD + add sorting in addGraphEdges in SLD and NAD

### DIFF
--- a/network-area-diagram/src/main/java/com/powsybl/nad/build/iidm/NetworkGraphBuilder.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/build/iidm/NetworkGraphBuilder.java
@@ -116,11 +116,11 @@ public class NetworkGraphBuilder implements GraphBuilder {
     }
 
     private void addGraphEdges(VoltageLevel vl, Graph graph) {
-        vl.getLineStream().forEach(l -> visitLine(vl, l, graph));
-        vl.getTwoWindingsTransformerStream().forEach(twt -> visitTwoWindingsTransformer(vl, twt, graph));
-        vl.getThreeWindingsTransformerStream().forEach(thwt -> visitThreeWindingsTransformer(vl, thwt, graph));
-        vl.getDanglingLineStream().forEach(dl -> visitDanglingLine(dl, graph));
-        vl.getConnectableStream(HvdcConverterStation.class).forEach(hvdc -> visitHvdcConverterStation(hvdc, graph));
+        vl.getLineStream().sorted(Comparator.comparing(Line::getId)).forEach(l -> visitLine(vl, l, graph));
+        vl.getTwoWindingsTransformerStream().sorted(Comparator.comparing(TwoWindingsTransformer::getId)).forEach(twt -> visitTwoWindingsTransformer(vl, twt, graph));
+        vl.getThreeWindingsTransformerStream().sorted(Comparator.comparing(ThreeWindingsTransformer::getId)).forEach(thwt -> visitThreeWindingsTransformer(vl, thwt, graph));
+        vl.getDanglingLineStream().sorted(Comparator.comparing(DanglingLine::getId)).forEach(dl -> visitDanglingLine(dl, graph));
+        vl.getConnectableStream(HvdcConverterStation.class).sorted(Comparator.comparing(HvdcConverterStation::getId)).forEach(hvdc -> visitHvdcConverterStation(hvdc, graph));
     }
 
     private void visitLine(VoltageLevel vl, Line line, Graph graph) {

--- a/network-area-diagram/src/test/java/com/powsybl/nad/svg/NominalVoltageStyleTest.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/svg/NominalVoltageStyleTest.java
@@ -19,6 +19,8 @@ import com.powsybl.nad.svg.iidm.NominalVoltageStyleProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Objects;
+
 /**
  * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
@@ -95,7 +97,7 @@ class NominalVoltageStyleTest extends AbstractTest {
 
     @Test
     void testIEEE24() {
-        Network network = NetworkSerDe.read(getClass().getResourceAsStream("/IEEE_24_bus.xiidm"));
+        Network network = NetworkSerDe.read(Objects.requireNonNull(getClass().getResourceAsStream("/IEEE_24_bus.xiidm")));
         assertSvgEquals("/IEEE_24_bus.svg", network);
     }
 

--- a/network-area-diagram/src/test/resources/IEEE_118_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_118_bus.svg
@@ -686,116 +686,8 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
             </g>
         </g>
         <g id="239">
-            <desc>L92-100-1</desc>
-            <g id="239.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="2301.23,45.68 2205.16,-319.95"/>
-                <g class="nad-edge-infos" transform="translate(2292.97,14.25)">
-                    <g class="nad-active">
-                        <g transform="rotate(-14.72)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-284.72)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="239.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="2109.08,-685.59 2205.16,-319.95"/>
-                <g class="nad-edge-infos" transform="translate(2117.34,-654.16)">
-                    <g class="nad-active">
-                        <g transform="rotate(165.28)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(75.28)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="240">
-            <desc>L94-100-1</desc>
-            <g id="240.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="1701.89,-353.02 1891.76,-523.42"/>
-                <g class="nad-edge-infos" transform="translate(1726.07,-374.73)">
-                    <g class="nad-active">
-                        <g transform="rotate(48.09)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-41.91)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="240.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="2081.63,-693.82 1891.76,-523.42"/>
-                <g class="nad-edge-infos" transform="translate(2057.44,-672.11)">
-                    <g class="nad-active">
-                        <g transform="rotate(-131.91)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-41.91)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="241">
-            <desc>L98-100-1</desc>
-            <g id="241.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="1284.72,-891.81 1679.98,-804.95"/>
-                <g class="nad-edge-infos" transform="translate(1316.46,-884.84)">
-                    <g class="nad-active">
-                        <g transform="rotate(102.39)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(12.39)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="241.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="2075.24,-718.09 1679.98,-804.95"/>
-                <g class="nad-edge-infos" transform="translate(2043.49,-725.07)">
-                    <g class="nad-active">
-                        <g transform="rotate(-77.61)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-347.61)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="242">
-            <desc>L99-100-1</desc>
-            <g id="242.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="1346.04,-1185.85 1712.41,-956.32"/>
-                <g class="nad-edge-infos" transform="translate(1373.58,-1168.60)">
-                    <g class="nad-active">
-                        <g transform="rotate(122.07)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(32.07)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="242.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="2078.79,-726.79 1712.41,-956.32"/>
-                <g class="nad-edge-infos" transform="translate(2051.25,-744.04)">
-                    <g class="nad-active">
-                        <g transform="rotate(-57.93)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-327.93)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="243">
             <desc>L100-101-1</desc>
-            <g id="243.1" class="nad-vl120to180">
+            <g id="239.1" class="nad-vl120to180">
                 <polyline class="nad-edge-path" points="2127.10,-700.74 2432.81,-560.82"/>
                 <g class="nad-edge-infos" transform="translate(2156.65,-687.22)">
                     <g class="nad-active">
@@ -807,7 +699,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="243.2" class="nad-vl120to180">
+            <g id="239.2" class="nad-vl120to180">
                 <polyline class="nad-edge-path" points="2738.51,-420.90 2432.81,-560.82"/>
                 <g class="nad-edge-infos" transform="translate(2708.96,-434.43)">
                     <g class="nad-active">
@@ -820,9 +712,9 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                 </g>
             </g>
         </g>
-        <g id="244">
+        <g id="240">
             <desc>L100-103-1</desc>
-            <g id="244.1" class="nad-vl120to180">
+            <g id="240.1" class="nad-vl120to180">
                 <polyline class="nad-edge-path" points="2129.49,-709.79 2250.02,-699.23"/>
                 <g class="nad-edge-infos" transform="translate(2161.87,-706.95)">
                     <g class="nad-active">
@@ -834,7 +726,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="244.2" class="nad-vl120to180">
+            <g id="240.2" class="nad-vl120to180">
                 <polyline class="nad-edge-path" points="2370.56,-688.68 2250.02,-699.23"/>
                 <g class="nad-edge-infos" transform="translate(2338.18,-691.51)">
                     <g class="nad-active">
@@ -847,9 +739,9 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                 </g>
             </g>
         </g>
-        <g id="245">
+        <g id="241">
             <desc>L100-104-1</desc>
-            <g id="245.1" class="nad-vl120to180">
+            <g id="241.1" class="nad-vl120to180">
                 <polyline class="nad-edge-path" points="2127.12,-723.59 2327.06,-814.68"/>
                 <g class="nad-edge-infos" transform="translate(2156.70,-737.06)">
                     <g class="nad-active">
@@ -861,7 +753,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="245.2" class="nad-vl120to180">
+            <g id="241.2" class="nad-vl120to180">
                 <polyline class="nad-edge-path" points="2527.00,-905.76 2327.06,-814.68"/>
                 <g class="nad-edge-infos" transform="translate(2497.43,-892.29)">
                     <g class="nad-active">
@@ -874,9 +766,9 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                 </g>
             </g>
         </g>
-        <g id="246">
+        <g id="242">
             <desc>L100-106-1</desc>
-            <g id="246.1" class="nad-vl120to180">
+            <g id="242.1" class="nad-vl120to180">
                 <polyline class="nad-edge-path" points="2122.44,-730.69 2398.53,-981.84"/>
                 <g class="nad-edge-infos" transform="translate(2146.48,-752.56)">
                     <g class="nad-active">
@@ -888,7 +780,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="246.2" class="nad-vl120to180">
+            <g id="242.2" class="nad-vl120to180">
                 <polyline class="nad-edge-path" points="2674.63,-1232.98 2398.53,-981.84"/>
                 <g class="nad-edge-infos" transform="translate(2650.59,-1211.11)">
                     <g class="nad-active">
@@ -897,6 +789,114 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
                         <text transform="rotate(-42.29)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="243">
+            <desc>L92-100-1</desc>
+            <g id="243.1" class="nad-vl120to180">
+                <polyline class="nad-edge-path" points="2301.23,45.68 2205.16,-319.95"/>
+                <g class="nad-edge-infos" transform="translate(2292.97,14.25)">
+                    <g class="nad-active">
+                        <g transform="rotate(-14.72)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-284.72)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="243.2" class="nad-vl120to180">
+                <polyline class="nad-edge-path" points="2109.08,-685.59 2205.16,-319.95"/>
+                <g class="nad-edge-infos" transform="translate(2117.34,-654.16)">
+                    <g class="nad-active">
+                        <g transform="rotate(165.28)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(75.28)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="244">
+            <desc>L94-100-1</desc>
+            <g id="244.1" class="nad-vl120to180">
+                <polyline class="nad-edge-path" points="1701.89,-353.02 1891.76,-523.42"/>
+                <g class="nad-edge-infos" transform="translate(1726.07,-374.73)">
+                    <g class="nad-active">
+                        <g transform="rotate(48.09)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-41.91)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="244.2" class="nad-vl120to180">
+                <polyline class="nad-edge-path" points="2081.63,-693.82 1891.76,-523.42"/>
+                <g class="nad-edge-infos" transform="translate(2057.44,-672.11)">
+                    <g class="nad-active">
+                        <g transform="rotate(-131.91)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-41.91)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="245">
+            <desc>L98-100-1</desc>
+            <g id="245.1" class="nad-vl120to180">
+                <polyline class="nad-edge-path" points="1284.72,-891.81 1679.98,-804.95"/>
+                <g class="nad-edge-infos" transform="translate(1316.46,-884.84)">
+                    <g class="nad-active">
+                        <g transform="rotate(102.39)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(12.39)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="245.2" class="nad-vl120to180">
+                <polyline class="nad-edge-path" points="2075.24,-718.09 1679.98,-804.95"/>
+                <g class="nad-edge-infos" transform="translate(2043.49,-725.07)">
+                    <g class="nad-active">
+                        <g transform="rotate(-77.61)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-347.61)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="246">
+            <desc>L99-100-1</desc>
+            <g id="246.1" class="nad-vl120to180">
+                <polyline class="nad-edge-path" points="1346.04,-1185.85 1712.41,-956.32"/>
+                <g class="nad-edge-infos" transform="translate(1373.58,-1168.60)">
+                    <g class="nad-active">
+                        <g transform="rotate(122.07)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(32.07)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="246.2" class="nad-vl120to180">
+                <polyline class="nad-edge-path" points="2078.79,-726.79 1712.41,-956.32"/>
+                <g class="nad-edge-infos" transform="translate(2051.25,-744.04)">
+                    <g class="nad-active">
+                        <g transform="rotate(-57.93)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-327.93)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
@@ -1226,62 +1226,8 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
             </g>
         </g>
         <g id="259">
-            <desc>L4-11-1</desc>
-            <g id="259.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="834.08,-2036.88 726.45,-1978.05"/>
-                <g class="nad-edge-infos" transform="translate(805.57,-2021.29)">
-                    <g class="nad-active">
-                        <g transform="rotate(-118.66)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-28.66)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="259.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="618.82,-1919.21 726.45,-1978.05"/>
-                <g class="nad-edge-infos" transform="translate(647.34,-1934.80)">
-                    <g class="nad-active">
-                        <g transform="rotate(61.34)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-28.66)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="260">
-            <desc>L5-11-1</desc>
-            <g id="260.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="251.60,-2024.45 410.15,-1969.72"/>
-                <g class="nad-edge-infos" transform="translate(282.32,-2013.85)">
-                    <g class="nad-active">
-                        <g transform="rotate(109.04)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(19.04)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="260.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="568.70,-1914.99 410.15,-1969.72"/>
-                <g class="nad-edge-infos" transform="translate(537.98,-1925.60)">
-                    <g class="nad-active">
-                        <g transform="rotate(-70.96)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-340.96)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="261">
             <desc>L11-12-1</desc>
-            <g id="261.1" class="nad-vl120to180">
+            <g id="259.1" class="nad-vl120to180">
                 <polyline class="nad-edge-path" points="588.37,-1932.78 544.39,-2118.81"/>
                 <g class="nad-edge-infos" transform="translate(580.89,-1964.41)">
                     <g class="nad-active">
@@ -1293,7 +1239,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="261.2" class="nad-vl120to180">
+            <g id="259.2" class="nad-vl120to180">
                 <polyline class="nad-edge-path" points="500.41,-2304.83 544.39,-2118.81"/>
                 <g class="nad-edge-infos" transform="translate(507.89,-2273.21)">
                     <g class="nad-active">
@@ -1306,9 +1252,9 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                 </g>
             </g>
         </g>
-        <g id="262">
+        <g id="260">
             <desc>L11-13-1</desc>
-            <g id="262.1" class="nad-vl120to180">
+            <g id="260.1" class="nad-vl120to180">
                 <polyline class="nad-edge-path" points="591.16,-1878.75 559.86,-1637.06"/>
                 <g class="nad-edge-infos" transform="translate(586.99,-1846.52)">
                     <g class="nad-active">
@@ -1320,7 +1266,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="262.2" class="nad-vl120to180">
+            <g id="260.2" class="nad-vl120to180">
                 <polyline class="nad-edge-path" points="528.56,-1395.38 559.86,-1637.06"/>
                 <g class="nad-edge-infos" transform="translate(532.73,-1427.61)">
                     <g class="nad-active">
@@ -1329,6 +1275,60 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
                         <text transform="rotate(-82.62)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="261">
+            <desc>L4-11-1</desc>
+            <g id="261.1" class="nad-vl120to180">
+                <polyline class="nad-edge-path" points="834.08,-2036.88 726.45,-1978.05"/>
+                <g class="nad-edge-infos" transform="translate(805.57,-2021.29)">
+                    <g class="nad-active">
+                        <g transform="rotate(-118.66)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-28.66)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="261.2" class="nad-vl120to180">
+                <polyline class="nad-edge-path" points="618.82,-1919.21 726.45,-1978.05"/>
+                <g class="nad-edge-infos" transform="translate(647.34,-1934.80)">
+                    <g class="nad-active">
+                        <g transform="rotate(61.34)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-28.66)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="262">
+            <desc>L5-11-1</desc>
+            <g id="262.1" class="nad-vl120to180">
+                <polyline class="nad-edge-path" points="251.60,-2024.45 410.15,-1969.72"/>
+                <g class="nad-edge-infos" transform="translate(282.32,-2013.85)">
+                    <g class="nad-active">
+                        <g transform="rotate(109.04)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(19.04)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="262.2" class="nad-vl120to180">
+                <polyline class="nad-edge-path" points="568.70,-1914.99 410.15,-1969.72"/>
+                <g class="nad-edge-infos" transform="translate(537.98,-1925.60)">
+                    <g class="nad-active">
+                        <g transform="rotate(-70.96)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-340.96)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
@@ -1442,35 +1442,8 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
             </g>
         </g>
         <g id="267">
-            <desc>L32-114-1</desc>
-            <g id="267.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-1384.91,-1319.71 -1519.80,-1471.99"/>
-                <g class="nad-edge-infos" transform="translate(-1406.46,-1344.04)">
-                    <g class="nad-active">
-                        <g transform="rotate(-41.53)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-311.53)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="267.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-1654.68,-1624.27 -1519.80,-1471.99"/>
-                <g class="nad-edge-infos" transform="translate(-1633.13,-1599.94)">
-                    <g class="nad-active">
-                        <g transform="rotate(138.47)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(48.47)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="268">
             <desc>L114-115-1</desc>
-            <g id="268.1" class="nad-vl120to180">
+            <g id="267.1" class="nad-vl120to180">
                 <polyline class="nad-edge-path" points="-1682.49,-1619.07 -1727.37,-1498.25"/>
                 <g class="nad-edge-infos" transform="translate(-1693.81,-1588.61)">
                     <g class="nad-active">
@@ -1482,7 +1455,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="268.2" class="nad-vl120to180">
+            <g id="267.2" class="nad-vl120to180">
                 <polyline class="nad-edge-path" points="-1772.25,-1377.42 -1727.37,-1498.25"/>
                 <g class="nad-edge-infos" transform="translate(-1760.93,-1407.89)">
                     <g class="nad-active">
@@ -1491,6 +1464,33 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
                         <text transform="rotate(-69.62)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="268">
+            <desc>L32-114-1</desc>
+            <g id="268.1" class="nad-vl120to180">
+                <polyline class="nad-edge-path" points="-1384.91,-1319.71 -1519.80,-1471.99"/>
+                <g class="nad-edge-infos" transform="translate(-1406.46,-1344.04)">
+                    <g class="nad-active">
+                        <g transform="rotate(-41.53)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-311.53)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="268.2" class="nad-vl120to180">
+                <polyline class="nad-edge-path" points="-1654.68,-1624.27 -1519.80,-1471.99"/>
+                <g class="nad-edge-infos" transform="translate(-1633.13,-1599.94)">
+                    <g class="nad-active">
+                        <g transform="rotate(138.47)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(48.47)" x="19.00"></text>
                     </g>
                 </g>
             </g>
@@ -1631,89 +1631,8 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
             </g>
         </g>
         <g id="274">
-            <desc>L2-12-1</desc>
-            <g id="274.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="671.72,-2952.54 586.68,-2655.29"/>
-                <g class="nad-edge-infos" transform="translate(662.78,-2921.30)">
-                    <g class="nad-active">
-                        <g transform="rotate(-164.04)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-74.04)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="274.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="501.64,-2358.04 586.68,-2655.29"/>
-                <g class="nad-edge-infos" transform="translate(510.58,-2389.28)">
-                    <g class="nad-active">
-                        <g transform="rotate(15.96)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-74.04)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="275">
-            <desc>L3-12-1</desc>
-            <g id="275.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="674.62,-2568.93 592.68,-2461.21"/>
-                <g class="nad-edge-infos" transform="translate(654.94,-2543.07)">
-                    <g class="nad-active">
-                        <g transform="rotate(-142.74)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-52.74)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="275.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="510.73,-2353.48 592.68,-2461.21"/>
-                <g class="nad-edge-infos" transform="translate(530.41,-2379.35)">
-                    <g class="nad-active">
-                        <g transform="rotate(37.26)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-52.74)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="276">
-            <desc>L7-12-1</desc>
-            <g id="276.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="211.75,-2804.56 345.87,-2579.89"/>
-                <g class="nad-edge-infos" transform="translate(228.41,-2776.66)">
-                    <g class="nad-active">
-                        <g transform="rotate(149.17)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(59.17)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="276.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="479.99,-2355.21 345.87,-2579.89"/>
-                <g class="nad-edge-infos" transform="translate(463.33,-2383.12)">
-                    <g class="nad-active">
-                        <g transform="rotate(-30.83)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-300.83)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="277">
             <desc>L12-14-1</desc>
-            <g id="277.1" class="nad-vl120to180">
+            <g id="274.1" class="nad-vl120to180">
                 <polyline class="nad-edge-path" points="485.71,-2305.40 366.31,-1931.55"/>
                 <g class="nad-edge-infos" transform="translate(475.83,-2274.44)">
                     <g class="nad-active">
@@ -1725,7 +1644,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="277.2" class="nad-vl120to180">
+            <g id="274.2" class="nad-vl120to180">
                 <polyline class="nad-edge-path" points="246.91,-1557.70 366.31,-1931.55"/>
                 <g class="nad-edge-infos" transform="translate(256.80,-1588.65)">
                     <g class="nad-active">
@@ -1738,9 +1657,9 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                 </g>
             </g>
         </g>
-        <g id="278">
+        <g id="275">
             <desc>L12-16-1</desc>
-            <g id="278.1" class="nad-vl120to180">
+            <g id="275.1" class="nad-vl120to180">
                 <polyline class="nad-edge-path" points="476.07,-2310.81 245.58,-2044.75"/>
                 <g class="nad-edge-infos" transform="translate(454.79,-2286.25)">
                     <g class="nad-active">
@@ -1752,7 +1671,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="278.2" class="nad-vl120to180">
+            <g id="275.2" class="nad-vl120to180">
                 <polyline class="nad-edge-path" points="15.09,-1778.69 245.58,-2044.75"/>
                 <g class="nad-edge-infos" transform="translate(36.37,-1803.25)">
                     <g class="nad-active">
@@ -1761,6 +1680,87 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
                         <text transform="rotate(-49.10)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="276">
+            <desc>L2-12-1</desc>
+            <g id="276.1" class="nad-vl120to180">
+                <polyline class="nad-edge-path" points="671.72,-2952.54 586.68,-2655.29"/>
+                <g class="nad-edge-infos" transform="translate(662.78,-2921.30)">
+                    <g class="nad-active">
+                        <g transform="rotate(-164.04)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-74.04)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="276.2" class="nad-vl120to180">
+                <polyline class="nad-edge-path" points="501.64,-2358.04 586.68,-2655.29"/>
+                <g class="nad-edge-infos" transform="translate(510.58,-2389.28)">
+                    <g class="nad-active">
+                        <g transform="rotate(15.96)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-74.04)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="277">
+            <desc>L3-12-1</desc>
+            <g id="277.1" class="nad-vl120to180">
+                <polyline class="nad-edge-path" points="674.62,-2568.93 592.68,-2461.21"/>
+                <g class="nad-edge-infos" transform="translate(654.94,-2543.07)">
+                    <g class="nad-active">
+                        <g transform="rotate(-142.74)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-52.74)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="277.2" class="nad-vl120to180">
+                <polyline class="nad-edge-path" points="510.73,-2353.48 592.68,-2461.21"/>
+                <g class="nad-edge-infos" transform="translate(530.41,-2379.35)">
+                    <g class="nad-active">
+                        <g transform="rotate(37.26)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-52.74)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="278">
+            <desc>L7-12-1</desc>
+            <g id="278.1" class="nad-vl120to180">
+                <polyline class="nad-edge-path" points="211.75,-2804.56 345.87,-2579.89"/>
+                <g class="nad-edge-infos" transform="translate(228.41,-2776.66)">
+                    <g class="nad-active">
+                        <g transform="rotate(149.17)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(59.17)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="278.2" class="nad-vl120to180">
+                <polyline class="nad-edge-path" points="479.99,-2355.21 345.87,-2579.89"/>
+                <g class="nad-edge-infos" transform="translate(463.33,-2383.12)">
+                    <g class="nad-active">
+                        <g transform="rotate(-30.83)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-300.83)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
@@ -2530,35 +2530,8 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
             </g>
         </g>
         <g id="307">
-            <desc>L8-30-1</desc>
-            <g id="307.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="-822.34,-746.28 -827.06,-561.07"/>
-                <g class="nad-edge-infos" transform="translate(-823.17,-713.79)">
-                    <g class="nad-active">
-                        <g transform="rotate(-178.54)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-88.54)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="307.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="-831.79,-375.85 -827.06,-561.07"/>
-                <g class="nad-edge-infos" transform="translate(-830.96,-408.34)">
-                    <g class="nad-active">
-                        <g transform="rotate(1.46)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-88.54)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="308">
             <desc>L30-38-1</desc>
-            <g id="308.1" class="nad-vl300to500">
+            <g id="307.1" class="nad-vl300to500">
                 <polyline class="nad-edge-path" points="-832.08,-320.86 -824.90,155.73"/>
                 <g class="nad-edge-infos" transform="translate(-831.59,-288.37)">
                     <g class="nad-active">
@@ -2570,7 +2543,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="308.2" class="nad-vl300to500">
+            <g id="307.2" class="nad-vl300to500">
                 <polyline class="nad-edge-path" points="-817.73,632.31 -824.90,155.73"/>
                 <g class="nad-edge-infos" transform="translate(-818.22,599.82)">
                     <g class="nad-active">
@@ -2579,6 +2552,33 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
                         <text transform="rotate(-270.86)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="308">
+            <desc>L8-30-1</desc>
+            <g id="308.1" class="nad-vl300to500">
+                <polyline class="nad-edge-path" points="-822.34,-746.28 -827.06,-561.07"/>
+                <g class="nad-edge-infos" transform="translate(-823.17,-713.79)">
+                    <g class="nad-active">
+                        <g transform="rotate(-178.54)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-88.54)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="308.2" class="nad-vl300to500">
+                <polyline class="nad-edge-path" points="-831.79,-375.85 -827.06,-561.07"/>
+                <g class="nad-edge-infos" transform="translate(-830.96,-408.34)">
+                    <g class="nad-active">
+                        <g transform="rotate(1.46)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-88.54)" x="19.00"></text>
                     </g>
                 </g>
             </g>

--- a/network-area-diagram/src/test/resources/IEEE_118_bus_partial_non_connected.svg
+++ b/network-area-diagram/src/test/resources/IEEE_118_bus_partial_non_connected.svg
@@ -215,8 +215,23 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
             </g>
         </g>
         <g id="56">
-            <desc>L32-114-1</desc>
+            <desc>L114-115-1</desc>
             <g id="56.1" class="nad-vl120to180">
+                <polyline class="nad-edge-path" points="517.43,23.30 524.32,-131.93"/>
+                <g class="nad-edge-infos" transform="translate(518.87,-9.17)">
+                    <g class="nad-active">
+                        <g transform="rotate(2.54)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-87.46)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="57">
+            <desc>L32-114-1</desc>
+            <g id="57.1" class="nad-vl120to180">
                 <polyline class="nad-edge-path" points="810.03,318.71 673.28,194.01"/>
                 <g class="nad-edge-infos" transform="translate(786.02,296.81)">
                     <g class="nad-active">
@@ -228,7 +243,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="56.2" class="nad-vl120to180">
+            <g id="57.2" class="nad-vl120to180">
                 <polyline class="nad-edge-path" points="536.53,69.30 673.28,194.01"/>
                 <g class="nad-edge-infos" transform="translate(560.55,91.20)">
                     <g class="nad-active">
@@ -237,21 +252,6 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
                         <text transform="rotate(42.36)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="57">
-            <desc>L114-115-1</desc>
-            <g id="57.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="517.43,23.30 524.32,-131.93"/>
-                <g class="nad-edge-infos" transform="translate(518.87,-9.17)">
-                    <g class="nad-active">
-                        <g transform="rotate(2.54)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-87.46)" x="19.00"></text>
                     </g>
                 </g>
             </g>
@@ -344,50 +344,8 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
             </g>
         </g>
         <g id="63">
-            <desc>L27-28-1</desc>
-            <g id="63.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="929.68,-280.77 963.73,-484.83"/>
-                <g class="nad-edge-infos" transform="translate(935.03,-312.83)">
-                    <g class="nad-active">
-                        <g transform="rotate(9.48)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-80.52)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="64">
-            <desc>L27-32-1</desc>
-            <g id="64.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="920.79,-226.49 877.75,41.80"/>
-                <g class="nad-edge-infos" transform="translate(915.64,-194.40)">
-                    <g class="nad-active">
-                        <g transform="rotate(-170.89)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-80.89)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="64.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="834.71,310.09 877.75,41.80"/>
-                <g class="nad-edge-infos" transform="translate(839.86,278.00)">
-                    <g class="nad-active">
-                        <g transform="rotate(9.11)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-80.89)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="65">
             <desc>L27-115-1</desc>
-            <g id="65.1" class="nad-vl120to180">
+            <g id="63.1" class="nad-vl120to180">
                 <polyline class="nad-edge-path" points="897.97,-257.87 728.79,-284.14"/>
                 <g class="nad-edge-infos" transform="translate(865.86,-262.85)">
                     <g class="nad-active">
@@ -400,24 +358,51 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                 </g>
             </g>
         </g>
-        <g id="66">
-            <desc>L8-30-1</desc>
-            <g id="66.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="-410.76,509.75 -430.32,720.57"/>
-                <g class="nad-edge-infos" transform="translate(-413.76,542.11)">
+        <g id="64">
+            <desc>L27-28-1</desc>
+            <g id="64.1" class="nad-vl120to180">
+                <polyline class="nad-edge-path" points="929.68,-280.77 963.73,-484.83"/>
+                <g class="nad-edge-infos" transform="translate(935.03,-312.83)">
                     <g class="nad-active">
-                        <g transform="rotate(-174.70)">
+                        <g transform="rotate(9.48)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-84.70)" x="-19.00" style="text-anchor:end"></text>
+                        <text transform="rotate(-80.52)" x="19.00"></text>
                     </g>
                 </g>
             </g>
         </g>
-        <g id="67">
+        <g id="65">
+            <desc>L27-32-1</desc>
+            <g id="65.1" class="nad-vl120to180">
+                <polyline class="nad-edge-path" points="920.79,-226.49 877.75,41.80"/>
+                <g class="nad-edge-infos" transform="translate(915.64,-194.40)">
+                    <g class="nad-active">
+                        <g transform="rotate(-170.89)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-80.89)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="65.2" class="nad-vl120to180">
+                <polyline class="nad-edge-path" points="834.71,310.09 877.75,41.80"/>
+                <g class="nad-edge-infos" transform="translate(839.86,278.00)">
+                    <g class="nad-active">
+                        <g transform="rotate(9.11)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-80.89)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="66">
             <desc>L26-30-1</desc>
-            <g id="67.2" class="nad-vl300to500">
+            <g id="66.2" class="nad-vl300to500">
                 <polyline class="nad-edge-path" points="-432.72,494.84 -602.49,581.23"/>
                 <g class="nad-edge-infos" transform="translate(-461.69,509.58)">
                     <g class="nad-active">
@@ -430,9 +415,9 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                 </g>
             </g>
         </g>
-        <g id="68">
+        <g id="67">
             <desc>L30-38-1</desc>
-            <g id="68.1" class="nad-vl300to500">
+            <g id="67.1" class="nad-vl300to500">
                 <polyline class="nad-edge-path" points="-413.30,455.34 -480.09,100.79"/>
                 <g class="nad-edge-infos" transform="translate(-419.32,423.40)">
                     <g class="nad-active">
@@ -444,7 +429,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="68.2" class="nad-vl300to500">
+            <g id="67.2" class="nad-vl300to500">
                 <polyline class="nad-edge-path" points="-546.87,-253.77 -480.09,100.79"/>
                 <g class="nad-edge-infos" transform="translate(-540.85,-221.83)">
                     <g class="nad-active">
@@ -453,6 +438,21 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
                         <text transform="rotate(79.33)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="68">
+            <desc>L8-30-1</desc>
+            <g id="68.2" class="nad-vl300to500">
+                <polyline class="nad-edge-path" points="-410.76,509.75 -430.32,720.57"/>
+                <g class="nad-edge-infos" transform="translate(-413.76,542.11)">
+                    <g class="nad-active">
+                        <g transform="rotate(-174.70)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-84.70)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
@@ -535,23 +535,8 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
             </g>
         </g>
         <g id="73">
-            <desc>L35-37-1</desc>
-            <g id="73.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-1183.60,-334.78 -1136.32,-167.43"/>
-                <g class="nad-edge-infos" transform="translate(-1174.76,-303.50)">
-                    <g class="nad-active">
-                        <g transform="rotate(164.23)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(74.23)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="74">
             <desc>L33-37-1</desc>
-            <g id="74.2" class="nad-vl120to180">
+            <g id="73.2" class="nad-vl120to180">
                 <polyline class="nad-edge-path" points="-1218.20,-365.79 -1421.48,-399.88"/>
                 <g class="nad-edge-infos" transform="translate(-1250.25,-371.16)">
                     <g class="nad-active">
@@ -564,9 +549,9 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                 </g>
             </g>
         </g>
-        <g id="75">
+        <g id="74">
             <desc>L34-37-1</desc>
-            <g id="75.2" class="nad-vl120to180">
+            <g id="74.2" class="nad-vl120to180">
                 <polyline class="nad-edge-path" points="-1209.90,-341.20 -1361.01,-180.32"/>
                 <g class="nad-edge-infos" transform="translate(-1232.15,-317.51)">
                     <g class="nad-active">
@@ -575,6 +560,21 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
                         <text transform="rotate(-46.79)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="75">
+            <desc>L35-37-1</desc>
+            <g id="75.2" class="nad-vl120to180">
+                <polyline class="nad-edge-path" points="-1183.60,-334.78 -1136.32,-167.43"/>
+                <g class="nad-edge-infos" transform="translate(-1174.76,-303.50)">
+                    <g class="nad-active">
+                        <g transform="rotate(164.23)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(74.23)" x="19.00"></text>
                     </g>
                 </g>
             </g>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus.svg
@@ -169,35 +169,8 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
             </g>
         </g>
         <g id="27">
-            <desc>L9-10-1</desc>
-            <g id="27.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-172.20,-92.74 -361.39,-1.64"/>
-                <g class="nad-edge-infos" transform="translate(-219.50,-69.97)">
-                    <g class="nad-active">
-                        <g transform="rotate(-115.71)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-25.71)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="27.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-550.59,89.46 -361.39,-1.64"/>
-                <g class="nad-edge-infos" transform="translate(-521.31,75.36)">
-                    <g class="nad-active">
-                        <g transform="rotate(64.29)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-25.71)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="28">
             <desc>L10-11-1</desc>
-            <g id="28.1" class="nad-vl0to30">
+            <g id="27.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-553.14,115.79 -434.62,204.42"/>
                 <g class="nad-edge-infos" transform="translate(-527.12,135.25)">
                     <g class="nad-active">
@@ -209,7 +182,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="28.2" class="nad-vl0to30">
+            <g id="27.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-316.10,293.04 -434.62,204.42"/>
                 <g class="nad-edge-infos" transform="translate(-342.13,273.58)">
                     <g class="nad-active">
@@ -218,6 +191,33 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
                         <text transform="rotate(-323.21)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="28">
+            <desc>L9-10-1</desc>
+            <g id="28.1" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-172.20,-92.74 -361.39,-1.64"/>
+                <g class="nad-edge-infos" transform="translate(-219.50,-69.97)">
+                    <g class="nad-active">
+                        <g transform="rotate(-115.71)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-25.71)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="28.2" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-550.59,89.46 -361.39,-1.64"/>
+                <g class="nad-edge-infos" transform="translate(-521.31,75.36)">
+                    <g class="nad-active">
+                        <g transform="rotate(64.29)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-25.71)" x="19.00"></text>
                     </g>
                 </g>
             </g>
@@ -250,35 +250,8 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
             </g>
         </g>
         <g id="30">
-            <desc>L6-12-1</desc>
-            <g id="30.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="256.41,-18.36 462.83,26.19"/>
-                <g class="nad-edge-infos" transform="translate(288.18,-11.50)">
-                    <g class="nad-active">
-                        <g transform="rotate(102.18)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(12.18)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="30.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="669.26,70.75 462.83,26.19"/>
-                <g class="nad-edge-infos" transform="translate(637.49,63.89)">
-                    <g class="nad-active">
-                        <g transform="rotate(-77.82)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-347.82)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="31">
             <desc>L12-13-1</desc>
-            <g id="31.1" class="nad-vl0to30">
+            <g id="30.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="677.38,95.31 581.29,205.02"/>
                 <g class="nad-edge-infos" transform="translate(655.97,119.76)">
                     <g class="nad-active">
@@ -290,7 +263,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="31.2" class="nad-vl0to30">
+            <g id="30.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="485.20,314.73 581.29,205.02"/>
                 <g class="nad-edge-infos" transform="translate(506.62,290.29)">
                     <g class="nad-active">
@@ -303,36 +276,36 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                 </g>
             </g>
         </g>
-        <g id="32">
-            <desc>L6-13-1</desc>
-            <g id="32.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="234.93,14.73 344.14,164.03"/>
-                <g class="nad-edge-infos" transform="translate(254.11,40.96)">
+        <g id="31">
+            <desc>L6-12-1</desc>
+            <g id="31.1" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="256.41,-18.36 462.83,26.19"/>
+                <g class="nad-edge-infos" transform="translate(288.18,-11.50)">
                     <g class="nad-active">
-                        <g transform="rotate(143.82)">
+                        <g transform="rotate(102.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(53.82)" x="19.00"></text>
+                        <text transform="rotate(12.18)" x="19.00"></text>
                     </g>
                 </g>
             </g>
-            <g id="32.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="453.35,313.34 344.14,164.03"/>
-                <g class="nad-edge-infos" transform="translate(434.16,287.10)">
+            <g id="31.2" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="669.26,70.75 462.83,26.19"/>
+                <g class="nad-edge-infos" transform="translate(637.49,63.89)">
                     <g class="nad-active">
-                        <g transform="rotate(-36.18)">
+                        <g transform="rotate(-77.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-306.18)" x="-19.00" style="text-anchor:end"></text>
+                        <text transform="rotate(-347.82)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
         </g>
-        <g id="33">
+        <g id="32">
             <desc>L13-14-1</desc>
-            <g id="33.1" class="nad-vl0to30">
+            <g id="32.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="443.61,339.86 290.26,376.58"/>
                 <g class="nad-edge-infos" transform="translate(412.00,347.42)">
                     <g class="nad-active">
@@ -344,7 +317,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="33.2" class="nad-vl0to30">
+            <g id="32.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="136.91,413.30 290.26,376.58"/>
                 <g class="nad-edge-infos" transform="translate(168.52,405.73)">
                     <g class="nad-active">
@@ -353,6 +326,33 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
                         <text transform="rotate(-13.47)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="33">
+            <desc>L6-13-1</desc>
+            <g id="33.1" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="234.93,14.73 344.14,164.03"/>
+                <g class="nad-edge-infos" transform="translate(254.11,40.96)">
+                    <g class="nad-active">
+                        <g transform="rotate(143.82)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(53.82)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="33.2" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="453.35,313.34 344.14,164.03"/>
+                <g class="nad-edge-infos" transform="translate(434.16,287.10)">
+                    <g class="nad-active">
+                        <g transform="rotate(-36.18)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-306.18)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_disconnection.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_disconnection.svg
@@ -169,35 +169,8 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
             </g>
         </g>
         <g id="24">
-            <desc>L9-10-1</desc>
-            <g id="24.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-190.22,-84.07 -370.40,2.69"/>
-                <g class="nad-edge-infos" transform="translate(-219.50,-69.97)">
-                    <g class="nad-active">
-                        <g transform="rotate(-115.71)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-25.71)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="24.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-550.59,89.46 -370.40,2.69"/>
-                <g class="nad-edge-infos" transform="translate(-521.31,75.36)">
-                    <g class="nad-active">
-                        <g transform="rotate(64.29)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-25.71)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="25">
             <desc>L10-11-1</desc>
-            <g id="25.1" class="nad-vl0to30">
+            <g id="24.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-553.14,115.79 -434.62,204.42"/>
                 <g class="nad-edge-infos" transform="translate(-527.12,135.25)">
                     <g class="nad-active">
@@ -209,7 +182,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="25.2" class="nad-vl0to30">
+            <g id="24.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-316.10,293.04 -434.62,204.42"/>
                 <g class="nad-edge-infos" transform="translate(-342.13,273.58)">
                     <g class="nad-active">
@@ -218,6 +191,33 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
                         <text transform="rotate(-323.21)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="25">
+            <desc>L9-10-1</desc>
+            <g id="25.1" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-190.22,-84.07 -370.40,2.69"/>
+                <g class="nad-edge-infos" transform="translate(-219.50,-69.97)">
+                    <g class="nad-active">
+                        <g transform="rotate(-115.71)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-25.71)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="25.2" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-550.59,89.46 -370.40,2.69"/>
+                <g class="nad-edge-infos" transform="translate(-521.31,75.36)">
+                    <g class="nad-active">
+                        <g transform="rotate(64.29)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-25.71)" x="19.00"></text>
                     </g>
                 </g>
             </g>
@@ -250,35 +250,8 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
             </g>
         </g>
         <g id="27">
-            <desc>L6-12-1</desc>
-            <g id="27.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="227.08,-24.69 448.17,23.03"/>
-                <g class="nad-edge-infos" transform="translate(258.85,-17.83)">
-                    <g class="nad-active">
-                        <g transform="rotate(102.18)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(12.18)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="27.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="669.26,70.75 448.17,23.03"/>
-                <g class="nad-edge-infos" transform="translate(637.49,63.89)">
-                    <g class="nad-active">
-                        <g transform="rotate(-77.82)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-347.82)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="28">
             <desc>L12-13-1</desc>
-            <g id="28.1" class="nad-vl0to30">
+            <g id="27.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="677.38,95.31 581.29,205.02"/>
                 <g class="nad-edge-infos" transform="translate(655.97,119.76)">
                     <g class="nad-active">
@@ -290,7 +263,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="28.2" class="nad-vl0to30">
+            <g id="27.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="485.20,314.73 581.29,205.02"/>
                 <g class="nad-edge-infos" transform="translate(506.62,290.29)">
                     <g class="nad-active">
@@ -303,36 +276,36 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                 </g>
             </g>
         </g>
-        <g id="29">
-            <desc>L6-13-1</desc>
-            <g id="29.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="217.21,-9.48 335.28,151.93"/>
-                <g class="nad-edge-infos" transform="translate(236.40,16.75)">
+        <g id="28">
+            <desc>L6-12-1</desc>
+            <g id="28.1" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="227.08,-24.69 448.17,23.03"/>
+                <g class="nad-edge-infos" transform="translate(258.85,-17.83)">
                     <g class="nad-active">
-                        <g transform="rotate(143.82)">
+                        <g transform="rotate(102.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(53.82)" x="19.00"></text>
+                        <text transform="rotate(12.18)" x="19.00"></text>
                     </g>
                 </g>
             </g>
-            <g id="29.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="453.35,313.34 335.28,151.93"/>
-                <g class="nad-edge-infos" transform="translate(434.16,287.10)">
+            <g id="28.2" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="669.26,70.75 448.17,23.03"/>
+                <g class="nad-edge-infos" transform="translate(637.49,63.89)">
                     <g class="nad-active">
-                        <g transform="rotate(-36.18)">
+                        <g transform="rotate(-77.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-306.18)" x="-19.00" style="text-anchor:end"></text>
+                        <text transform="rotate(-347.82)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
         </g>
-        <g id="30" class="nad-disconnected">
+        <g id="29" class="nad-disconnected">
             <desc>L13-14-1</desc>
-            <g id="30.1" class="nad-disconnected nad-vl0to30">
+            <g id="29.1" class="nad-disconnected nad-vl0to30">
                 <polyline class="nad-edge-path" points="443.61,339.86 297.31,374.89"/>
                 <g class="nad-edge-infos" transform="translate(412.00,347.42)">
                     <g class="nad-active">
@@ -344,7 +317,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="30.2" class="nad-disconnected nad-vl0to30">
+            <g id="29.2" class="nad-disconnected nad-vl0to30">
                 <polyline class="nad-edge-path" points="151.01,409.92 297.31,374.89"/>
                 <g class="nad-edge-infos" transform="translate(182.62,402.35)">
                     <g class="nad-active">
@@ -353,6 +326,33 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
                         <text transform="rotate(-13.47)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="30">
+            <desc>L6-13-1</desc>
+            <g id="30.1" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="217.21,-9.48 335.28,151.93"/>
+                <g class="nad-edge-infos" transform="translate(236.40,16.75)">
+                    <g class="nad-active">
+                        <g transform="rotate(143.82)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(53.82)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="30.2" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="453.35,313.34 335.28,151.93"/>
+                <g class="nad-edge-infos" transform="translate(434.16,287.10)">
+                    <g class="nad-active">
+                        <g transform="rotate(-36.18)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-306.18)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_fictitious.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_fictitious.svg
@@ -178,35 +178,8 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
             </g>
         </g>
         <g id="30">
-            <desc>L9-10-1</desc>
-            <g id="30.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="62.59,339.48 -249.07,332.57"/>
-                <g class="nad-edge-infos" transform="translate(30.10,338.76)">
-                    <g class="nad-active">
-                        <g transform="rotate(-88.73)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-358.73)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="30.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-560.72,325.65 -249.07,332.57"/>
-                <g class="nad-edge-infos" transform="translate(-528.23,326.37)">
-                    <g class="nad-active">
-                        <g transform="rotate(91.27)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(1.27)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="31">
             <desc>L10-11-1</desc>
-            <g id="31.1" class="nad-vl0to30">
+            <g id="30.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-597.01,301.99 -683.85,116.23"/>
                 <g class="nad-edge-infos" transform="translate(-610.78,272.54)">
                     <g class="nad-active">
@@ -218,7 +191,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="31.2" class="nad-vl0to30">
+            <g id="30.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-770.69,-69.53 -683.85,116.23"/>
                 <g class="nad-edge-infos" transform="translate(-756.92,-40.09)">
                     <g class="nad-active">
@@ -227,6 +200,33 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
                         <text transform="rotate(64.95)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="31">
+            <desc>L9-10-1</desc>
+            <g id="31.1" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="62.59,339.48 -249.07,332.57"/>
+                <g class="nad-edge-infos" transform="translate(30.10,338.76)">
+                    <g class="nad-active">
+                        <g transform="rotate(-88.73)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-358.73)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="31.2" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-560.72,325.65 -249.07,332.57"/>
+                <g class="nad-edge-infos" transform="translate(-528.23,326.37)">
+                    <g class="nad-active">
+                        <g transform="rotate(91.27)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(1.27)" x="19.00"></text>
                     </g>
                 </g>
             </g>
@@ -259,35 +259,8 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
             </g>
         </g>
         <g id="33">
-            <desc>L6-12-1</desc>
-            <g id="33.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-382.10,-355.46 -274.09,-294.19"/>
-                <g class="nad-edge-infos" transform="translate(-353.83,-339.42)">
-                    <g class="nad-active">
-                        <g transform="rotate(119.56)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(29.56)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="33.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-166.08,-232.92 -274.09,-294.19"/>
-                <g class="nad-edge-infos" transform="translate(-194.35,-248.96)">
-                    <g class="nad-active">
-                        <g transform="rotate(-60.44)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-330.44)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="34">
             <desc>L12-13-1</desc>
-            <g id="34.1" class="nad-vl0to30">
+            <g id="33.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-161.45,-218.26 -225.22,-83.99"/>
                 <g class="nad-edge-infos" transform="translate(-175.39,-188.90)">
                     <g class="nad-active">
@@ -299,7 +272,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="34.2" class="nad-vl0to30">
+            <g id="33.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-289.00,50.28 -225.22,-83.99"/>
                 <g class="nad-edge-infos" transform="translate(-275.05,20.93)">
                     <g class="nad-active">
@@ -312,36 +285,36 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                 </g>
             </g>
         </g>
-        <g id="35">
-            <desc>L6-13-1</desc>
-            <g id="35.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-398.41,-343.22 -352.11,-147.36"/>
-                <g class="nad-edge-infos" transform="translate(-390.93,-311.60)">
+        <g id="34">
+            <desc>L6-12-1</desc>
+            <g id="34.1" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-382.10,-355.46 -274.09,-294.19"/>
+                <g class="nad-edge-infos" transform="translate(-353.83,-339.42)">
                     <g class="nad-active">
-                        <g transform="rotate(166.70)">
+                        <g transform="rotate(119.56)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(76.70)" x="19.00"></text>
+                        <text transform="rotate(29.56)" x="19.00"></text>
                     </g>
                 </g>
             </g>
-            <g id="35.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-305.80,48.50 -352.11,-147.36"/>
-                <g class="nad-edge-infos" transform="translate(-313.28,16.87)">
+            <g id="34.2" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-166.08,-232.92 -274.09,-294.19"/>
+                <g class="nad-edge-infos" transform="translate(-194.35,-248.96)">
                     <g class="nad-active">
-                        <g transform="rotate(-13.30)">
+                        <g transform="rotate(-60.44)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-283.30)" x="-19.00" style="text-anchor:end"></text>
+                        <text transform="rotate(-330.44)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
         </g>
-        <g id="36">
+        <g id="35">
             <desc>L13-14-1</desc>
-            <g id="36.1" class="nad-vl0to30">
+            <g id="35.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-294.89,98.31 -249.72,322.22"/>
                 <g class="nad-edge-infos" transform="translate(-288.47,130.17)">
                     <g class="nad-active">
@@ -353,7 +326,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="36.2" class="nad-vl0to30">
+            <g id="35.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-204.55,546.12 -249.72,322.22"/>
                 <g class="nad-edge-infos" transform="translate(-210.98,514.26)">
                     <g class="nad-active">
@@ -362,6 +335,33 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
                         <text transform="rotate(-281.41)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="36">
+            <desc>L6-13-1</desc>
+            <g id="36.1" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-398.41,-343.22 -352.11,-147.36"/>
+                <g class="nad-edge-infos" transform="translate(-390.93,-311.60)">
+                    <g class="nad-active">
+                        <g transform="rotate(166.70)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(76.70)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="36.2" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-305.80,48.50 -352.11,-147.36"/>
+                <g class="nad-edge-infos" transform="translate(-313.28,16.87)">
+                    <g class="nad-active">
+                        <g transform="rotate(-13.30)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-283.30)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_fictitious_metadata.json
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_fictitious_metadata.json
@@ -235,19 +235,19 @@
     "type" : "LineEdge"
   }, {
     "svgId" : "30",
-    "equipmentId" : "L9-10-1",
-    "node1" : "26",
-    "node2" : "2",
-    "busNode1" : "27",
-    "busNode2" : "3",
-    "type" : "LineEdge"
-  }, {
-    "svgId" : "31",
     "equipmentId" : "L10-11-1",
     "node1" : "2",
     "node2" : "4",
     "busNode1" : "3",
     "busNode2" : "5",
+    "type" : "LineEdge"
+  }, {
+    "svgId" : "31",
+    "equipmentId" : "L9-10-1",
+    "node1" : "26",
+    "node2" : "2",
+    "busNode1" : "27",
+    "busNode2" : "3",
     "type" : "LineEdge"
   }, {
     "svgId" : "32",
@@ -259,14 +259,6 @@
     "type" : "LineEdge"
   }, {
     "svgId" : "33",
-    "equipmentId" : "L6-12-1",
-    "node1" : "20",
-    "node2" : "6",
-    "busNode1" : "21",
-    "busNode2" : "7",
-    "type" : "LineEdge"
-  }, {
-    "svgId" : "34",
     "equipmentId" : "L12-13-1",
     "node1" : "6",
     "node2" : "8",
@@ -274,20 +266,28 @@
     "busNode2" : "9",
     "type" : "LineEdge"
   }, {
-    "svgId" : "35",
-    "equipmentId" : "L6-13-1",
+    "svgId" : "34",
+    "equipmentId" : "L6-12-1",
     "node1" : "20",
-    "node2" : "8",
+    "node2" : "6",
     "busNode1" : "21",
-    "busNode2" : "9",
+    "busNode2" : "7",
     "type" : "LineEdge"
   }, {
-    "svgId" : "36",
+    "svgId" : "35",
     "equipmentId" : "L13-14-1",
     "node1" : "8",
     "node2" : "10",
     "busNode1" : "9",
     "busNode2" : "11",
+    "type" : "LineEdge"
+  }, {
+    "svgId" : "36",
+    "equipmentId" : "L6-13-1",
+    "node1" : "20",
+    "node2" : "8",
+    "busNode1" : "21",
+    "busNode2" : "9",
     "type" : "LineEdge"
   }, {
     "svgId" : "37",

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_injections_metadata.json
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_injections_metadata.json
@@ -336,19 +336,19 @@
     "type" : "LineEdge"
   }, {
     "svgId" : "47",
-    "equipmentId" : "L9-10-1",
-    "node1" : "41",
-    "node2" : "3",
-    "busNode1" : "44",
-    "busNode2" : "5",
-    "type" : "LineEdge"
-  }, {
-    "svgId" : "48",
     "equipmentId" : "L10-11-1",
     "node1" : "3",
     "node2" : "6",
     "busNode1" : "5",
     "busNode2" : "8",
+    "type" : "LineEdge"
+  }, {
+    "svgId" : "48",
+    "equipmentId" : "L9-10-1",
+    "node1" : "41",
+    "node2" : "3",
+    "busNode1" : "44",
+    "busNode2" : "5",
     "type" : "LineEdge"
   }, {
     "svgId" : "49",
@@ -360,14 +360,6 @@
     "type" : "LineEdge"
   }, {
     "svgId" : "50",
-    "equipmentId" : "L6-12-1",
-    "node1" : "32",
-    "node2" : "9",
-    "busNode1" : "35",
-    "busNode2" : "11",
-    "type" : "LineEdge"
-  }, {
-    "svgId" : "51",
     "equipmentId" : "L12-13-1",
     "node1" : "9",
     "node2" : "12",
@@ -375,20 +367,28 @@
     "busNode2" : "14",
     "type" : "LineEdge"
   }, {
-    "svgId" : "52",
-    "equipmentId" : "L6-13-1",
+    "svgId" : "51",
+    "equipmentId" : "L6-12-1",
     "node1" : "32",
-    "node2" : "12",
+    "node2" : "9",
     "busNode1" : "35",
-    "busNode2" : "14",
+    "busNode2" : "11",
     "type" : "LineEdge"
   }, {
-    "svgId" : "53",
+    "svgId" : "52",
     "equipmentId" : "L13-14-1",
     "node1" : "12",
     "node2" : "15",
     "busNode1" : "14",
     "busNode2" : "17",
+    "type" : "LineEdge"
+  }, {
+    "svgId" : "53",
+    "equipmentId" : "L6-13-1",
+    "node1" : "32",
+    "node2" : "12",
+    "busNode1" : "35",
+    "busNode2" : "14",
     "type" : "LineEdge"
   }, {
     "svgId" : "54",

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_text_nodes.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_text_nodes.svg
@@ -178,35 +178,8 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
             </g>
         </g>
         <g id="30">
-            <desc>L9-10-1</desc>
-            <g id="30.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-427.58,312.84 -724.27,60.01"/>
-                <g class="nad-edge-infos" transform="translate(-452.31,291.76)">
-                    <g class="nad-active">
-                        <g transform="rotate(-49.56)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-319.56)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="30.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-1020.97,-192.81 -724.27,60.01"/>
-                <g class="nad-edge-infos" transform="translate(-996.23,-171.73)">
-                    <g class="nad-active">
-                        <g transform="rotate(130.44)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(40.44)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="31">
             <desc>L10-11-1</desc>
-            <g id="31.1" class="nad-vl0to30">
+            <g id="30.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-1031.43,-233.23 -936.48,-486.71"/>
                 <g class="nad-edge-infos" transform="translate(-1020.03,-263.66)">
                     <g class="nad-active">
@@ -218,7 +191,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="31.2" class="nad-vl0to30">
+            <g id="30.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-841.53,-740.20 -936.48,-486.71"/>
                 <g class="nad-edge-infos" transform="translate(-852.93,-709.76)">
                     <g class="nad-active">
@@ -227,6 +200,33 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
                         <text transform="rotate(-69.47)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="31">
+            <desc>L9-10-1</desc>
+            <g id="31.1" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-427.58,312.84 -724.27,60.01"/>
+                <g class="nad-edge-infos" transform="translate(-452.31,291.76)">
+                    <g class="nad-active">
+                        <g transform="rotate(-49.56)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-319.56)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="31.2" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-1020.97,-192.81 -724.27,60.01"/>
+                <g class="nad-edge-infos" transform="translate(-996.23,-171.73)">
+                    <g class="nad-active">
+                        <g transform="rotate(130.44)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(40.44)" x="19.00"></text>
                     </g>
                 </g>
             </g>
@@ -259,35 +259,8 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
             </g>
         </g>
         <g id="33">
-            <desc>L6-12-1</desc>
-            <g id="33.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-130.50,-719.43 -43.07,-817.57"/>
-                <g class="nad-edge-infos" transform="translate(-108.89,-743.69)">
-                    <g class="nad-active">
-                        <g transform="rotate(41.70)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-48.30)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="33.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="44.35,-915.71 -43.07,-817.57"/>
-                <g class="nad-edge-infos" transform="translate(22.74,-891.44)">
-                    <g class="nad-active">
-                        <g transform="rotate(-138.30)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-48.30)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="34">
             <desc>L12-13-1</desc>
-            <g id="34.1" class="nad-vl0to30">
+            <g id="33.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="45.39,-914.83 -144.53,-677.23"/>
                 <g class="nad-edge-infos" transform="translate(25.10,-889.44)">
                     <g class="nad-active">
@@ -299,7 +272,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="34.2" class="nad-vl0to30">
+            <g id="33.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-334.45,-439.64 -144.53,-677.23"/>
                 <g class="nad-edge-infos" transform="translate(-314.16,-465.02)">
                     <g class="nad-active">
@@ -312,36 +285,36 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                 </g>
             </g>
         </g>
-        <g id="35">
-            <desc>L6-13-1</desc>
-            <g id="35.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-162.41,-679.72 -248.92,-560.05"/>
-                <g class="nad-edge-infos" transform="translate(-181.45,-653.38)">
+        <g id="34">
+            <desc>L6-12-1</desc>
+            <g id="34.1" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-130.50,-719.43 -43.07,-817.57"/>
+                <g class="nad-edge-infos" transform="translate(-108.89,-743.69)">
                     <g class="nad-active">
-                        <g transform="rotate(-144.14)">
+                        <g transform="rotate(41.70)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-54.14)" x="-19.00" style="text-anchor:end"></text>
+                        <text transform="rotate(-48.30)" x="19.00"></text>
                     </g>
                 </g>
             </g>
-            <g id="35.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-335.43,-440.39 -248.92,-560.05"/>
-                <g class="nad-edge-infos" transform="translate(-316.39,-466.72)">
+            <g id="34.2" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="44.35,-915.71 -43.07,-817.57"/>
+                <g class="nad-edge-infos" transform="translate(22.74,-891.44)">
                     <g class="nad-active">
-                        <g transform="rotate(35.86)">
+                        <g transform="rotate(-138.30)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-54.14)" x="19.00"></text>
+                        <text transform="rotate(-48.30)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
         </g>
-        <g id="36">
+        <g id="35">
             <desc>L13-14-1</desc>
-            <g id="36.1" class="nad-vl0to30">
+            <g id="35.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-364.66,-398.60 -550.16,-124.47"/>
                 <g class="nad-edge-infos" transform="translate(-382.88,-371.68)">
                     <g class="nad-active">
@@ -353,7 +326,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="36.2" class="nad-vl0to30">
+            <g id="35.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-735.66,149.66 -550.16,-124.47"/>
                 <g class="nad-edge-infos" transform="translate(-717.45,122.75)">
                     <g class="nad-active">
@@ -362,6 +335,33 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
                         <text transform="rotate(-55.91)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="36">
+            <desc>L6-13-1</desc>
+            <g id="36.1" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-162.41,-679.72 -248.92,-560.05"/>
+                <g class="nad-edge-infos" transform="translate(-181.45,-653.38)">
+                    <g class="nad-active">
+                        <g transform="rotate(-144.14)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-54.14)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="36.2" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-335.43,-440.39 -248.92,-560.05"/>
+                <g class="nad-edge-infos" transform="translate(-316.39,-466.72)">
+                    <g class="nad-active">
+                        <g transform="rotate(35.86)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-54.14)" x="19.00"></text>
                     </g>
                 </g>
             </g>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter2.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter2.svg
@@ -219,32 +219,6 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
         </g>
         <g id="30">
             <g id="30.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-365.18,66.20 -362.23,282.03"/>
-                <g class="nad-edge-infos" transform="translate(-364.73,98.69)">
-                    <g class="nad-active">
-                        <g transform="rotate(179.22)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(89.22)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="30.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-359.28,497.87 -362.23,282.03"/>
-                <g class="nad-edge-infos" transform="translate(-359.72,465.37)">
-                    <g class="nad-active">
-                        <g transform="rotate(-0.78)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-270.78)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="31">
-            <g id="31.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-332.76,533.92 -163.36,589.33"/>
                 <g class="nad-edge-infos" transform="translate(-301.87,544.02)">
                     <g class="nad-active">
@@ -257,8 +231,48 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                 </g>
             </g>
         </g>
+        <g id="31">
+            <g id="31.1" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-365.18,66.20 -362.23,282.03"/>
+                <g class="nad-edge-infos" transform="translate(-364.73,98.69)">
+                    <g class="nad-active">
+                        <g transform="rotate(179.22)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(89.22)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="31.2" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-359.28,497.87 -362.23,282.03"/>
+                <g class="nad-edge-infos" transform="translate(-359.72,465.37)">
+                    <g class="nad-active">
+                        <g transform="rotate(-0.78)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-270.78)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
         <g id="32">
-            <g id="32.1" class="nad-vl0to30">
+            <g id="32.2" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-332.15,-472.99 -182.29,-452.52"/>
+                <g class="nad-edge-infos" transform="translate(-299.95,-468.59)">
+                    <g class="nad-active">
+                        <g transform="rotate(97.78)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(7.78)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="33">
+            <g id="33.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-365.22,11.20 -362.47,-219.01"/>
                 <g class="nad-edge-infos" transform="translate(-364.84,-21.30)">
                     <g class="nad-active">
@@ -270,7 +284,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="32.2" class="nad-vl0to30">
+            <g id="33.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-359.72,-449.21 -362.47,-219.01"/>
                 <g class="nad-edge-infos" transform="translate(-360.11,-416.72)">
                     <g class="nad-active">
@@ -279,20 +293,6 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
                         <text transform="rotate(-89.32)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="33">
-            <g id="33.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-332.15,-472.99 -182.29,-452.52"/>
-                <g class="nad-edge-infos" transform="translate(-299.95,-468.59)">
-                    <g class="nad-active">
-                        <g transform="rotate(97.78)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(7.78)" x="19.00"></text>
                     </g>
                 </g>
             </g>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter2_metadata.json
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter2_metadata.json
@@ -233,14 +233,6 @@
     "type" : "LineEdge"
   }, {
     "svgId" : "30",
-    "equipmentId" : "L9-10-1",
-    "node1" : "20",
-    "node2" : "2",
-    "busNode1" : "21",
-    "busNode2" : "3",
-    "type" : "LineEdge"
-  }, {
-    "svgId" : "31",
     "equipmentId" : "L10-11-1",
     "node1" : "2",
     "node2" : "22",
@@ -248,19 +240,27 @@
     "busNode2" : "23",
     "type" : "LineEdge"
   }, {
-    "svgId" : "32",
-    "equipmentId" : "L9-14-1",
+    "svgId" : "31",
+    "equipmentId" : "L9-10-1",
     "node1" : "20",
-    "node2" : "4",
+    "node2" : "2",
     "busNode1" : "21",
-    "busNode2" : "5",
+    "busNode2" : "3",
     "type" : "LineEdge"
   }, {
-    "svgId" : "33",
+    "svgId" : "32",
     "equipmentId" : "L13-14-1",
     "node1" : "26",
     "node2" : "4",
     "busNode1" : "27",
+    "busNode2" : "5",
+    "type" : "LineEdge"
+  }, {
+    "svgId" : "33",
+    "equipmentId" : "L9-14-1",
+    "node1" : "20",
+    "node2" : "4",
+    "busNode1" : "21",
     "busNode2" : "5",
     "type" : "LineEdge"
   }, {

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter3.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter3.svg
@@ -152,32 +152,6 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
     <g class="nad-branch-edges">
         <g id="22">
             <g id="22.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="194.50,12.94 397.25,100.67"/>
-                <g class="nad-edge-infos" transform="translate(224.33,25.85)">
-                    <g class="nad-active">
-                        <g transform="rotate(113.40)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(23.40)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="22.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="599.99,188.39 397.25,100.67"/>
-                <g class="nad-edge-infos" transform="translate(570.16,175.49)">
-                    <g class="nad-active">
-                        <g transform="rotate(-66.60)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-336.60)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="23">
-            <g id="23.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="652.55,202.48 823.41,222.32"/>
                 <g class="nad-edge-infos" transform="translate(684.83,206.23)">
                     <g class="nad-active">
@@ -190,8 +164,48 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                 </g>
             </g>
         </g>
+        <g id="23">
+            <g id="23.1" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="194.50,12.94 397.25,100.67"/>
+                <g class="nad-edge-infos" transform="translate(224.33,25.85)">
+                    <g class="nad-active">
+                        <g transform="rotate(113.40)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(23.40)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="23.2" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="599.99,188.39 397.25,100.67"/>
+                <g class="nad-edge-infos" transform="translate(570.16,175.49)">
+                    <g class="nad-active">
+                        <g transform="rotate(-66.60)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-336.60)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
         <g id="24">
-            <g id="24.1" class="nad-vl0to30">
+            <g id="24.2" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="435.04,-423.99 515.16,-573.64"/>
+                <g class="nad-edge-infos" transform="translate(450.38,-452.64)">
+                    <g class="nad-active">
+                        <g transform="rotate(28.16)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-61.84)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="25">
+            <g id="25.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="183.91,-21.25 295.66,-198.86"/>
                 <g class="nad-edge-infos" transform="translate(201.22,-48.76)">
                     <g class="nad-active">
@@ -203,7 +217,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="24.2" class="nad-vl0to30">
+            <g id="25.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="407.41,-376.47 295.66,-198.86"/>
                 <g class="nad-edge-infos" transform="translate(390.10,-348.96)">
                     <g class="nad-active">
@@ -212,20 +226,6 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
                         <text transform="rotate(-57.82)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="25">
-            <g id="25.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="435.04,-423.99 515.16,-573.64"/>
-                <g class="nad-edge-infos" transform="translate(450.38,-452.64)">
-                    <g class="nad-active">
-                        <g transform="rotate(28.16)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-61.84)" x="19.00"></text>
                     </g>
                 </g>
             </g>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter4.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_filter4.svg
@@ -161,32 +161,6 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
     <g class="nad-branch-edges">
         <g id="22">
             <g id="22.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="349.88,-264.11 163.53,-356.97"/>
-                <g class="nad-edge-infos" transform="translate(320.80,-278.60)">
-                    <g class="nad-active">
-                        <g transform="rotate(-63.51)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-333.51)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="22.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-22.83,-449.83 163.53,-356.97"/>
-                <g class="nad-edge-infos" transform="translate(6.26,-435.33)">
-                    <g class="nad-active">
-                        <g transform="rotate(116.49)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(26.49)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="23">
-            <g id="23.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-71.81,-449.34 -233.74,-364.60"/>
                 <g class="nad-edge-infos" transform="translate(-100.60,-434.27)">
                     <g class="nad-active">
@@ -198,7 +172,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="23.2" class="nad-vl0to30">
+            <g id="22.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-395.67,-279.86 -233.74,-364.60"/>
                 <g class="nad-edge-infos" transform="translate(-366.88,-294.93)">
                     <g class="nad-active">
@@ -207,6 +181,32 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
                         <text transform="rotate(-27.62)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="23">
+            <g id="23.1" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="349.88,-264.11 163.53,-356.97"/>
+                <g class="nad-edge-infos" transform="translate(320.80,-278.60)">
+                    <g class="nad-active">
+                        <g transform="rotate(-63.51)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-333.51)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="23.2" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-22.83,-449.83 163.53,-356.97"/>
+                <g class="nad-edge-infos" transform="translate(6.26,-435.33)">
+                    <g class="nad-active">
+                        <g transform="rotate(116.49)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(26.49)" x="19.00"></text>
                     </g>
                 </g>
             </g>
@@ -239,32 +239,6 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
         </g>
         <g id="25">
             <g id="25.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-536.48,212.26 -504.69,386.59"/>
-                <g class="nad-edge-infos" transform="translate(-530.65,244.23)">
-                    <g class="nad-active">
-                        <g transform="rotate(169.66)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(79.66)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="25.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-472.90,560.92 -504.69,386.59"/>
-                <g class="nad-edge-infos" transform="translate(-478.73,528.95)">
-                    <g class="nad-active">
-                        <g transform="rotate(-10.34)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-280.34)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="26">
-            <g id="26.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-444.48,573.66 -314.18,494.26"/>
                 <g class="nad-edge-infos" transform="translate(-416.73,556.75)">
                     <g class="nad-active">
@@ -276,7 +250,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="26.2" class="nad-vl0to30">
+            <g id="25.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-183.87,414.85 -314.18,494.26"/>
                 <g class="nad-edge-infos" transform="translate(-211.62,431.76)">
                     <g class="nad-active">
@@ -289,34 +263,34 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                 </g>
             </g>
         </g>
-        <g id="27">
-            <g id="27.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-517.47,198.74 -350.90,292.87"/>
-                <g class="nad-edge-infos" transform="translate(-489.18,214.73)">
+        <g id="26">
+            <g id="26.1" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-536.48,212.26 -504.69,386.59"/>
+                <g class="nad-edge-infos" transform="translate(-530.65,244.23)">
                     <g class="nad-active">
-                        <g transform="rotate(119.47)">
+                        <g transform="rotate(169.66)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(29.47)" x="19.00"></text>
+                        <text transform="rotate(79.66)" x="19.00"></text>
                     </g>
                 </g>
             </g>
-            <g id="27.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-184.33,387.01 -350.90,292.87"/>
-                <g class="nad-edge-infos" transform="translate(-212.62,371.02)">
+            <g id="26.2" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-472.90,560.92 -504.69,386.59"/>
+                <g class="nad-edge-infos" transform="translate(-478.73,528.95)">
                     <g class="nad-active">
-                        <g transform="rotate(-60.53)">
+                        <g transform="rotate(-10.34)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-330.53)" x="-19.00" style="text-anchor:end"></text>
+                        <text transform="rotate(-280.34)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
         </g>
-        <g id="28">
-            <g id="28.1" class="nad-vl0to30">
+        <g id="27">
+            <g id="27.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-136.14,387.57 31.19,298.04"/>
                 <g class="nad-edge-infos" transform="translate(-107.48,372.24)">
                     <g class="nad-active">
@@ -328,7 +302,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="28.2" class="nad-vl0to30">
+            <g id="27.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="198.53,208.52 31.19,298.04"/>
                 <g class="nad-edge-infos" transform="translate(169.87,223.85)">
                     <g class="nad-active">
@@ -337,6 +311,32 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
                         <text transform="rotate(-28.15)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="28">
+            <g id="28.1" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-517.47,198.74 -350.90,292.87"/>
+                <g class="nad-edge-infos" transform="translate(-489.18,214.73)">
+                    <g class="nad-active">
+                        <g transform="rotate(119.47)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(29.47)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="28.2" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-184.33,387.01 -350.90,292.87"/>
+                <g class="nad-edge-infos" transform="translate(-212.62,371.02)">
+                    <g class="nad-active">
+                        <g transform="rotate(-60.53)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-330.53)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_nofilter.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_nofilter.svg
@@ -228,32 +228,6 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
         </g>
         <g id="30">
             <g id="30.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="60.59,339.44 -249.07,332.57"/>
-                <g class="nad-edge-infos" transform="translate(28.10,338.71)">
-                    <g class="nad-active">
-                        <g transform="rotate(-88.73)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-358.73)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="30.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-558.72,325.70 -249.07,332.57"/>
-                <g class="nad-edge-infos" transform="translate(-526.23,326.42)">
-                    <g class="nad-active">
-                        <g transform="rotate(91.27)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(1.27)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="31">
-            <g id="31.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-597.86,300.17 -683.85,116.23"/>
                 <g class="nad-edge-infos" transform="translate(-611.62,270.73)">
                     <g class="nad-active">
@@ -265,7 +239,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="31.2" class="nad-vl0to30">
+            <g id="30.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-769.84,-67.72 -683.85,116.23"/>
                 <g class="nad-edge-infos" transform="translate(-756.08,-38.28)">
                     <g class="nad-active">
@@ -274,6 +248,32 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
                         <text transform="rotate(64.95)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="31">
+            <g id="31.1" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="60.59,339.44 -249.07,332.57"/>
+                <g class="nad-edge-infos" transform="translate(28.10,338.71)">
+                    <g class="nad-active">
+                        <g transform="rotate(-88.73)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-358.73)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="31.2" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-558.72,325.70 -249.07,332.57"/>
+                <g class="nad-edge-infos" transform="translate(-526.23,326.42)">
+                    <g class="nad-active">
+                        <g transform="rotate(91.27)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(1.27)" x="19.00"></text>
                     </g>
                 </g>
             </g>
@@ -306,32 +306,6 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
         </g>
         <g id="33">
             <g id="33.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-380.36,-354.47 -280.61,-297.89"/>
-                <g class="nad-edge-infos" transform="translate(-352.09,-338.44)">
-                    <g class="nad-active">
-                        <g transform="rotate(119.56)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(29.56)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="33.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-180.87,-241.31 -280.61,-297.89"/>
-                <g class="nad-edge-infos" transform="translate(-209.13,-257.35)">
-                    <g class="nad-active">
-                        <g transform="rotate(-60.44)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-330.44)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="34">
-            <g id="34.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-168.74,-202.90 -228.44,-77.21"/>
                 <g class="nad-edge-infos" transform="translate(-182.69,-173.54)">
                     <g class="nad-active">
@@ -343,7 +317,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="34.2" class="nad-vl0to30">
+            <g id="33.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-288.14,48.48 -228.44,-77.21"/>
                 <g class="nad-edge-infos" transform="translate(-274.19,19.12)">
                     <g class="nad-active">
@@ -356,34 +330,34 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                 </g>
             </g>
         </g>
-        <g id="35">
-            <g id="35.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-397.95,-341.28 -352.11,-147.36"/>
-                <g class="nad-edge-infos" transform="translate(-390.47,-309.65)">
+        <g id="34">
+            <g id="34.1" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-380.36,-354.47 -280.61,-297.89"/>
+                <g class="nad-edge-infos" transform="translate(-352.09,-338.44)">
                     <g class="nad-active">
-                        <g transform="rotate(166.70)">
+                        <g transform="rotate(119.56)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(76.70)" x="19.00"></text>
+                        <text transform="rotate(29.56)" x="19.00"></text>
                     </g>
                 </g>
             </g>
-            <g id="35.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-306.26,46.56 -352.11,-147.36"/>
-                <g class="nad-edge-infos" transform="translate(-313.74,14.93)">
+            <g id="34.2" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-180.87,-241.31 -280.61,-297.89"/>
+                <g class="nad-edge-infos" transform="translate(-209.13,-257.35)">
                     <g class="nad-active">
-                        <g transform="rotate(-13.30)">
+                        <g transform="rotate(-60.44)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-283.30)" x="-19.00" style="text-anchor:end"></text>
+                        <text transform="rotate(-330.44)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
         </g>
-        <g id="36">
-            <g id="36.1" class="nad-vl0to30">
+        <g id="35">
+            <g id="35.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-294.50,100.28 -251.20,314.87"/>
                 <g class="nad-edge-infos" transform="translate(-288.07,132.13)">
                     <g class="nad-active">
@@ -395,7 +369,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="36.2" class="nad-vl0to30">
+            <g id="35.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-207.91,529.46 -251.20,314.87"/>
                 <g class="nad-edge-infos" transform="translate(-214.34,497.60)">
                     <g class="nad-active">
@@ -404,6 +378,32 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
                         <text transform="rotate(-281.41)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="36">
+            <g id="36.1" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-397.95,-341.28 -352.11,-147.36"/>
+                <g class="nad-edge-infos" transform="translate(-390.47,-309.65)">
+                    <g class="nad-active">
+                        <g transform="rotate(166.70)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(76.70)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="36.2" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-306.26,46.56 -352.11,-147.36"/>
+                <g class="nad-edge-infos" transform="translate(-313.74,14.93)">
+                    <g class="nad-active">
+                        <g transform="rotate(-13.30)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-283.30)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>

--- a/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_nofilter_metadata.json
+++ b/network-area-diagram/src/test/resources/IEEE_14_bus_voltage_nofilter_metadata.json
@@ -233,19 +233,19 @@
     "type" : "LineEdge"
   }, {
     "svgId" : "30",
-    "equipmentId" : "L9-10-1",
-    "node1" : "26",
-    "node2" : "2",
-    "busNode1" : "27",
-    "busNode2" : "3",
-    "type" : "LineEdge"
-  }, {
-    "svgId" : "31",
     "equipmentId" : "L10-11-1",
     "node1" : "2",
     "node2" : "4",
     "busNode1" : "3",
     "busNode2" : "5",
+    "type" : "LineEdge"
+  }, {
+    "svgId" : "31",
+    "equipmentId" : "L9-10-1",
+    "node1" : "26",
+    "node2" : "2",
+    "busNode1" : "27",
+    "busNode2" : "3",
     "type" : "LineEdge"
   }, {
     "svgId" : "32",
@@ -257,14 +257,6 @@
     "type" : "LineEdge"
   }, {
     "svgId" : "33",
-    "equipmentId" : "L6-12-1",
-    "node1" : "20",
-    "node2" : "6",
-    "busNode1" : "21",
-    "busNode2" : "7",
-    "type" : "LineEdge"
-  }, {
-    "svgId" : "34",
     "equipmentId" : "L12-13-1",
     "node1" : "6",
     "node2" : "8",
@@ -272,20 +264,28 @@
     "busNode2" : "9",
     "type" : "LineEdge"
   }, {
-    "svgId" : "35",
-    "equipmentId" : "L6-13-1",
+    "svgId" : "34",
+    "equipmentId" : "L6-12-1",
     "node1" : "20",
-    "node2" : "8",
+    "node2" : "6",
     "busNode1" : "21",
-    "busNode2" : "9",
+    "busNode2" : "7",
     "type" : "LineEdge"
   }, {
-    "svgId" : "36",
+    "svgId" : "35",
     "equipmentId" : "L13-14-1",
     "node1" : "8",
     "node2" : "10",
     "busNode1" : "9",
     "busNode2" : "11",
+    "type" : "LineEdge"
+  }, {
+    "svgId" : "36",
+    "equipmentId" : "L6-13-1",
+    "node1" : "20",
+    "node2" : "8",
+    "busNode1" : "21",
+    "busNode2" : "9",
     "type" : "LineEdge"
   }, {
     "svgId" : "37",

--- a/network-area-diagram/src/test/resources/IEEE_14_id_prefixed.svg
+++ b/network-area-diagram/src/test/resources/IEEE_14_id_prefixed.svg
@@ -178,35 +178,8 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
             </g>
         </g>
         <g id="test_30">
-            <desc>L9-10-1</desc>
-            <g id="test_30.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="62.59,339.48 -249.07,332.57"/>
-                <g class="nad-edge-infos" transform="translate(30.10,338.76)">
-                    <g class="nad-active">
-                        <g transform="rotate(-88.73)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-358.73)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="test_30.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-560.72,325.65 -249.07,332.57"/>
-                <g class="nad-edge-infos" transform="translate(-528.23,326.37)">
-                    <g class="nad-active">
-                        <g transform="rotate(91.27)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(1.27)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="test_31">
             <desc>L10-11-1</desc>
-            <g id="test_31.1" class="nad-vl0to30">
+            <g id="test_30.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-597.01,301.99 -683.85,116.23"/>
                 <g class="nad-edge-infos" transform="translate(-610.78,272.54)">
                     <g class="nad-active">
@@ -218,7 +191,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="test_31.2" class="nad-vl0to30">
+            <g id="test_30.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-770.69,-69.53 -683.85,116.23"/>
                 <g class="nad-edge-infos" transform="translate(-756.92,-40.09)">
                     <g class="nad-active">
@@ -227,6 +200,33 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
                         <text transform="rotate(64.95)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="test_31">
+            <desc>L9-10-1</desc>
+            <g id="test_31.1" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="62.59,339.48 -249.07,332.57"/>
+                <g class="nad-edge-infos" transform="translate(30.10,338.76)">
+                    <g class="nad-active">
+                        <g transform="rotate(-88.73)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-358.73)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="test_31.2" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-560.72,325.65 -249.07,332.57"/>
+                <g class="nad-edge-infos" transform="translate(-528.23,326.37)">
+                    <g class="nad-active">
+                        <g transform="rotate(91.27)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(1.27)" x="19.00"></text>
                     </g>
                 </g>
             </g>
@@ -259,35 +259,8 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
             </g>
         </g>
         <g id="test_33">
-            <desc>L6-12-1</desc>
-            <g id="test_33.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-382.10,-355.46 -280.61,-297.89"/>
-                <g class="nad-edge-infos" transform="translate(-353.83,-339.42)">
-                    <g class="nad-active">
-                        <g transform="rotate(119.56)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(29.56)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="test_33.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-179.13,-240.32 -280.61,-297.89"/>
-                <g class="nad-edge-infos" transform="translate(-207.39,-256.36)">
-                    <g class="nad-active">
-                        <g transform="rotate(-60.44)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-330.44)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="test_34">
             <desc>L12-13-1</desc>
-            <g id="test_34.1" class="nad-vl0to30">
+            <g id="test_33.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-167.89,-204.71 -228.44,-77.21"/>
                 <g class="nad-edge-infos" transform="translate(-181.83,-175.35)">
                     <g class="nad-active">
@@ -299,7 +272,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="test_34.2" class="nad-vl0to30">
+            <g id="test_33.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-289.00,50.28 -228.44,-77.21"/>
                 <g class="nad-edge-infos" transform="translate(-275.05,20.93)">
                     <g class="nad-active">
@@ -312,36 +285,36 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                 </g>
             </g>
         </g>
-        <g id="test_35">
-            <desc>L6-13-1</desc>
-            <g id="test_35.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-398.41,-343.22 -352.11,-147.36"/>
-                <g class="nad-edge-infos" transform="translate(-390.93,-311.60)">
+        <g id="test_34">
+            <desc>L6-12-1</desc>
+            <g id="test_34.1" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-382.10,-355.46 -280.61,-297.89"/>
+                <g class="nad-edge-infos" transform="translate(-353.83,-339.42)">
                     <g class="nad-active">
-                        <g transform="rotate(166.70)">
+                        <g transform="rotate(119.56)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(76.70)" x="19.00"></text>
+                        <text transform="rotate(29.56)" x="19.00"></text>
                     </g>
                 </g>
             </g>
-            <g id="test_35.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-305.80,48.50 -352.11,-147.36"/>
-                <g class="nad-edge-infos" transform="translate(-313.28,16.87)">
+            <g id="test_34.2" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-179.13,-240.32 -280.61,-297.89"/>
+                <g class="nad-edge-infos" transform="translate(-207.39,-256.36)">
                     <g class="nad-active">
-                        <g transform="rotate(-13.30)">
+                        <g transform="rotate(-60.44)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-283.30)" x="-19.00" style="text-anchor:end"></text>
+                        <text transform="rotate(-330.44)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
         </g>
-        <g id="test_36">
+        <g id="test_35">
             <desc>L13-14-1</desc>
-            <g id="test_36.1" class="nad-vl0to30">
+            <g id="test_35.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-294.89,98.31 -251.20,314.87"/>
                 <g class="nad-edge-infos" transform="translate(-288.47,130.17)">
                     <g class="nad-active">
@@ -353,7 +326,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="test_36.2" class="nad-vl0to30">
+            <g id="test_35.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-207.52,531.42 -251.20,314.87"/>
                 <g class="nad-edge-infos" transform="translate(-213.94,499.56)">
                     <g class="nad-active">
@@ -362,6 +335,33 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
                         <text transform="rotate(-281.41)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="test_36">
+            <desc>L6-13-1</desc>
+            <g id="test_36.1" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-398.41,-343.22 -352.11,-147.36"/>
+                <g class="nad-edge-infos" transform="translate(-390.93,-311.60)">
+                    <g class="nad-active">
+                        <g transform="rotate(166.70)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(76.70)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="test_36.2" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-305.80,48.50 -352.11,-147.36"/>
+                <g class="nad-edge-infos" transform="translate(-313.28,16.87)">
+                    <g class="nad-active">
+                        <g transform="rotate(-13.30)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-283.30)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>

--- a/network-area-diagram/src/test/resources/IEEE_24_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_24_bus.svg
@@ -191,35 +191,8 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
             </g>
         </g>
         <g id="49">
-            <desc>L-3-1-1 </desc>
-            <g id="49.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-315.54,-478.90 -613.66,-343.33"/>
-                <g class="nad-edge-infos" transform="translate(-345.12,-465.45)">
-                    <g class="nad-active">
-                        <g transform="rotate(-114.45)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-24.45)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="49.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-911.78,-207.75 -613.66,-343.33"/>
-                <g class="nad-edge-infos" transform="translate(-882.20,-221.21)">
-                    <g class="nad-active">
-                        <g transform="rotate(65.55)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-24.45)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="50">
             <desc>L-1-5-1 </desc>
-            <g id="50.1" class="nad-vl120to180">
+            <g id="49.1" class="nad-vl120to180">
                 <polyline class="nad-edge-path" points="-959.31,-189.52 -1089.70,-148.35"/>
                 <g class="nad-edge-infos" transform="translate(-990.30,-179.73)">
                     <g class="nad-active">
@@ -231,7 +204,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="50.2" class="nad-vl120to180">
+            <g id="49.2" class="nad-vl120to180">
                 <polyline class="nad-edge-path" points="-1220.09,-107.19 -1089.70,-148.35"/>
                 <g class="nad-edge-infos" transform="translate(-1189.10,-116.97)">
                     <g class="nad-active">
@@ -240,6 +213,33 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
                         <text transform="rotate(-17.52)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="50">
+            <desc>L-3-1-1 </desc>
+            <g id="50.1" class="nad-vl120to180">
+                <polyline class="nad-edge-path" points="-315.54,-478.90 -613.66,-343.33"/>
+                <g class="nad-edge-infos" transform="translate(-345.12,-465.45)">
+                    <g class="nad-active">
+                        <g transform="rotate(-114.45)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-24.45)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="50.2" class="nad-vl120to180">
+                <polyline class="nad-edge-path" points="-911.78,-207.75 -613.66,-343.33"/>
+                <g class="nad-edge-infos" transform="translate(-882.20,-221.21)">
+                    <g class="nad-active">
+                        <g transform="rotate(65.55)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-24.45)" x="19.00"></text>
                     </g>
                 </g>
             </g>
@@ -299,39 +299,8 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
             </g>
         </g>
         <g id="53">
-            <desc>T-5-10-1 </desc>
-            <g id="53.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-1221.16,-89.03 -1014.63,4.02"/>
-                <g class="nad-edge-infos" transform="translate(-1191.52,-75.68)">
-                    <g class="nad-active">
-                        <g transform="rotate(114.26)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(24.26)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="53.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-753.41,121.72 -959.93,28.67"/>
-                <g class="nad-edge-infos" transform="translate(-783.04,108.37)">
-                    <g class="nad-active">
-                        <g transform="rotate(-65.74)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-335.74)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-            <g>
-                <circle class="nad-vl120to180 nad-winding" cx="-996.40" cy="12.24" r="20.00"/>
-                <circle class="nad-vl120to180 nad-winding" cx="-978.16" cy="20.45" r="20.00"/>
-            </g>
-        </g>
-        <g id="54">
             <desc>T-11-10-1 </desc>
-            <g id="54.1" class="nad-vl180to300">
+            <g id="53.1" class="nad-vl180to300">
                 <polyline class="nad-edge-path" points="-114.16,141.27 -379.41,137.36"/>
                 <g class="nad-edge-infos" transform="translate(-146.65,140.79)">
                     <g class="nad-active">
@@ -343,7 +312,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="54.2" class="nad-vl120to180">
+            <g id="53.2" class="nad-vl120to180">
                 <polyline class="nad-edge-path" points="-704.66,132.57 -439.41,136.48"/>
                 <g class="nad-edge-infos" transform="translate(-672.16,133.05)">
                     <g class="nad-active">
@@ -360,9 +329,9 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                 <circle class="nad-vl120to180 nad-winding" cx="-419.41" cy="136.78" r="20.00"/>
             </g>
         </g>
-        <g id="55">
+        <g id="54">
             <desc>T-12-10-1 </desc>
-            <g id="55.1" class="nad-vl180to300">
+            <g id="54.1" class="nad-vl180to300">
                 <polyline class="nad-edge-path" points="-286.33,446.48 -473.36,314.05"/>
                 <g class="nad-edge-infos" transform="translate(-312.86,427.70)">
                     <g class="nad-active">
@@ -374,7 +343,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="55.2" class="nad-vl120to180">
+            <g id="54.2" class="nad-vl120to180">
                 <polyline class="nad-edge-path" points="-709.35,146.94 -522.32,279.37"/>
                 <g class="nad-edge-infos" transform="translate(-682.82,165.72)">
                     <g class="nad-active">
@@ -389,6 +358,37 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
             <g>
                 <circle class="nad-vl180to300 nad-winding" cx="-489.68" cy="302.49" r="20.00"/>
                 <circle class="nad-vl120to180 nad-winding" cx="-506.00" cy="290.93" r="20.00"/>
+            </g>
+        </g>
+        <g id="55">
+            <desc>T-5-10-1 </desc>
+            <g id="55.1" class="nad-vl120to180">
+                <polyline class="nad-edge-path" points="-1221.16,-89.03 -1014.63,4.02"/>
+                <g class="nad-edge-infos" transform="translate(-1191.52,-75.68)">
+                    <g class="nad-active">
+                        <g transform="rotate(114.26)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(24.26)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="55.2" class="nad-vl120to180">
+                <polyline class="nad-edge-path" points="-753.41,121.72 -959.93,28.67"/>
+                <g class="nad-edge-infos" transform="translate(-783.04,108.37)">
+                    <g class="nad-active">
+                        <g transform="rotate(-65.74)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-335.74)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g>
+                <circle class="nad-vl120to180 nad-winding" cx="-996.40" cy="12.24" r="20.00"/>
+                <circle class="nad-vl120to180 nad-winding" cx="-978.16" cy="20.45" r="20.00"/>
             </g>
         </g>
         <g id="56">
@@ -616,35 +616,8 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
             </g>
         </g>
         <g id="64">
-            <desc>L-16-15-1 </desc>
-            <g id="64.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="815.78,-301.76 812.72,-506.88"/>
-                <g class="nad-edge-infos" transform="translate(815.30,-334.26)">
-                    <g class="nad-active">
-                        <g transform="rotate(-0.86)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-270.86)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="64.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="809.65,-712.00 812.72,-506.88"/>
-                <g class="nad-edge-infos" transform="translate(810.14,-679.50)">
-                    <g class="nad-active">
-                        <g transform="rotate(179.14)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(89.14)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="65">
             <desc>L-15-21-1 </desc>
-            <g id="65.1" class="nad-vl180to300">
+            <g id="64.1" class="nad-vl180to300">
                 <polyline class="nad-edge-path" points="827.80,-719.97 867.39,-682.52 1068.14,-634.65"/>
                 <g class="nad-edge-infos" transform="translate(896.57,-675.56)">
                     <g class="nad-active">
@@ -656,7 +629,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="65.2" class="nad-vl180to300">
+            <g id="64.2" class="nad-vl180to300">
                 <polyline class="nad-edge-path" points="1321.13,-602.34 1268.90,-586.78 1068.14,-634.65"/>
                 <g class="nad-edge-infos" transform="translate(1239.72,-593.74)">
                     <g class="nad-active">
@@ -669,36 +642,9 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                 </g>
             </g>
         </g>
-        <g id="66">
-            <desc>L-21-15-2 </desc>
-            <g id="66.1" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="1327.05,-627.14 1287.46,-664.60 1086.70,-712.47"/>
-                <g class="nad-edge-infos" transform="translate(1258.27,-671.55)">
-                    <g class="nad-active">
-                        <g transform="rotate(-76.59)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-346.59)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="66.2" class="nad-vl180to300">
-                <polyline class="nad-edge-path" points="833.71,-744.78 885.94,-760.34 1086.70,-712.47"/>
-                <g class="nad-edge-infos" transform="translate(915.13,-753.38)">
-                    <g class="nad-active">
-                        <g transform="rotate(103.41)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(13.41)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="67">
+        <g id="65">
             <desc>L-15-24-1 </desc>
-            <g id="67.1" class="nad-vl180to300">
+            <g id="65.1" class="nad-vl180to300">
                 <polyline class="nad-edge-path" points="784.00,-740.88 525.92,-775.46"/>
                 <g class="nad-edge-infos" transform="translate(751.79,-745.20)">
                     <g class="nad-active">
@@ -710,7 +656,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="67.2" class="nad-vl180to300">
+            <g id="65.2" class="nad-vl180to300">
                 <polyline class="nad-edge-path" points="267.84,-810.04 525.92,-775.46"/>
                 <g class="nad-edge-infos" transform="translate(300.06,-805.73)">
                     <g class="nad-active">
@@ -719,6 +665,60 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
                         <text transform="rotate(7.63)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="66">
+            <desc>L-16-15-1 </desc>
+            <g id="66.1" class="nad-vl180to300">
+                <polyline class="nad-edge-path" points="815.78,-301.76 812.72,-506.88"/>
+                <g class="nad-edge-infos" transform="translate(815.30,-334.26)">
+                    <g class="nad-active">
+                        <g transform="rotate(-0.86)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-270.86)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="66.2" class="nad-vl180to300">
+                <polyline class="nad-edge-path" points="809.65,-712.00 812.72,-506.88"/>
+                <g class="nad-edge-infos" transform="translate(810.14,-679.50)">
+                    <g class="nad-active">
+                        <g transform="rotate(179.14)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(89.14)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="67">
+            <desc>L-21-15-2 </desc>
+            <g id="67.1" class="nad-vl180to300">
+                <polyline class="nad-edge-path" points="1327.05,-627.14 1287.46,-664.60 1086.70,-712.47"/>
+                <g class="nad-edge-infos" transform="translate(1258.27,-671.55)">
+                    <g class="nad-active">
+                        <g transform="rotate(-76.59)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-346.59)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="67.2" class="nad-vl180to300">
+                <polyline class="nad-edge-path" points="833.71,-744.78 885.94,-760.34 1086.70,-712.47"/>
+                <g class="nad-edge-infos" transform="translate(915.13,-753.38)">
+                    <g class="nad-active">
+                        <g transform="rotate(103.41)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(13.41)" x="19.00"></text>
                     </g>
                 </g>
             </g>

--- a/network-area-diagram/src/test/resources/IEEE_30_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_30_bus.svg
@@ -242,28 +242,28 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
             </g>
         </g>
         <g id="62">
-            <desc>L9-10-1</desc>
-            <g id="62.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="156.18,554.72 99.49,215.65"/>
-                <g class="nad-edge-infos" transform="translate(150.82,522.66)">
+            <desc>L10-17-1</desc>
+            <g id="62.1" class="nad-vl30to50">
+                <polyline class="nad-edge-path" points="62.68,-156.99 458.06,-295.29"/>
+                <g class="nad-edge-infos" transform="translate(93.36,-167.72)">
                     <g class="nad-active">
-                        <g transform="rotate(-9.49)">
+                        <g transform="rotate(70.72)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-279.49)" x="-19.00" style="text-anchor:end"></text>
+                        <text transform="rotate(-19.28)" x="19.00"></text>
                     </g>
                 </g>
             </g>
             <g id="62.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="42.81,-123.42 99.49,215.65"/>
-                <g class="nad-edge-infos" transform="translate(48.17,-91.37)">
+                <polyline class="nad-edge-path" points="853.44,-433.58 458.06,-295.29"/>
+                <g class="nad-edge-infos" transform="translate(822.76,-422.85)">
                     <g class="nad-active">
-                        <g transform="rotate(170.51)">
+                        <g transform="rotate(-109.28)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(80.51)" x="19.00"></text>
+                        <text transform="rotate(-19.28)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
@@ -296,35 +296,8 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
             </g>
         </g>
         <g id="64">
-            <desc>L10-17-1</desc>
-            <g id="64.1" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="62.68,-156.99 458.06,-295.29"/>
-                <g class="nad-edge-infos" transform="translate(93.36,-167.72)">
-                    <g class="nad-active">
-                        <g transform="rotate(70.72)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-19.28)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="64.2" class="nad-vl30to50">
-                <polyline class="nad-edge-path" points="853.44,-433.58 458.06,-295.29"/>
-                <g class="nad-edge-infos" transform="translate(822.76,-422.85)">
-                    <g class="nad-active">
-                        <g transform="rotate(-109.28)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-19.28)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="65">
             <desc>L10-21-1</desc>
-            <g id="65.1" class="nad-vl30to50">
+            <g id="64.1" class="nad-vl30to50">
                 <polyline class="nad-edge-path" points="13.39,-152.38 -115.22,-171.81"/>
                 <g class="nad-edge-infos" transform="translate(-18.74,-157.24)">
                     <g class="nad-active">
@@ -336,7 +309,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="65.2" class="nad-vl30to50">
+            <g id="64.2" class="nad-vl30to50">
                 <polyline class="nad-edge-path" points="-243.83,-191.24 -115.22,-171.81"/>
                 <g class="nad-edge-infos" transform="translate(-211.70,-186.38)">
                     <g class="nad-active">
@@ -349,9 +322,9 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                 </g>
             </g>
         </g>
-        <g id="66">
+        <g id="65">
             <desc>L10-22-1</desc>
-            <g id="66.1" class="nad-vl30to50">
+            <g id="65.1" class="nad-vl30to50">
                 <polyline class="nad-edge-path" points="15.50,-159.35 -217.50,-267.99"/>
                 <g class="nad-edge-infos" transform="translate(-13.96,-173.08)">
                     <g class="nad-active">
@@ -363,7 +336,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="66.2" class="nad-vl30to50">
+            <g id="65.2" class="nad-vl30to50">
                 <polyline class="nad-edge-path" points="-450.50,-376.62 -217.50,-267.99"/>
                 <g class="nad-edge-infos" transform="translate(-421.04,-362.89)">
                     <g class="nad-active">
@@ -372,6 +345,33 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
                         <text transform="rotate(25.00)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="66">
+            <desc>L9-10-1</desc>
+            <g id="66.1" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="156.18,554.72 99.49,215.65"/>
+                <g class="nad-edge-infos" transform="translate(150.82,522.66)">
+                    <g class="nad-active">
+                        <g transform="rotate(-9.49)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-279.49)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="66.2" class="nad-vl30to50">
+                <polyline class="nad-edge-path" points="42.81,-123.42 99.49,215.65"/>
+                <g class="nad-edge-infos" transform="translate(48.17,-91.37)">
+                    <g class="nad-active">
+                        <g transform="rotate(170.51)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(80.51)" x="19.00"></text>
                     </g>
                 </g>
             </g>
@@ -1064,35 +1064,8 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
             </g>
         </g>
         <g id="92">
-            <desc>L8-28-1</desc>
-            <g id="92.1" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="277.94,834.73 40.68,823.06"/>
-                <g class="nad-edge-infos" transform="translate(245.48,833.13)">
-                    <g class="nad-active">
-                        <g transform="rotate(-87.18)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-357.18)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="92.2" class="nad-vl120to180">
-                <polyline class="nad-edge-path" points="-196.58,811.39 40.68,823.06"/>
-                <g class="nad-edge-infos" transform="translate(-164.12,812.99)">
-                    <g class="nad-active">
-                        <g transform="rotate(92.82)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(2.82)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="93">
             <desc>L6-28-1</desc>
-            <g id="93.1" class="nad-vl120to180">
+            <g id="92.1" class="nad-vl120to180">
                 <polyline class="nad-edge-path" points="166.66,309.17 -19.88,549.58"/>
                 <g class="nad-edge-infos" transform="translate(146.73,334.85)">
                     <g class="nad-active">
@@ -1104,7 +1077,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="93.2" class="nad-vl120to180">
+            <g id="92.2" class="nad-vl120to180">
                 <polyline class="nad-edge-path" points="-206.42,789.99 -19.88,549.58"/>
                 <g class="nad-edge-infos" transform="translate(-186.49,764.31)">
                     <g class="nad-active">
@@ -1113,6 +1086,33 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
                         <text transform="rotate(-52.19)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="93">
+            <desc>L8-28-1</desc>
+            <g id="93.1" class="nad-vl120to180">
+                <polyline class="nad-edge-path" points="277.94,834.73 40.68,823.06"/>
+                <g class="nad-edge-infos" transform="translate(245.48,833.13)">
+                    <g class="nad-active">
+                        <g transform="rotate(-87.18)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-357.18)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="93.2" class="nad-vl120to180">
+                <polyline class="nad-edge-path" points="-196.58,811.39 40.68,823.06"/>
+                <g class="nad-edge-infos" transform="translate(-164.12,812.99)">
+                    <g class="nad-active">
+                        <g transform="rotate(92.82)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(2.82)" x="19.00"></text>
                     </g>
                 </g>
             </g>

--- a/network-area-diagram/src/test/resources/IEEE_57_bus.svg
+++ b/network-area-diagram/src/test/resources/IEEE_57_bus.svg
@@ -316,35 +316,8 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
     </g>
     <g class="nad-branch-edges">
         <g id="99">
-            <desc>L1-2-1</desc>
-            <g id="99.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-182.94,-779.94 -368.54,-714.50"/>
-                <g class="nad-edge-infos" transform="translate(-213.59,-769.13)">
-                    <g class="nad-active">
-                        <g transform="rotate(-109.42)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-19.42)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="99.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-554.15,-649.06 -368.54,-714.50"/>
-                <g class="nad-edge-infos" transform="translate(-523.50,-659.86)">
-                    <g class="nad-active">
-                        <g transform="rotate(70.58)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-19.42)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="100">
             <desc>L1-15-1</desc>
-            <g id="100.1" class="nad-vl0to30">
+            <g id="99.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-153.54,-761.81 -123.84,-527.96"/>
                 <g class="nad-edge-infos" transform="translate(-149.45,-729.57)">
                     <g class="nad-active">
@@ -356,7 +329,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="100.2" class="nad-vl0to30">
+            <g id="99.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-94.13,-294.12 -123.84,-527.96"/>
                 <g class="nad-edge-infos" transform="translate(-98.22,-326.36)">
                     <g class="nad-active">
@@ -369,9 +342,9 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                 </g>
             </g>
         </g>
-        <g id="101">
+        <g id="100">
             <desc>L1-16-1</desc>
-            <g id="101.1" class="nad-vl0to30">
+            <g id="100.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-135.99,-806.82 32.80,-949.20"/>
                 <g class="nad-edge-infos" transform="translate(-111.14,-827.77)">
                     <g class="nad-active">
@@ -383,7 +356,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="101.2" class="nad-vl0to30">
+            <g id="100.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="201.59,-1091.57 32.80,-949.20"/>
                 <g class="nad-edge-infos" transform="translate(176.74,-1070.62)">
                     <g class="nad-active">
@@ -396,9 +369,9 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                 </g>
             </g>
         </g>
-        <g id="102">
+        <g id="101">
             <desc>L1-17-1</desc>
-            <g id="102.1" class="nad-vl0to30">
+            <g id="101.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-129.54,-790.43 26.08,-798.07"/>
                 <g class="nad-edge-infos" transform="translate(-97.08,-792.03)">
                     <g class="nad-active">
@@ -410,7 +383,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="102.2" class="nad-vl0to30">
+            <g id="101.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="181.71,-805.70 26.08,-798.07"/>
                 <g class="nad-edge-infos" transform="translate(149.25,-804.11)">
                     <g class="nad-active">
@@ -423,36 +396,36 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                 </g>
             </g>
         </g>
-        <g id="103">
-            <desc>L9-10-1</desc>
-            <g id="103.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="833.92,51.27 852.22,-136.12"/>
-                <g class="nad-edge-infos" transform="translate(837.08,18.93)">
+        <g id="102">
+            <desc>L1-2-1</desc>
+            <g id="102.1" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-182.94,-779.94 -368.54,-714.50"/>
+                <g class="nad-edge-infos" transform="translate(-213.59,-769.13)">
                     <g class="nad-active">
-                        <g transform="rotate(5.58)">
+                        <g transform="rotate(-109.42)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-84.42)" x="19.00"></text>
+                        <text transform="rotate(-19.42)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
-            <g id="103.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="870.52,-323.50 852.22,-136.12"/>
-                <g class="nad-edge-infos" transform="translate(867.36,-291.16)">
+            <g id="102.2" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-554.15,-649.06 -368.54,-714.50"/>
+                <g class="nad-edge-infos" transform="translate(-523.50,-659.86)">
                     <g class="nad-active">
-                        <g transform="rotate(-174.42)">
+                        <g transform="rotate(70.58)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-84.42)" x="-19.00" style="text-anchor:end"></text>
+                        <text transform="rotate(-19.42)" x="19.00"></text>
                     </g>
                 </g>
             </g>
         </g>
-        <g id="104">
+        <g id="103">
             <desc>L10-12-1</desc>
-            <g id="104.1" class="nad-vl0to30">
+            <g id="103.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="829.39,-414.25 704.81,-503.64"/>
                 <g class="nad-edge-infos" transform="translate(802.98,-433.20)">
                     <g class="nad-active">
@@ -464,7 +437,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="104.2" class="nad-vl0to30">
+            <g id="103.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="580.24,-593.02 704.81,-503.64"/>
                 <g class="nad-edge-infos" transform="translate(606.64,-574.07)">
                     <g class="nad-active">
@@ -477,9 +450,9 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                 </g>
             </g>
         </g>
-        <g id="105">
+        <g id="104">
             <desc>L50-51-1</desc>
-            <g id="105.1" class="nad-vl0to30">
+            <g id="104.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="611.30,-335.30 730.15,-355.69"/>
                 <g class="nad-edge-infos" transform="translate(643.33,-340.80)">
                     <g class="nad-active">
@@ -491,7 +464,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="105.2" class="nad-vl0to30">
+            <g id="104.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="849.00,-376.08 730.15,-355.69"/>
                 <g class="nad-edge-infos" transform="translate(787.40,-365.51)">
                     <g class="nad-active">
@@ -500,6 +473,33 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
                         <text transform="rotate(-9.73)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="105">
+            <desc>L9-10-1</desc>
+            <g id="105.1" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="833.92,51.27 852.22,-136.12"/>
+                <g class="nad-edge-infos" transform="translate(837.08,18.93)">
+                    <g class="nad-active">
+                        <g transform="rotate(5.58)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-84.42)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="105.2" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="870.52,-323.50 852.22,-136.12"/>
+                <g class="nad-edge-infos" transform="translate(867.36,-291.16)">
+                    <g class="nad-active">
+                        <g transform="rotate(-174.42)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-84.42)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
@@ -536,35 +536,8 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
             </g>
         </g>
         <g id="107">
-            <desc>L9-11-1</desc>
-            <g id="107.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="884.41,95.78 1065.15,54.78"/>
-                <g class="nad-edge-infos" transform="translate(916.10,88.59)">
-                    <g class="nad-active">
-                        <g transform="rotate(77.22)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-12.78)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="107.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="1245.89,13.79 1065.15,54.78"/>
-                <g class="nad-edge-infos" transform="translate(1194.69,25.40)">
-                    <g class="nad-active">
-                        <g transform="rotate(-102.78)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-12.78)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="108">
             <desc>L11-13-1</desc>
-            <g id="108.1" class="nad-vl0to30">
+            <g id="107.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="1245.00,3.82 934.63,-9.98"/>
                 <g class="nad-edge-infos" transform="translate(1192.55,1.49)">
                     <g class="nad-active">
@@ -576,7 +549,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="108.2" class="nad-vl0to30">
+            <g id="107.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="624.26,-23.79 934.63,-9.98"/>
                 <g class="nad-edge-infos" transform="translate(656.73,-22.35)">
                     <g class="nad-active">
@@ -589,9 +562,9 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                 </g>
             </g>
         </g>
-        <g id="109">
+        <g id="108">
             <desc>L41-42-1</desc>
-            <g id="109.1" class="nad-vl0to30">
+            <g id="108.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="1339.96,6.13 1528.04,8.21"/>
                 <g class="nad-edge-infos" transform="translate(1372.46,6.49)">
                     <g class="nad-active">
@@ -603,7 +576,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="109.2" class="nad-vl0to30">
+            <g id="108.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="1716.13,10.29 1528.04,8.21"/>
                 <g class="nad-edge-infos" transform="translate(1683.63,9.93)">
                     <g class="nad-active">
@@ -616,9 +589,9 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                 </g>
             </g>
         </g>
-        <g id="110">
+        <g id="109">
             <desc>L41-43-1</desc>
-            <g id="110.1" class="nad-vl0to30">
+            <g id="109.1" class="nad-vl0to30">
                 <path class="nad-edge-path" d="M1235.74,-28.02 L1217.46,-41.13 C1184.95,-64.45 1196.54,-87.34 1232.98,-103.83"/>
                 <g class="nad-edge-infos" transform="translate(1217.46,-41.13)">
                     <g class="nad-active">
@@ -630,7 +603,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="110.2" class="nad-vl0to30">
+            <g id="109.2" class="nad-vl0to30">
                 <path class="nad-edge-path" d="M1284.19,-11.93 L1290.34,-74.12 C1294.27,-113.93 1269.43,-120.33 1232.98,-103.83"/>
                 <g class="nad-edge-infos" transform="translate(1290.34,-74.12)">
                     <g class="nad-active">
@@ -643,9 +616,9 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                 </g>
             </g>
         </g>
-        <g id="111">
+        <g id="110">
             <desc>L56-41-1</desc>
-            <g id="111.1" class="nad-vl0to30">
+            <g id="110.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="1566.39,-348.28 1442.42,-193.82"/>
                 <g class="nad-edge-infos" transform="translate(1546.05,-322.93)">
                     <g class="nad-active">
@@ -657,7 +630,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="111.2" class="nad-vl0to30">
+            <g id="110.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="1318.45,-39.35 1442.42,-193.82"/>
                 <g class="nad-edge-infos" transform="translate(1338.80,-64.70)">
                     <g class="nad-active">
@@ -666,6 +639,33 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
                         <text transform="rotate(-51.25)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="111">
+            <desc>L9-11-1</desc>
+            <g id="111.1" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="884.41,95.78 1065.15,54.78"/>
+                <g class="nad-edge-infos" transform="translate(916.10,88.59)">
+                    <g class="nad-active">
+                        <g transform="rotate(77.22)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-12.78)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="111.2" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="1245.89,13.79 1065.15,54.78"/>
+                <g class="nad-edge-infos" transform="translate(1194.69,25.40)">
+                    <g class="nad-active">
+                        <g transform="rotate(-102.78)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-12.78)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
@@ -733,35 +733,8 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
             </g>
         </g>
         <g id="114">
-            <desc>L9-12-1</desc>
-            <g id="114.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="808.06,54.70 687.82,-264.31"/>
-                <g class="nad-edge-infos" transform="translate(796.59,24.28)">
-                    <g class="nad-active">
-                        <g transform="rotate(-20.65)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-290.65)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="114.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="567.59,-583.32 687.82,-264.31"/>
-                <g class="nad-edge-infos" transform="translate(579.06,-552.91)">
-                    <g class="nad-active">
-                        <g transform="rotate(159.35)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(69.35)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="115">
             <desc>L12-13-1</desc>
-            <g id="115.1" class="nad-vl0to30">
+            <g id="114.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="558.32,-581.55 562.13,-332.70"/>
                 <g class="nad-edge-infos" transform="translate(558.81,-549.06)">
                     <g class="nad-active">
@@ -773,7 +746,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="115.2" class="nad-vl0to30">
+            <g id="114.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="565.94,-83.84 562.13,-332.70"/>
                 <g class="nad-edge-infos" transform="translate(565.44,-116.33)">
                     <g class="nad-active">
@@ -786,9 +759,9 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                 </g>
             </g>
         </g>
-        <g id="116">
+        <g id="115">
             <desc>L12-16-1</desc>
-            <g id="116.1" class="nad-vl0to30">
+            <g id="115.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="542.58,-631.89 390.25,-859.18"/>
                 <g class="nad-edge-infos" transform="translate(524.49,-658.89)">
                     <g class="nad-active">
@@ -800,7 +773,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="116.2" class="nad-vl0to30">
+            <g id="115.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="237.92,-1086.46 390.25,-859.18"/>
                 <g class="nad-edge-infos" transform="translate(256.01,-1059.47)">
                     <g class="nad-active">
@@ -813,9 +786,9 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                 </g>
             </g>
         </g>
-        <g id="117">
+        <g id="116">
             <desc>L12-17-1</desc>
-            <g id="117.1" class="nad-vl0to30">
+            <g id="116.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="533.98,-622.63 383.53,-708.05"/>
                 <g class="nad-edge-infos" transform="translate(505.72,-638.68)">
                     <g class="nad-active">
@@ -827,7 +800,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="117.2" class="nad-vl0to30">
+            <g id="116.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="233.09,-793.47 383.53,-708.05"/>
                 <g class="nad-edge-infos" transform="translate(261.35,-777.42)">
                     <g class="nad-active">
@@ -840,36 +813,36 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                 </g>
             </g>
         </g>
-        <g id="118">
-            <desc>L9-13-1</desc>
-            <g id="118.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="777.23,82.15 697.57,41.08"/>
-                <g class="nad-edge-infos" transform="translate(748.34,67.26)">
+        <g id="117">
+            <desc>L9-12-1</desc>
+            <g id="117.1" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="808.06,54.70 687.82,-264.31"/>
+                <g class="nad-edge-infos" transform="translate(796.59,24.28)">
                     <g class="nad-active">
-                        <g transform="rotate(-62.72)">
+                        <g transform="rotate(-20.65)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-332.72)" x="-19.00" style="text-anchor:end"></text>
+                        <text transform="rotate(-290.65)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
-            <g id="118.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="617.92,0.01 697.57,41.08"/>
-                <g class="nad-edge-infos" transform="translate(646.81,14.90)">
+            <g id="117.2" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="567.59,-583.32 687.82,-264.31"/>
+                <g class="nad-edge-infos" transform="translate(579.06,-552.91)">
                     <g class="nad-active">
-                        <g transform="rotate(117.28)">
+                        <g transform="rotate(159.35)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(27.28)" x="19.00"></text>
+                        <text transform="rotate(69.35)" x="19.00"></text>
                     </g>
                 </g>
             </g>
         </g>
-        <g id="119">
+        <g id="118">
             <desc>L13-14-1</desc>
-            <g id="119.1" class="nad-vl0to30">
+            <g id="118.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="522.04,9.74 379.87,124.31"/>
                 <g class="nad-edge-infos" transform="translate(496.74,30.13)">
                     <g class="nad-active">
@@ -881,7 +854,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="119.2" class="nad-vl0to30">
+            <g id="118.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="237.70,238.87 379.87,124.31"/>
                 <g class="nad-edge-infos" transform="translate(263.01,218.48)">
                     <g class="nad-active">
@@ -894,9 +867,9 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                 </g>
             </g>
         </g>
-        <g id="120">
+        <g id="119">
             <desc>L13-15-1</desc>
-            <g id="120.1" class="nad-vl0to30">
+            <g id="119.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="512.09,-43.99 239.97,-131.71"/>
                 <g class="nad-edge-infos" transform="translate(481.16,-53.96)">
                     <g class="nad-active">
@@ -908,7 +881,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="120.2" class="nad-vl0to30">
+            <g id="119.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-32.16,-219.43 239.97,-131.71"/>
                 <g class="nad-edge-infos" transform="translate(-1.22,-209.46)">
                     <g class="nad-active">
@@ -917,6 +890,33 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
                         <text transform="rotate(17.87)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="120">
+            <desc>L38-49-1</desc>
+            <g id="120.1" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="490.68,245.27 525.04,122.70"/>
+                <g class="nad-edge-infos" transform="translate(499.45,213.98)">
+                    <g class="nad-active">
+                        <g transform="rotate(15.66)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-74.34)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="120.2" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="559.39,0.13 525.04,122.70"/>
+                <g class="nad-edge-infos" transform="translate(542.52,60.32)">
+                    <g class="nad-active">
+                        <g transform="rotate(-164.34)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-74.34)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
@@ -976,28 +976,28 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
             </g>
         </g>
         <g id="123">
-            <desc>L38-49-1</desc>
+            <desc>L9-13-1</desc>
             <g id="123.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="490.68,245.27 525.04,122.70"/>
-                <g class="nad-edge-infos" transform="translate(499.45,213.98)">
+                <polyline class="nad-edge-path" points="777.23,82.15 697.57,41.08"/>
+                <g class="nad-edge-infos" transform="translate(748.34,67.26)">
                     <g class="nad-active">
-                        <g transform="rotate(15.66)">
+                        <g transform="rotate(-62.72)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-74.34)" x="19.00"></text>
+                        <text transform="rotate(-332.72)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
             <g id="123.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="559.39,0.13 525.04,122.70"/>
-                <g class="nad-edge-infos" transform="translate(542.52,60.32)">
+                <polyline class="nad-edge-path" points="617.92,0.01 697.57,41.08"/>
+                <g class="nad-edge-infos" transform="translate(646.81,14.90)">
                     <g class="nad-active">
-                        <g transform="rotate(-164.34)">
+                        <g transform="rotate(117.28)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-74.34)" x="-19.00" style="text-anchor:end"></text>
+                        <text transform="rotate(27.28)" x="19.00"></text>
                     </g>
                 </g>
             </g>

--- a/network-area-diagram/src/test/resources/four_substations.svg
+++ b/network-area-diagram/src/test/resources/four_substations.svg
@@ -475,35 +475,6 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
         </g>
         <g id="27" class="nad-hvdc-edge">
             <g id="27.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="-154.01,-76.33 -158.07,63.85"/>
-                <g class="nad-edge-infos" transform="translate(-154.95,-43.84)">
-                    <g class="nad-active nad-state-out">
-                        <g transform="rotate(-178.34)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-88.34)" x="-19.00" style="text-anchor:end">10</text>
-                    </g>
-                </g>
-            </g>
-            <g id="27.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="-162.13,204.03 -158.07,63.85"/>
-                <g class="nad-edge-infos" transform="translate(-161.19,171.54)">
-                    <g class="nad-active nad-state-in">
-                        <g transform="rotate(1.66)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-88.34)" x="19.00">-10</text>
-                    </g>
-                </g>
-            </g>
-            <g>
-                <polyline points="-157.06,28.86 -159.09,98.84" class="nad-hvdc"/>
-            </g>
-        </g>
-        <g id="28" class="nad-hvdc-edge">
-            <g id="28.1" class="nad-vl300to500">
                 <polyline class="nad-edge-path" points="-105.17,-100.92 21.70,-12.48"/>
                 <g class="nad-edge-infos" transform="translate(-78.51,-82.33)">
                     <g class="nad-active nad-state-out">
@@ -515,7 +486,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="28.2" class="nad-vl300to500">
+            <g id="27.2" class="nad-vl300to500">
                 <polyline class="nad-edge-path" points="148.57,75.96 21.70,-12.48"/>
                 <g class="nad-edge-infos" transform="translate(121.91,57.38)">
                     <g class="nad-active nad-state-in">
@@ -529,6 +500,35 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
             </g>
             <g>
                 <polyline points="-7.01,-32.49 50.41,7.54" class="nad-hvdc"/>
+            </g>
+        </g>
+        <g id="28" class="nad-hvdc-edge">
+            <g id="28.1" class="nad-vl300to500">
+                <polyline class="nad-edge-path" points="-154.01,-76.33 -158.07,63.85"/>
+                <g class="nad-edge-infos" transform="translate(-154.95,-43.84)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-178.34)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-88.34)" x="-19.00" style="text-anchor:end">10</text>
+                    </g>
+                </g>
+            </g>
+            <g id="28.2" class="nad-vl300to500">
+                <polyline class="nad-edge-path" points="-162.13,204.03 -158.07,63.85"/>
+                <g class="nad-edge-infos" transform="translate(-161.19,171.54)">
+                    <g class="nad-active nad-state-in">
+                        <g transform="rotate(1.66)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-88.34)" x="19.00">-10</text>
+                    </g>
+                </g>
+            </g>
+            <g>
+                <polyline points="-157.06,28.86 -159.09,98.84" class="nad-hvdc"/>
             </g>
         </g>
         <g id="29">

--- a/network-area-diagram/src/test/resources/hvdc.svg
+++ b/network-area-diagram/src/test/resources/hvdc.svg
@@ -120,38 +120,8 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
             </g>
         </g>
         <g id="11" class="nad-hvdc-edge">
-            <desc>HVDC1</desc>
-            <g id="11.1" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="-153.08,-108.31 -157.64,48.86"/>
-                <g class="nad-edge-infos" transform="translate(-154.02,-75.83)">
-                    <g class="nad-active nad-state-out">
-                        <g transform="rotate(-178.34)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-88.34)" x="-19.00" style="text-anchor:end">10</text>
-                    </g>
-                </g>
-            </g>
-            <g id="11.2" class="nad-vl300to500">
-                <polyline class="nad-edge-path" points="-162.19,206.02 -157.64,48.86"/>
-                <g class="nad-edge-infos" transform="translate(-161.25,173.54)">
-                    <g class="nad-active nad-state-in">
-                        <g transform="rotate(1.66)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-88.34)" x="19.00">-10</text>
-                    </g>
-                </g>
-            </g>
-            <g>
-                <polyline points="-156.62,13.87 -158.65,83.84" class="nad-hvdc"/>
-            </g>
-        </g>
-        <g id="12" class="nad-hvdc-edge">
             <desc>HVDC2</desc>
-            <g id="12.1" class="nad-vl300to500">
+            <g id="11.1" class="nad-vl300to500">
                 <polyline class="nad-edge-path" points="-131.42,-119.22 9.40,-21.06"/>
                 <g class="nad-edge-infos" transform="translate(-104.76,-100.63)">
                     <g class="nad-active nad-state-out">
@@ -163,7 +133,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="12.2" class="nad-vl300to500">
+            <g id="11.2" class="nad-vl300to500">
                 <polyline class="nad-edge-path" points="150.21,77.11 9.40,-21.06"/>
                 <g class="nad-edge-infos" transform="translate(123.55,58.52)">
                     <g class="nad-active nad-state-in">
@@ -177,6 +147,36 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
             </g>
             <g>
                 <polyline points="-19.32,-41.07 38.11,-1.04" class="nad-hvdc"/>
+            </g>
+        </g>
+        <g id="12" class="nad-hvdc-edge">
+            <desc>HVDC1</desc>
+            <g id="12.1" class="nad-vl300to500">
+                <polyline class="nad-edge-path" points="-153.08,-108.31 -157.64,48.86"/>
+                <g class="nad-edge-infos" transform="translate(-154.02,-75.83)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-178.34)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-88.34)" x="-19.00" style="text-anchor:end">10</text>
+                    </g>
+                </g>
+            </g>
+            <g id="12.2" class="nad-vl300to500">
+                <polyline class="nad-edge-path" points="-162.19,206.02 -157.64,48.86"/>
+                <g class="nad-edge-infos" transform="translate(-161.25,173.54)">
+                    <g class="nad-active nad-state-in">
+                        <g transform="rotate(1.66)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-88.34)" x="19.00">-10</text>
+                    </g>
+                </g>
+            </g>
+            <g>
+                <polyline points="-156.62,13.87 -158.65,83.84" class="nad-hvdc"/>
             </g>
         </g>
         <g id="13">

--- a/network-area-diagram/src/test/resources/ieee14_custom_paths.svg
+++ b/network-area-diagram/src/test/resources/ieee14_custom_paths.svg
@@ -167,37 +167,6 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
         </g>
         <g id="27">
             <g id="27.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-174.00,-91.88 -361.39,-1.64"/>
-                <g class="nad-edge-infos" transform="translate(-221.30,-69.10)">
-                    <g class="nad-active">
-                        <g transform="rotate(-115.71)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-25.71)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="27.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="-548.79,88.59 -361.39,-1.64"/>
-                <g class="nad-edge-infos" transform="translate(-519.51,74.49)">
-                    <g class="nad-active">
-                        <g transform="rotate(64.29)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-25.71)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-            <g>
-                <g class="nad-edge-label" transform="translate(-361.39,-1.64)">
-                    <text transform="rotate(-25.71)" x="0.00" style="text-anchor:middle">L9-10-1</text>
-                </g>
-            </g>
-        </g>
-        <g id="28">
-            <g id="28.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-551.54,116.99 -434.62,204.42"/>
                 <g class="nad-edge-infos" transform="translate(-525.51,136.45)">
                     <g class="nad-active">
@@ -209,7 +178,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="28.2" class="nad-vl0to30">
+            <g id="27.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="-317.70,291.84 -434.62,204.42"/>
                 <g class="nad-edge-infos" transform="translate(-343.73,272.38)">
                     <g class="nad-active">
@@ -224,6 +193,37 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
             <g>
                 <g class="nad-edge-label" transform="translate(-434.62,204.42)">
                     <text transform="rotate(36.79)" x="0.00" style="text-anchor:middle">L10-11-1</text>
+                </g>
+            </g>
+        </g>
+        <g id="28">
+            <g id="28.1" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-174.00,-91.88 -361.39,-1.64"/>
+                <g class="nad-edge-infos" transform="translate(-221.30,-69.10)">
+                    <g class="nad-active">
+                        <g transform="rotate(-115.71)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-25.71)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="28.2" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="-548.79,88.59 -361.39,-1.64"/>
+                <g class="nad-edge-infos" transform="translate(-519.51,74.49)">
+                    <g class="nad-active">
+                        <g transform="rotate(64.29)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-25.71)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g>
+                <g class="nad-edge-label" transform="translate(-361.39,-1.64)">
+                    <text transform="rotate(-25.71)" x="0.00" style="text-anchor:middle">L9-10-1</text>
                 </g>
             </g>
         </g>
@@ -260,37 +260,6 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
         </g>
         <g id="30">
             <g id="30.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="258.36,-17.93 462.83,26.19"/>
-                <g class="nad-edge-infos" transform="translate(290.13,-11.08)">
-                    <g class="nad-active">
-                        <g transform="rotate(102.18)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(12.18)" x="19.00"></text>
-                    </g>
-                </g>
-            </g>
-            <g id="30.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="667.30,70.32 462.83,26.19"/>
-                <g class="nad-edge-infos" transform="translate(635.54,63.47)">
-                    <g class="nad-active">
-                        <g transform="rotate(-77.82)">
-                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
-                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
-                        </g>
-                        <text transform="rotate(-347.82)" x="-19.00" style="text-anchor:end"></text>
-                    </g>
-                </g>
-            </g>
-            <g>
-                <g class="nad-edge-label" transform="translate(462.83,26.19)">
-                    <text transform="rotate(12.18)" x="0.00" style="text-anchor:middle">L6-12-1</text>
-                </g>
-            </g>
-        </g>
-        <g id="31">
-            <g id="31.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="676.07,96.81 581.29,205.02"/>
                 <g class="nad-edge-infos" transform="translate(654.65,121.26)">
                     <g class="nad-active">
@@ -302,7 +271,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="31.2" class="nad-vl0to30">
+            <g id="30.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="486.52,313.23 581.29,205.02"/>
                 <g class="nad-edge-infos" transform="translate(507.94,288.78)">
                     <g class="nad-active">
@@ -320,39 +289,39 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                 </g>
             </g>
         </g>
-        <g id="32">
-            <g id="32.1" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="236.11,16.34 344.14,164.03"/>
-                <g class="nad-edge-infos" transform="translate(255.29,42.58)">
+        <g id="31">
+            <g id="31.1" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="258.36,-17.93 462.83,26.19"/>
+                <g class="nad-edge-infos" transform="translate(290.13,-11.08)">
                     <g class="nad-active">
-                        <g transform="rotate(143.82)">
+                        <g transform="rotate(102.18)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(53.82)" x="19.00"></text>
+                        <text transform="rotate(12.18)" x="19.00"></text>
                     </g>
                 </g>
             </g>
-            <g id="32.2" class="nad-vl0to30">
-                <polyline class="nad-edge-path" points="452.17,311.72 344.14,164.03"/>
-                <g class="nad-edge-infos" transform="translate(432.98,285.49)">
+            <g id="31.2" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="667.30,70.32 462.83,26.19"/>
+                <g class="nad-edge-infos" transform="translate(635.54,63.47)">
                     <g class="nad-active">
-                        <g transform="rotate(-36.18)">
+                        <g transform="rotate(-77.82)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-306.18)" x="-19.00" style="text-anchor:end"></text>
+                        <text transform="rotate(-347.82)" x="-19.00" style="text-anchor:end"></text>
                     </g>
                 </g>
             </g>
             <g>
-                <g class="nad-edge-label" transform="translate(344.14,164.03)">
-                    <text transform="rotate(53.82)" x="0.00" style="text-anchor:middle">L6-13-1</text>
+                <g class="nad-edge-label" transform="translate(462.83,26.19)">
+                    <text transform="rotate(12.18)" x="0.00" style="text-anchor:middle">L6-12-1</text>
                 </g>
             </g>
         </g>
-        <g id="33">
-            <g id="33.1" class="nad-vl0to30">
+        <g id="32">
+            <g id="32.1" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="441.66,340.32 290.26,376.58"/>
                 <g class="nad-edge-infos" transform="translate(410.05,347.89)">
                     <g class="nad-active">
@@ -364,7 +333,7 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
                     </g>
                 </g>
             </g>
-            <g id="33.2" class="nad-vl0to30">
+            <g id="32.2" class="nad-vl0to30">
                 <polyline class="nad-edge-path" points="138.86,412.83 290.26,376.58"/>
                 <g class="nad-edge-infos" transform="translate(170.46,405.27)">
                     <g class="nad-active">
@@ -379,6 +348,37 @@ foreignObject.nad-text-nodes {overflow: visible; color: black}
             <g>
                 <g class="nad-edge-label" transform="translate(290.26,376.58)">
                     <text transform="rotate(-13.47)" x="0.00" style="text-anchor:middle">L13-14-1</text>
+                </g>
+            </g>
+        </g>
+        <g id="33">
+            <g id="33.1" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="236.11,16.34 344.14,164.03"/>
+                <g class="nad-edge-infos" transform="translate(255.29,42.58)">
+                    <g class="nad-active">
+                        <g transform="rotate(143.82)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(53.82)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="33.2" class="nad-vl0to30">
+                <polyline class="nad-edge-path" points="452.17,311.72 344.14,164.03"/>
+                <g class="nad-edge-infos" transform="translate(432.98,285.49)">
+                    <g class="nad-active">
+                        <g transform="rotate(-36.18)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-306.18)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g>
+                <g class="nad-edge-label" transform="translate(344.14,164.03)">
+                    <text transform="rotate(53.82)" x="0.00" style="text-anchor:middle">L6-13-1</text>
                 </g>
             </g>
         </g>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Feature

**What is the current behavior?**
In both NAD and SLD, the elements displayed are not sorted, which can result in having differences in display of the same network over time.
In SLD, streams are computed through `vl.getConnectableStream(<Class>)`.

**What is the new behavior (if this is a feature change)?**
In both NAD and SLD, the elements displayed are now sorted.
In SLD, streams are computed through the specific methods (for example `vl.getLineStream()`)

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
