### PR TITLE
fix Null network in diagram style provider

### DIFF
--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/iidm/HighlightLineStateStyleProvider.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/iidm/HighlightLineStateStyleProvider.java
@@ -31,11 +31,7 @@ import com.powsybl.sld.model.nodes.feeders.FeederWithSides;
 import com.powsybl.sld.svg.styles.EmptyStyleProvider;
 import com.powsybl.sld.svg.styles.StyleClassConstants;
 
-import java.util.Collections;
-import java.util.EnumMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 /**
  * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
@@ -46,6 +42,7 @@ public class HighlightLineStateStyleProvider extends EmptyStyleProvider {
     private final Network network;
 
     public HighlightLineStateStyleProvider(Network network) {
+        Objects.requireNonNull(network);
         this.network = network;
     }
 

--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/iidm/HighlightLineStateStyleProvider.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/styles/iidm/HighlightLineStateStyleProvider.java
@@ -41,6 +41,10 @@ public class HighlightLineStateStyleProvider extends EmptyStyleProvider {
 
     private final Network network;
 
+    /**
+     *
+     * @param network the IIDM network (must not be {@code null})
+     */
     public HighlightLineStateStyleProvider(Network network) {
         Objects.requireNonNull(network);
         this.network = network;

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/util/TopologicalStyleTest.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/util/TopologicalStyleTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.List;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -91,7 +92,7 @@ class TopologicalStyleTest extends AbstractTestCaseIidm {
     }
 
     @Test
-    void test() throws IOException {
+    void test() {
         // building graphs
         VoltageLevelGraph graph1 = graphBuilder.buildVoltageLevelGraph(vl1.getId());
         VoltageLevelGraph graph2 = graphBuilder.buildVoltageLevelGraph(vl2.getId());
@@ -189,6 +190,17 @@ class TopologicalStyleTest extends AbstractTestCaseIidm {
                 new DefaultLabelProvider(network, componentLibrary, layoutParameters, svgParameters),
                 new TopologicalStyleProvider(network, svgParameters, true),
                 new DefaultSVGLegendWriter(network, svgParameters)));
+    }
+
+    @Test
+    void defaultStyleProviderThrowsWhenNetworkIsNull() {
+        network = null;
+        assertThatCode(this::getDefaultDiagramStyleProvider).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void defaultStyleProviderDoesNotThrowWhenNetworkIsSet() {
+        assertThatCode(this::getDefaultDiagramStyleProvider).doesNotThrowAnyException();
     }
 
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
Fixes #181

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

**What is the current behavior?**
<!-- You can also link to an open issue here -->

**What is the new behavior (if this is a feature change)?**

**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [x] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
`HighlightLineStateStyleProvider(Network)` now rejects a `null` network at construction time.
Pass a non-null `Network` to `HighlightLineStateStyleProvider`.

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
